### PR TITLE
feat: deprecate `.clear` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,20 +140,21 @@ The Chat REPL supports:
 
 ```
 〉.help
-.info                    Print system-wide information
-.set                     Modify the configuration temporarily
-.model                   Choose a model
-.role                    Select a role
-.clear role              Clear the currently selected role
-.session                 Start a session
-.clear session           End current session
-.copy                    Copy the last output to the clipboard
-.read                    Read the contents of a file and submit
-.edit                    Multi-line editing (CTRL+S to finish)
 .help                    Print this help message
+.info                    Print system-wide information
+.edit                    Multi-line editing (CTRL+S to finish)
+.model                   Switch LLM model
+.role                    Use role
+.exit role               Leave current role
+.session                 Start a context-aware chat session
+.exit session            End the current session
+.set                     Modify the configuration parameters
+.copy                    Copy the last reply to the clipboard
+.read                    Import from file and submit
 .exit                    Exit the REPL
 
 Press Ctrl+C to abort readline, Ctrl+D to exit the REPL
+
 ```
 
 ### `.info` - view current configuration information
@@ -190,17 +191,7 @@ AIChat also provides `.edit` command for multi-lines editing.
 }
 ```
 
-> Submit the multi-line text with `Ctrl+S`.
-
-
-### `.set` - modify the configuration temporarily
-
-```
-〉.set dry_run true
-〉.set highlight false
-〉.set save false
-〉.set temperature 1.2
-```
+> Submit with `Ctrl+S`.
 
 
 ### `.model` - choose a model
@@ -233,7 +224,7 @@ emoji〉hello
 Clear current selected role:
 
 ```
-emoji〉.clear role
+emoji〉.exit role
 
 〉hello
 Hello there! How can I assist you today?
@@ -254,7 +245,7 @@ temp）1 to 5, odd only                                                         
 temp）to 7                                                                                4070
 1, 3, 5, 7
 
-temp）.clear session
+temp）.exit session
 
 〉
 ```
@@ -267,6 +258,15 @@ aichat -s temp --info             # Show session details
 aichat -r shell -s                # Create a session with a role
 aichat -m openai:gpt-4-32k -s     # Create a session with a model
 aichat -s sh unzip a file         # Run session in command mode
+```
+
+### `.set` - modify the configuration temporarily
+
+```
+〉.set temperature 1.2
+〉.set dry_run true
+〉.set highlight false
+〉.set save false
 ```
 
 ## License

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,28 +3,28 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
-    /// List all models
+    /// List all available models
     #[clap(long)]
     pub list_models: bool,
     /// Choose a LLM model
     #[clap(short, long)]
     pub model: Option<String>,
-    /// List all roles
+    /// List all available roles
     #[clap(long)]
     pub list_roles: bool,
-    /// Select a role
+    /// Choose a role
     #[clap(short, long)]
     pub role: Option<String>,
-    /// List sessions
+    /// List all available sessions
     #[clap(long)]
     pub list_sessions: bool,
-    /// Initiate or continue a session
+    /// Initiate or reuse a session
     #[clap(short = 's', long)]
     pub session: Option<Option<String>>,
     /// Specify the text-wrapping mode (no*, auto, <max-width>)
     #[clap(short = 'w', long)]
     pub wrap: Option<String>,
-    /// Print information
+    /// Print related information
     #[clap(long)]
     pub info: bool,
     /// Use light theme

--- a/src/repl/handler.rs
+++ b/src/repl/handler.rs
@@ -15,13 +15,13 @@ use std::cell::RefCell;
 
 pub enum ReplCmd {
     Submit(String),
+    ViewInfo,
     SetModel(String),
     SetRole(String),
-    UpdateConfig(String),
-    ClearRole,
-    ViewInfo,
+    ExitRole,
     StartSession(Option<String>),
-    EndSession,
+    ExitSession,
+    Set(String),
     Copy,
     ReadFile(String),
 }
@@ -66,6 +66,10 @@ impl ReplCmdHandler {
                     let _ = self.copy(&buffer);
                 }
             }
+            ReplCmd::ViewInfo => {
+                let output = self.config.read().info()?;
+                print_now!("{}\n\n", output.trim_end());
+            }
             ReplCmd::SetModel(name) => {
                 self.config.write().set_model(&name)?;
                 print_now!("\n");
@@ -74,24 +78,20 @@ impl ReplCmdHandler {
                 let output = self.config.write().set_role(&name)?;
                 print_now!("{}\n\n", output.trim_end());
             }
-            ReplCmd::ClearRole => {
+            ReplCmd::ExitRole => {
                 self.config.write().clear_role()?;
-                print_now!("\n");
-            }
-            ReplCmd::ViewInfo => {
-                let output = self.config.read().info()?;
-                print_now!("{}\n\n", output.trim_end());
-            }
-            ReplCmd::UpdateConfig(input) => {
-                self.config.write().update(&input)?;
                 print_now!("\n");
             }
             ReplCmd::StartSession(name) => {
                 self.config.write().start_session(&name)?;
                 print_now!("\n");
             }
-            ReplCmd::EndSession => {
+            ReplCmd::ExitSession => {
                 self.config.write().end_session()?;
+                print_now!("\n");
+            }
+            ReplCmd::Set(input) => {
+                self.config.write().update(&input)?;
                 print_now!("\n");
             }
             ReplCmd::Copy => {


### PR DESCRIPTION
- Rename `.clear session` to `.exit session`
- Rename `.clear role` to `.exit role`
- Deprecate `.clear` command