### PR TITLE
feat: add .edit command for multi-line editing

### DIFF
--- a/src/repl/init.rs
+++ b/src/repl/init.rs
@@ -32,15 +32,12 @@ impl Repl {
         let edit_mode: Box<dyn EditMode> = if config.read().vi_keybindings {
             let mut normal_keybindings = default_vi_normal_keybindings();
             let mut insert_keybindings = default_vi_insert_keybindings();
-            Self::add_menu_keybindings(&mut normal_keybindings);
-            Self::add_menu_keybindings(&mut insert_keybindings);
-            Self::add_clear_keybindings(&mut normal_keybindings);
-            Self::add_clear_keybindings(&mut insert_keybindings);
+            Self::extra_keybindings(&mut normal_keybindings);
+            Self::extra_keybindings(&mut insert_keybindings);
             Box::new(Vi::new(insert_keybindings, normal_keybindings))
         } else {
             let mut keybindings = default_emacs_keybindings();
-            Self::add_menu_keybindings(&mut keybindings);
-            Self::add_clear_keybindings(&mut keybindings);
+            Self::extra_keybindings(&mut keybindings);
             Box::new(Emacs::new(keybindings))
         };
         let mut editor = Reedline::create()
@@ -67,7 +64,7 @@ impl Repl {
         completer
     }
 
-    fn add_menu_keybindings(keybindings: &mut Keybindings) {
+    fn extra_keybindings(keybindings: &mut Keybindings) {
         keybindings.add_binding(
             KeyModifiers::NONE,
             KeyCode::Tab,
@@ -76,13 +73,15 @@ impl Repl {
                 ReedlineEvent::MenuNext,
             ]),
         );
-    }
-
-    fn add_clear_keybindings(keybindings: &mut Keybindings) {
         keybindings.add_binding(
             KeyModifiers::CONTROL,
             KeyCode::Char('l'),
             ReedlineEvent::ExecuteHostCommand(".clear screen".into()),
+        );
+        keybindings.add_binding(
+            KeyModifiers::CONTROL,
+            KeyCode::Char('s'),
+            ReedlineEvent::Submit,
         );
     }
 

--- a/src/repl/validator.rs
+++ b/src/repl/validator.rs
@@ -1,12 +1,13 @@
+use super::EDIT_RE;
+
 use reedline::{ValidationResult, Validator};
 
 /// A default validator which checks for mismatched quotes and brackets
-#[allow(clippy::module_name_repetitions)]
 pub struct ReplValidator;
 
 impl Validator for ReplValidator {
     fn validate(&self, line: &str) -> ValidationResult {
-        if line.ends_with('\\') {
+        if let Ok(true) = EDIT_RE.is_match(line) {
             ValidationResult::Incomplete
         } else {
             ValidationResult::Complete


### PR DESCRIPTION
```
〉.edit
abc
def
ijk

```

This pr deprecates #147 and  old `{}`/`()` multi-line editing.
