### PR TITLE
feat: type `{` `[` `(` to enter multi-line editing mode

### DIFF
--- a/src/config/role.rs
+++ b/src/config/role.rs
@@ -39,7 +39,7 @@ impl Role {
         if self.embeded() {
             merge_prompt_content(&self.prompt, content)
         } else {
-            format!("{}{content}", self.prompt)
+            format!("{}\n{content}", self.prompt)
         }
     }
 

--- a/src/repl/prompt.rs
+++ b/src/repl/prompt.rs
@@ -3,8 +3,6 @@ use crate::config::SharedConfig;
 use reedline::{Prompt, PromptHistorySearch, PromptHistorySearchStatus};
 use std::borrow::Cow;
 
-const DEFAULT_MULTILINE_INDICATOR: &str = "::: ";
-
 #[derive(Clone)]
 pub struct ReplPrompt(SharedConfig);
 
@@ -43,7 +41,7 @@ impl Prompt for ReplPrompt {
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {
-        Cow::Borrowed(DEFAULT_MULTILINE_INDICATOR)
+        Cow::Borrowed("")
     }
 
     fn render_prompt_history_search_indicator(


### PR DESCRIPTION
Previous we use `.editor` command, it's too complicated.