### PR TITLE
fix: show duplicate lines in kitty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn start_directive(
         let output = client.send_message(input)?;
         if highlight {
             let mut markdown_render = MarkdownRender::new(light_theme);
-            println!("{}", markdown_render.render(&output).trim());
+            println!("{}", markdown_render.render_block(&output).trim());
         } else {
             println!("{}", output.trim());
         }

--- a/src/render/cmd.rs
+++ b/src/render/cmd.rs
@@ -26,7 +26,7 @@ pub fn cmd_render_stream(
                         let mut lines: Vec<&str> = text.split('\n').collect();
                         buffer = lines.pop().unwrap_or_default().to_string();
                         let output = lines.join("\n");
-                        print_now!("{}\n", markdown_render.render(&output));
+                        print_now!("{}\n", markdown_render.render_block(&output));
                     } else {
                         buffer = format!("{buffer}{text}");
                         if !(markdown_render.is_code_block()
@@ -36,14 +36,14 @@ pub fn cmd_render_stream(
                             || buffer.starts_with('|'))
                         {
                             if let Some((output, remain)) = split_line(&buffer) {
-                                print_now!("{}", markdown_render.render_line_stateless(&output));
+                                print_now!("{}", markdown_render.render_line(&output));
                                 buffer = remain;
                             }
                         }
                     }
                 }
                 ReplyStreamEvent::Done => {
-                    let output = markdown_render.render(&buffer);
+                    let output = markdown_render.render_block(&buffer);
                     print_now!("{}\n", output.trim_end());
                     break;
                 }

--- a/src/render/markdown.rs
+++ b/src/render/markdown.rs
@@ -53,14 +53,17 @@ impl MarkdownRender {
         }
     }
 
-    pub fn render(&mut self, src: &str) -> String {
+    pub fn render_block(&mut self, src: &str) -> String {
         src.split('\n')
-            .map(|line| self.render_line(line).unwrap_or_else(|| line.to_string()))
+            .map(|line| {
+                self.render_line_impl(line)
+                    .unwrap_or_else(|| line.to_string())
+            })
             .collect::<Vec<String>>()
             .join("\n")
     }
 
-    pub fn render_line_stateless(&self, line: &str) -> String {
+    pub fn render_line(&self, line: &str) -> String {
         let output = if self.is_code_block() && detect_code_block(line).is_none() {
             self.render_code_line(line)
         } else {
@@ -76,7 +79,7 @@ impl MarkdownRender {
         )
     }
 
-    fn render_line(&mut self, line: &str) -> Option<String> {
+    fn render_line_impl(&mut self, line: &str) -> Option<String> {
         if let Some(lang) = detect_code_block(line) {
             match self.prev_line_type {
                 LineType::Normal | LineType::CodeEnd => {


### PR DESCRIPTION
Only happens in kitty terminal and only if steaming word just locate on terminal boundary
![image](https://github.com/sigoden/aichat/assets/4012553/31495e6e-3d46-4171-9784-224cb43ec388)

close #105 