### PR TITLE
Extend the ability to support third party LLM through customizable API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Download it from [GitHub Releases](https://github.com/sigoden/aichat/releases), 
 - Support proxy connection
 - Dark/light theme
 - Save chat messages
+- Customizable API URL
 
 ## Config
 
@@ -58,6 +59,8 @@ api_key: "<YOUR SECRET API KEY>" # Request via https://platform.openai.com/accou
 organization_id: "org-xxx" # optional, set organization id
 model: "gpt-3.5-turbo" # optional, choose a model
 temperature: 1.0 # optional, see https://platform.openai.com/docs/api-reference/chat/create#chat/create-temperature
+api_url: "https://api.openai.com/v1/chat/completions" #optional, set API url to request
+max_tokens: 1024 # optional, set max tokens for return from API.
 save: true # optional, If set true, aichat will save chat messages to message.md
 highlight: true # optional, Set false to turn highlight
 proxy: "socks5://127.0.0.1:1080" # optional, set proxy server. e.g. http://127.0.0.1:8080 or socks5://127.0.0.1:1080
@@ -158,6 +161,8 @@ roles_file          /home/alice/.config/aichat/roles.yaml
 messages_file       /home/alice/.config/aichat/messages.md
 api_key             sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 organization_id     -
+api_url             https://api.openai.com/v1/chat/completions
+max_tokens          1024
 model               gpt-3.5-turbo
 temperature         -
 save                true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,11 @@ pub struct Cli {
     /// No stream output
     #[clap(short = 'S', long)]
     pub no_stream: bool,
+    /// Define the API URL for requesting
+    #[clap(short = 'I', long)]
+    pub api_url: Option<String>,
+    #[clap(long)]
+    pub max_tokens: Option<usize>,
     /// List all roles
     #[clap(long)]
     pub list_roles: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,12 @@ fn main() -> Result<()> {
     if cli.dry_run {
         config.write().dry_run = true;
     }
+    if cli.max_tokens.is_some() {
+        config.write().max_tokens = cli.max_tokens.unwrap();
+    }
+    if cli.api_url.is_some() {
+        config.write().api_url = cli.api_url.expect("Error setting API_URL").to_string();
+    }
     let role = match &cli.role {
         Some(name) => Some(
             config


### PR DESCRIPTION
Add api_url , max_tokens into settings. These settings extends the aichat to support third party LLM services which using OPENAI-like API such as llama-cpp-python[server], LocalAI and etc.

Example:
start local API service first, below is an example for aichat with a local codellama on a MacBook laptop
```bash
python3 -m pip install llama-cpp-python
python3 -m llama_cpp.server --n_gpu_layers 1 --model ~/models/codellama_13b.gguf --port 3000
```

```bash
aichat -I http://localhost:3000/v1/chat/completions --max_tokens 2048
```