### PR TITLE
feat: check token usage in dry_run mode

### DIFF
--- a/src/config/message.rs
+++ b/src/config/message.rs
@@ -1,6 +1,5 @@
 use crate::utils::count_tokens;
 
-use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -24,14 +23,6 @@ pub enum MessageRole {
     System,
     Assistant,
     User,
-}
-
-pub fn within_max_tokens_limit(messages: &[Message], max_tokens: usize) -> Result<()> {
-    let tokens = num_tokens_from_messages(messages);
-    if tokens >= max_tokens {
-        bail!("Exceed max tokens limit")
-    }
-    Ok(())
 }
 
 pub fn num_tokens_from_messages(messages: &[Message]) -> usize {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ fn start_directive(
     if !stdout().is_terminal() {
         config.write().highlight = false;
     }
+    config.read().maybe_print_send_tokens(input);
     let output = if no_stream {
         let (highlight, light_theme) = config.read().get_render_options();
         let output = client.send_message(input)?;

--- a/src/repl/handler.rs
+++ b/src/repl/handler.rs
@@ -51,6 +51,7 @@ impl ReplCmdHandler {
                     self.reply.borrow_mut().clear();
                     return Ok(());
                 }
+                self.config.read().maybe_print_send_tokens(&input);
                 let wg = WaitGroup::new();
                 let ret = render_stream(
                     &input,


### PR DESCRIPTION
In command mode:
```
AICHAT_DRY_RUN=true aichat -r coder async sleep function in js
>>> The following message consumes 59 tokens.
I want you to act as a senior programmer.  I want you to answer only with the fenced code block. I want you to add an language identifier to the fenced code block. Do not write explanations.

async sleep function in js
```

In chat mode:
```
coder〉.set dry_run true

coder〉async sleep function in js
>>> The following message consumes 59 tokens.
I want you to act as a senior programmer.  I want you to answer only with the fenced code block. I want you to add an language identifier to the fenced code block. Do not write explanations.

async sleep function in js
```