### PR TITLE
fix: minor code cleanup and pedantic lints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       run: cargo test --all
 
     - name: Clippy
-      run: cargo clippy --all --all-targets
+      run: cargo clippy --all --all-targets -- -D warnings
 
     - name: Format
       run: cargo fmt --all --check

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 
+#[allow(clippy::struct_excessive_bools, clippy::module_name_repetitions)]
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,6 +12,7 @@ use tokio::time::sleep;
 
 const API_URL: &str = "https://api.openai.com/v1/chat/completions";
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub struct ChatGptClient {
     config: SharedConfig,
@@ -106,16 +107,15 @@ impl ChatGptClient {
             let chunk = part?.data;
             if chunk == "[DONE]" {
                 break;
-            } else {
-                let data: Value = serde_json::from_str(&chunk)?;
-                let text = data["choices"][0]["delta"]["content"]
-                    .as_str()
-                    .unwrap_or_default();
-                if text.is_empty() {
-                    continue;
-                }
-                handler.text(text)?;
             }
+            let data: Value = serde_json::from_str(&chunk)?;
+            let text = data["choices"][0]["delta"]["content"]
+                .as_str()
+                .unwrap_or_default();
+            if text.is_empty() {
+                continue;
+            }
+            handler.text(text)?;
         }
 
         Ok(())

--- a/src/config/conversation.rs
+++ b/src/config/conversation.rs
@@ -43,11 +43,12 @@ impl Conversation {
         self.tokens = num_tokens_from_messages(&self.build_emssages(""));
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     pub fn add_message(&mut self, input: &str, output: &str) -> Result<()> {
         let mut need_add_msg = true;
         if self.messages.is_empty() {
             if let Some(role) = self.role.as_ref() {
-                self.messages.extend(role.build_emssages(input));
+                self.messages.extend(role.build_messages(input));
                 need_add_msg = false;
             }
         }
@@ -67,15 +68,15 @@ impl Conversation {
 
     pub fn echo_messages(&self, content: &str) -> String {
         let messages = self.build_emssages(content);
-        serde_yaml::to_string(&messages).unwrap_or("Unable to echo message".into())
+        serde_yaml::to_string(&messages).unwrap_or_else(|_| "Unable to echo message".into())
     }
 
     pub fn build_emssages(&self, content: &str) -> Vec<Message> {
-        let mut messages = self.messages.to_vec();
+        let mut messages = self.messages.clone();
         let mut need_add_msg = true;
         if messages.is_empty() {
             if let Some(role) = self.role.as_ref() {
-                messages = role.build_emssages(content);
+                messages = role.build_messages(content);
                 need_add_msg = false;
             }
         };

--- a/src/config/message.rs
+++ b/src/config/message.rs
@@ -17,6 +17,7 @@ impl Message {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MessageRole {
@@ -45,6 +46,6 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Message::new("Hello World")).unwrap(),
             "{\"role\":\"user\",\"content\":\"Hello World\"}"
-        )
+        );
     }
 }

--- a/src/config/role.rs
+++ b/src/config/role.rs
@@ -55,7 +55,7 @@ impl Role {
         }
     }
 
-    pub fn build_emssages(&self, content: &str) -> Vec<Message> {
+    pub fn build_messages(&self, content: &str) -> Vec<Message> {
         if self.embeded() {
             let content = merge_prompt_content(&self.prompt, content);
             vec![Message {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,9 @@ fn main() -> Result<()> {
         exit(0);
     }
     if cli.list_models {
-        config::MODELS
-            .iter()
-            .for_each(|(name, _)| println!("{}", name));
+        for (name, _) in &config::MODELS {
+            println!("{name}");
+        }
         exit(0);
     }
     if cli.dry_run {
@@ -76,18 +76,18 @@ fn main() -> Result<()> {
         if let Some(text) = text {
             input = format!("{text}\n{input}");
         }
-        start_directive(client, config, &input, no_stream)
+        start_directive(&client, &config, &input, no_stream)
     } else {
         match text {
-            Some(text) => start_directive(client, config, &text, no_stream),
+            Some(text) => start_directive(&client, &config, &text, no_stream),
             None => start_interactive(client, config),
         }
     }
 }
 
 fn start_directive(
-    client: ChatGptClient,
-    config: SharedConfig,
+    client: &ChatGptClient,
+    config: &SharedConfig,
     input: &str,
     no_stream: bool,
 ) -> Result<()> {
@@ -113,7 +113,7 @@ fn start_directive(
             abort_clone.set_ctrlc();
         })
         .expect("Error setting Ctrl-C handler");
-        let output = render_stream(input, &client, config.clone(), false, abort, wg.clone())?;
+        let output = render_stream(input, client, config, false, abort, wg.clone())?;
         wg.wait();
         output
     };

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,6 +3,7 @@ mod markdown;
 mod repl;
 
 use self::cmd::cmd_render_stream;
+#[allow(clippy::module_name_repetitions)]
 pub use self::markdown::MarkdownRender;
 use self::repl::repl_render_stream;
 
@@ -16,10 +17,11 @@ use crossbeam::channel::unbounded;
 use crossbeam::sync::WaitGroup;
 use std::thread::spawn;
 
+#[allow(clippy::module_name_repetitions)]
 pub fn render_stream(
     input: &str,
     client: &ChatGptClient,
-    config: SharedConfig,
+    config: &SharedConfig,
     repl: bool,
     abort: SharedAbortSignal,
     wg: WaitGroup,
@@ -30,9 +32,9 @@ pub fn render_stream(
         let abort_clone = abort.clone();
         spawn(move || {
             let err = if repl {
-                repl_render_stream(rx, light_theme, abort)
+                repl_render_stream(&rx, light_theme, &abort)
             } else {
-                cmd_render_stream(rx, light_theme, abort)
+                cmd_render_stream(&rx, light_theme, &abort)
             };
             if let Err(err) = err {
                 let err = format!("{err:?}");

--- a/src/render/repl.rs
+++ b/src/render/repl.rs
@@ -16,10 +16,11 @@ use std::{
 };
 use unicode_width::UnicodeWidthStr;
 
+#[allow(clippy::module_name_repetitions)]
 pub fn repl_render_stream(
-    rx: Receiver<ReplyStreamEvent>,
+    rx: &Receiver<ReplyStreamEvent>,
     light_theme: bool,
-    abort: SharedAbortSignal,
+    abort: &SharedAbortSignal,
 ) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -32,9 +33,9 @@ pub fn repl_render_stream(
 }
 
 fn repl_render_stream_inner(
-    rx: Receiver<ReplyStreamEvent>,
+    rx: &Receiver<ReplyStreamEvent>,
     light_theme: bool,
-    abort: SharedAbortSignal,
+    abort: &SharedAbortSignal,
     writer: &mut Stdout,
 ) -> Result<()> {
     let mut last_tick = Instant::now();
@@ -118,7 +119,8 @@ fn repl_render_stream_inner(
 }
 
 fn recover_cursor(writer: &mut Stdout, terminal_columns: u16, buffer: &str) -> Result<()> {
-    let buffer_rows = (buffer.width() as u16 + terminal_columns - 1) / terminal_columns;
+    let buffer_rows = (u16::try_from(buffer.width()).unwrap_or(u16::MAX) + terminal_columns - 1)
+        / terminal_columns;
     let (_, row) = cursor::position()?;
     if buffer_rows == 0 {
         queue!(writer, cursor::MoveTo(0, row))?;

--- a/src/repl/abort.rs
+++ b/src/repl/abort.rs
@@ -5,6 +5,7 @@ use std::sync::{
 
 pub type SharedAbortSignal = Arc<AbortSignal>;
 
+#[allow(clippy::module_name_repetitions)]
 pub struct AbortSignal {
     ctrlc: AtomicBool,
     ctrld: AtomicBool,

--- a/src/repl/handler.rs
+++ b/src/repl/handler.rs
@@ -24,6 +24,7 @@ pub enum ReplCmd {
     Copy,
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct ReplCmdHandler {
     client: ChatGptClient,
     config: SharedConfig,
@@ -32,6 +33,7 @@ pub struct ReplCmdHandler {
 }
 
 impl ReplCmdHandler {
+    #[allow(clippy::unnecessary_wraps)]
     pub fn init(
         client: ChatGptClient,
         config: SharedConfig,
@@ -58,7 +60,7 @@ impl ReplCmdHandler {
                 let ret = render_stream(
                     &input,
                     &self.client,
-                    self.config.clone(),
+                    &self.config,
                     true,
                     self.abort.clone(),
                     wg.clone(),
@@ -113,6 +115,7 @@ impl ReplCmdHandler {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct ReplyStreamHandler {
     sender: Option<Sender<ReplyStreamEvent>>,
     buffer: String,
@@ -154,22 +157,19 @@ impl ReplyStreamHandler {
     }
 
     pub fn done(&mut self) -> Result<()> {
-        match self.sender.as_ref() {
-            Some(tx) => {
-                let ret = tx
-                    .send(ReplyStreamEvent::Done)
-                    .with_context(|| "Failed to send StreamEvent:Done");
-                self.safe_ret(ret)?;
+        if let Some(tx) = self.sender.as_ref() {
+            let ret = tx
+                .send(ReplyStreamEvent::Done)
+                .with_context(|| "Failed to send StreamEvent:Done");
+            self.safe_ret(ret)?;
+        } else {
+            if !self.buffer.ends_with('\n') {
+                print_now!("\n");
             }
-            None => {
-                if !self.buffer.ends_with('\n') {
-                    print_now!("\n")
-                }
-                if self.repl {
+            if self.repl {
+                print_now!("\n");
+                if cfg!(macos) {
                     print_now!("\n");
-                    if cfg!(macos) {
-                        print_now!("\n")
-                    }
                 }
             }
         }

--- a/src/repl/highlighter.rs
+++ b/src/repl/highlighter.rs
@@ -5,6 +5,7 @@ use reedline::{Highlighter, StyledText};
 
 const MATCH_COLOR: Color = Color::Green;
 
+#[allow(clippy::module_name_repetitions)]
 pub struct ReplHighlighter {
     external_commands: Vec<String>,
     config: SharedConfig,
@@ -12,10 +13,10 @@ pub struct ReplHighlighter {
 
 impl ReplHighlighter {
     /// Construct the default highlighter with a given set of extern commands/keywords to detect and highlight
-    pub fn new(config: SharedConfig, external_commands: Vec<String>) -> ReplHighlighter {
+    pub fn new(config: SharedConfig, external_commands: Vec<String>) -> Self {
         Self {
-            config,
             external_commands,
+            config,
         }
     }
 }
@@ -28,9 +29,10 @@ impl Highlighter for ReplHighlighter {
         } else {
             Color::White
         };
-        let match_color = match self.config.read().highlight {
-            true => MATCH_COLOR,
-            false => color,
+        let match_color = if self.config.read().highlight {
+            MATCH_COLOR
+        } else {
+            color
         };
 
         if self
@@ -45,7 +47,7 @@ impl Highlighter for ReplHighlighter {
                 .filter(|c| line.contains(*c))
                 .map(std::ops::Deref::deref)
                 .collect();
-            let longest_match = matches.iter().fold("".to_string(), |acc, &item| {
+            let longest_match = matches.iter().fold(String::new(), |acc, &item| {
                 if item.len() > acc.len() {
                     item.to_string()
                 } else {

--- a/src/repl/init.rs
+++ b/src/repl/init.rs
@@ -24,7 +24,7 @@ impl Repl {
             .map(|(v, _)| v.to_string())
             .collect();
 
-        let completer = Self::create_completer(config.clone(), &commands);
+        let completer = Self::create_completer(&config, &commands);
         let highlighter = ReplHighlighter::new(config.clone(), commands);
         let keybindings = Self::create_keybindings();
         let history = Self::create_history()?;
@@ -45,7 +45,7 @@ impl Repl {
         Ok(Self { editor, prompt })
     }
 
-    fn create_completer(config: SharedConfig, commands: &[String]) -> DefaultCompleter {
+    fn create_completer(config: &SharedConfig, commands: &[String]) -> DefaultCompleter {
         let mut completion = commands.to_vec();
         completion.extend(config.read().repl_completions());
         let mut completer =

--- a/src/repl/prompt.rs
+++ b/src/repl/prompt.rs
@@ -9,6 +9,7 @@ const PROMPT_MULTILINE_COLOR: nu_ansi_term::Color = nu_ansi_term::Color::LightBl
 const INDICATOR_COLOR: Color = Color::Cyan;
 const PROMPT_RIGHT_COLOR: Color = Color::AnsiValue(5);
 
+#[allow(clippy::module_name_repetitions)]
 #[derive(Clone)]
 pub struct ReplPrompt {
     config: SharedConfig,
@@ -21,7 +22,7 @@ pub struct ReplPrompt {
 impl ReplPrompt {
     pub fn new(config: SharedConfig) -> Self {
         let (prompt_color, prompt_multiline_color, indicator_color, prompt_right_color) =
-            Self::get_colors(config.clone());
+            Self::get_colors(&config);
         Self {
             config,
             prompt_color,
@@ -32,14 +33,14 @@ impl ReplPrompt {
     }
     pub fn sync_config(&mut self) {
         let (prompt_color, prompt_multiline_color, indicator_color, prompt_right_color) =
-            Self::get_colors(self.config.clone());
+            Self::get_colors(&self.config);
         self.prompt_color = prompt_color;
         self.prompt_multiline_color = prompt_multiline_color;
         self.indicator_color = indicator_color;
         self.prompt_right_color = prompt_right_color;
     }
 
-    pub fn get_colors(config: SharedConfig) -> (Color, nu_ansi_term::Color, Color, Color) {
+    pub fn get_colors(config: &SharedConfig) -> (Color, nu_ansi_term::Color, Color, Color) {
         let (highlight, light_theme) = config.read().get_render_options();
         if highlight {
             (
@@ -68,11 +69,11 @@ impl ReplPrompt {
 
 impl Prompt for ReplPrompt {
     fn render_prompt_left(&self) -> Cow<str> {
-        if let Some(role) = self.config.read().role.as_ref() {
-            role.name.to_string().into()
-        } else {
-            Cow::Borrowed("")
-        }
+        self.config
+            .read()
+            .role
+            .as_ref()
+            .map_or(Cow::Borrowed(""), |role| Cow::Owned(role.name.clone()))
     }
 
     fn render_prompt_right(&self) -> Cow<str> {

--- a/src/repl/validator.rs
+++ b/src/repl/validator.rs
@@ -1,6 +1,7 @@
 use reedline::{ValidationResult, Validator};
 
 /// A default validator which checks for mismatched quotes and brackets
+#[allow(clippy::module_name_repetitions)]
 pub struct ReplValidator;
 
 impl Validator for ReplValidator {
@@ -30,7 +31,7 @@ fn incomplete_brackets(line: &str) -> bool {
             None => match c {
                 '{' | '(' => {
                     balance.push(c);
-                    symbol = Some(c)
+                    symbol = Some(c);
                 }
                 _ => {}
             },

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,7 +14,7 @@ macro_rules! print_now {
     };
 }
 
-pub fn print_now<T: ToString>(text: T) {
+pub fn print_now<T: ToString>(text: &T) {
     print!("{}", text.to_string());
     let _ = stdout().flush();
 }


### PR DESCRIPTION
Cleans up some anti-patterns throughout the code-base and brings code into compliance with much stricter linting (all, pedantic, and nursery).

Shouldn't change any actual behavior, but due to the nature of this type of PR I recommend a somewhat thorough code review / test. To that end, I'll be explaining large/scary changes in my own review.