### PR TITLE
refactor: rename azure-openai to azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ clients:
     api_key: sk-xxx
     organization_id:
 
-  - type: local ai
+  - type: localai
     api_base: http://localhost:8080/v1
+    models:
+      - name: gpt4all-j
+        max_tokens: 8192
 ```
 
 Check out [config.example.yaml](config.example.yaml) for all configuration items.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,7 +22,7 @@ clients:
     organization_id:
 
   # See https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart
-  - type: azure-openai
+  - type: azure
     api_base: https://RESOURCE.openai.azure.com
     api_key: xxx
     models:

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,11 +10,5 @@ pub use model::*;
 register_client!(
     (openai, "openai", OpenAI, OpenAIConfig, OpenAIClient),
     (localai, "localai", LocalAI, LocalAIConfig, LocalAIClient),
-    (
-        azure_openai,
-        "azure-openai",
-        AzureOpenAI,
-        AzureOpenAIConfig,
-        AzureOpenAIClient
-    ),
+    (azure, "azure", Azure, AzureConfig, AzureClient),
 );


### PR DESCRIPTION
client type is `azure` other than `azure-openai`
```
clients:
  # See https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart
  - type: azure
    api_base: https://RESOURCE.openai.azure.com
    api_key: xxx
    models:
      - name: MyGPT4                                  # Model deployment name
        max_tokens: 8192
```
     