### PR TITLE
feat: add role-specific config

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -148,7 +148,7 @@ impl ChatGptClient {
             "messages": messages,
         });
 
-        if let Some(v) = self.config.borrow().temperature {
+        if let Some(v) = self.config.borrow().get_temperature() {
             body.as_object_mut()
                 .and_then(|m| m.insert("temperature".into(), json!(v)));
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use chrono::prelude::*;
+use crossterm::style::{Color, Stylize};
 use std::io::{stdout, Write};
 
 #[macro_export]
@@ -16,4 +17,8 @@ pub fn print_now<T: ToString>(text: T) {
 pub fn now() -> String {
     let now = Local::now();
     now.to_rfc3339_opts(SecondsFormat::Secs, false)
+}
+
+pub fn emphasis(text: &str) -> String {
+    text.stylize().with(Color::White).to_string()
 }


### PR DESCRIPTION
Now we can set role temperature. For example:

```
- name: shell
  prompt: >
    I want you to act as a linux shell expert.
    I want you to answer only with bash code.
    Do not write explanations.
  temperature: 0.4  
```