### PR TITLE
Add support for Azure OpenAI

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use crate::config::SharedConfig;
+use crate::config::{Config, SharedConfig};
 use crate::repl::{ReplyStreamHandler, SharedAbortSignal};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -92,6 +92,7 @@ impl ChatGptClient {
             handler.text(&self.config.read().echo_messages(content))?;
             return Ok(());
         }
+        let is_aoai = self.config.read().aoai_endpoint.is_some();
         let builder = self.request_builder(content, true)?;
         let res = builder.send().await?;
         if !res.status().is_success() {
@@ -108,10 +109,13 @@ impl ChatGptClient {
                 break;
             } else {
                 let data: Value = serde_json::from_str(&chunk)?;
-                let text = data["choices"][0]["delta"]["content"]
-                    .as_str()
-                    .unwrap_or_default();
-                if text.is_empty() {
+                let text = if is_aoai {
+                    &data["choices"][0]["text"]
+                } else {
+                    &data["choices"][0]["delta"]["content"]
+                };
+                let text = text.as_str().unwrap_or_default();
+                if text.is_empty() || text == "<|im_end|>" {
                     continue;
                 }
                 handler.text(text)?;
@@ -136,16 +140,47 @@ impl ChatGptClient {
     }
 
     fn request_builder(&self, content: &str, stream: bool) -> Result<RequestBuilder> {
-        let (model, _) = self.config.read().get_model();
+        let (api_key, organization_id) = self.config.read().get_api_key();
         let messages = self.config.read().build_messages(content)?;
-        let mut body = json!({
-            "model": model,
-            "messages": messages,
-        });
+
+        let (builder, mut body) =
+            if let Some((endpoint, deployment)) = self.config.read().get_aoai_endpoint() {
+                // Azure OpenAI: https://learn.microsoft.com/en-gb/azure/cognitive-services/openai/reference
+                let url = format!(
+                    "{endpoint}/openai/deployments/{deployment}/completions?api-version=2022-12-01"
+                );
+                let body = json!({
+                    "prompt": Config::render_messages(&messages),
+                });
+
+                let builder = self.build_client()?.post(url).header("api-key", api_key);
+
+                (builder, body)
+            } else {
+                // OpenAI: https://platform.openai.com/docs/api-reference/chat
+                let (model, _) = self.config.read().get_model();
+                let body = json!({
+                    "model": model,
+                    "messages": messages,
+                });
+
+                let mut builder = self.build_client()?.post(API_URL).bearer_auth(api_key);
+
+                if let Some(organization_id) = organization_id {
+                    builder = builder.header("OpenAI-Organization", organization_id);
+                }
+
+                (builder, body)
+            };
 
         if let Some(v) = self.config.read().get_temperature() {
             body.as_object_mut()
                 .and_then(|m| m.insert("temperature".into(), json!(v)));
+        }
+
+        if let Some(v) = self.config.read().get_max_tokens() {
+            body.as_object_mut()
+                .and_then(|m| m.insert("max_tokens".into(), json!(v)));
         }
 
         if stream {
@@ -153,19 +188,7 @@ impl ChatGptClient {
                 .and_then(|m| m.insert("stream".into(), json!(true)));
         }
 
-        let (api_key, organization_id) = self.config.read().get_api_key();
-
-        let mut builder = self
-            .build_client()?
-            .post(API_URL)
-            .bearer_auth(api_key)
-            .json(&body);
-
-        if let Some(organization_id) = organization_id {
-            builder = builder.header("OpenAI-Organization", organization_id);
-        }
-
-        Ok(builder)
+        Ok(builder.json(&body))
     }
 }
 

--- a/src/config/message.rs
+++ b/src/config/message.rs
@@ -15,6 +15,21 @@ impl Message {
             content: content.to_string(),
         }
     }
+
+    pub fn render(&self) -> String {
+        let role = self.role.render();
+        let content = &self.content;
+        format!("<|im_start|>{role}\n{content}<|im_end|>\n")
+    }
+
+    pub fn render_all(messages: &[Message]) -> String {
+        let mut result = String::new();
+        for message in messages {
+            result.push_str(&message.render())
+        }
+        result.push_str("<|im_start|>assistant\n");
+        result
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -23,6 +38,16 @@ pub enum MessageRole {
     System,
     Assistant,
     User,
+}
+
+impl MessageRole {
+    pub fn render(&self) -> &'static str {
+        match self {
+            MessageRole::System => "system",
+            MessageRole::Assistant => "assistant",
+            MessageRole::User => "user",
+        }
+    }
 }
 
 pub fn num_tokens_from_messages(messages: &[Message]) -> usize {

--- a/src/config/role.rs
+++ b/src/config/role.rs
@@ -13,14 +13,17 @@ pub struct Role {
     pub prompt: String,
     /// What sampling temperature to use, between 0 and 2
     pub temperature: Option<f64>,
+    /// Maximum number of tokens to return
+    pub max_tokens: Option<u32>,
 }
 
 impl Role {
-    pub fn new(prompt: &str, temperature: Option<f64>) -> Self {
+    pub fn new(prompt: &str, temperature: Option<f64>, max_tokens: Option<u32>) -> Self {
         Self {
             name: TEMP_NAME.into(),
             prompt: prompt.into(),
             temperature,
+            max_tokens,
         }
     }
 


### PR DESCRIPTION
This PR adds support for the [Azure OpenAI service](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/), which is an alternate API for accessing the OpenAI models. In the initial-config wizard it adds a question `Use OpenAI via Azure?` (default no), and if the answer is yes it asks for the endpoint and deployment name. It stores these in the config file under new keys. It also adds support for `max_tokens` (on both APIs), since the Azure `max_tokens` default is very low.

Details:

If `aoai_endpoint` is set, then use Azure OpenAI endpoint rather than the direct OpenAI endpoint. Requires `aoai_deployment` to be specified as well. You should set the model too, so that aichat knows the correct number of remaining tokens.

Also adds support for `max_tokens` since the AOAI default is very low.

The Azure OpenAI API currently requires chats to be encoded as completions, so logic to do this is added as well.

Tested with gpt-35-turbo (version 0301).