### PR TITLE
fix: uncorrected render in command mode

### DIFF
--- a/src/render/cmd.rs
+++ b/src/render/cmd.rs
@@ -43,10 +43,12 @@ pub fn cmd_render_stream(
                                 let output = render.render(&input);
                                 let output = &output[col..];
                                 let (_, tail) = split_line_tail(output);
-                                if output.contains('\n') {
-                                    col = display_width(tail);
-                                } else {
-                                    col += display_width(output);
+                                if render.wrap_width().is_some() {
+                                    if output.contains('\n') {
+                                        col = display_width(tail);
+                                    } else {
+                                        col += display_width(output);
+                                    }
                                 }
                                 print_now!("{}", output);
                             }

--- a/src/render/markdown.rs
+++ b/src/render/markdown.rs
@@ -71,6 +71,10 @@ impl MarkdownRender {
         )
     }
 
+    pub(crate) const fn wrap_width(&self) -> Option<u16> {
+        self.wrap_width
+    }
+
     pub fn render(&mut self, text: &str) -> String {
         text.split('\n')
             .map(|line| self.render_line_mut(line))


### PR DESCRIPTION
Describe the bug

```
$ aichat --dry-run You need to first determine the text I provide. If it is a regular expression, you should explain its meaning.
You need to first determine the text I provide. If it is a regular expression,                                                                               you should explain its meaning.
```
A lot of spaces between sentences.