### PR TITLE
fix: rendering markdown in REPL

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -824,10 +824,12 @@ fn set_bool(target: &mut bool, value: &str) {
 
 #[cfg(debug_assertions)]
 fn setup_logger() -> Result<()> {
-    use simplelog::WriteLogger;
+    use simplelog::{LevelFilter, WriteLogger};
     let file = std::fs::File::create(Config::local_path("debug.log")?)?;
     let config = simplelog::ConfigBuilder::new()
         .add_filter_allow_str("aichat")
+        .set_thread_level(LevelFilter::Off)
+        .set_time_level(LevelFilter::Off)
         .build();
     WriteLogger::init(log::LevelFilter::Debug, config, file)?;
     Ok(())

--- a/src/render/markdown.rs
+++ b/src/render/markdown.rs
@@ -205,7 +205,9 @@ impl MarkdownRender {
 
 fn wrap(text: &str, width: usize) -> String {
     let indent: usize = text.chars().take_while(|c| *c == ' ').count();
-    let wrap_options = textwrap::Options::new(width).initial_indent(&text[0..indent]);
+    let wrap_options = textwrap::Options::new(width)
+        .wrap_algorithm(textwrap::WrapAlgorithm::FirstFit)
+        .initial_indent(&text[0..indent]);
     textwrap::wrap(&text[indent..], wrap_options).join("\n")
 }
 


### PR DESCRIPTION
The wrap is 80. The problem point i is `code,ich`， see below
```
The WWW-Authenticate header is an HTTP response header that is used in a server
response to indicate that authentication is required to access a resource. It is
is typically used in conjunction with the HTTP 401 Unauthorized status code,ich
which is returned when a client attempts to access a resource without proper
authentication.
```

After proper (Second-to-last token) is receivered, aichat renders markdown as follows:

```
The WWW-Authenticate header is an HTTP response header that is used in a server
response to indicate that authentication is required to access a resource. It is
typically used in conjunction with the HTTP 401 Unauthorized status code, which
is returned when a client attempts to access a resource without proper
```

But after authentication (last token) is receivered, aichat renders markdown as follows:
```
The WWW-Authenticate header is an HTTP response header that is used in a server
response to indicate that authentication is required to access a resource. It
is typically used in conjunction with the HTTP 401 Unauthorized status code,
which is returned when a client attempts to access a resource without proper
authentication
```

The markdown is been re-layouted. 

In order to solve this problem, two approaches are adopted.
1. Clear text from cursor down
2. Ajust wrap algrithm


