### PR TITLE
new 0613 models added

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,11 @@ dry_run             false
 
 ```
 > .model gpt-4
+> .model gpt-4-0613
 > .model gpt-4-32k
 > .model gpt-3.5-turbo
+> .model gpt-3.5-turbo-16k
+
 ```
 
 ### `.prompt` - use GPT prompt

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,10 +23,12 @@ use std::{
     sync::Arc,
 };
 
-pub const MODELS: [(&str, usize); 3] = [
+pub const MODELS: [(&str, usize); 5] = [
     ("gpt-4", 8192),
+    ("gpt-4-0613", 8192), // fewer limits when calling API compared to gpt-4
     ("gpt-4-32k", 32768),
     ("gpt-3.5-turbo", 4096),
+    ("gpt-3.5-turbo-16k", 16384), 
 ];
 
 const CONFIG_FILE_NAME: &str = "config.yaml";


### PR DESCRIPTION
OpenAI released new 0613 models, it is useful for testing functional calling and long context regarding new gpt-3.5-turbo-16k model and the new gpt-4-0613 model can be called more frequently comparing to gpt-4.

reference: https://openai.com/blog/function-calling-and-other-api-updates