### PR TITLE
feat: allow the use of an unlisted model

### DIFF
--- a/src/client/azure_openai.rs
+++ b/src/client/azure_openai.rs
@@ -66,6 +66,8 @@ impl AzureOpenAIClient {
             &api_base, self.model.name
         );
 
+        debug!("AzureOpenAI Request: {url} {body}");
+
         let builder = client.post(url).header("api-key", api_key).json(&body);
 
         Ok(builder)

--- a/src/client/ernie.rs
+++ b/src/client/ernie.rs
@@ -85,6 +85,8 @@ impl ErnieClient {
             &ACCESS_TOKEN
         });
 
+        debug!("Ernie Request: {url} {body}");
+
         let builder = client.post(url).json(&body);
 
         Ok(builder)

--- a/src/client/localai.rs
+++ b/src/client/localai.rs
@@ -68,6 +68,8 @@ impl LocalAIClient {
 
         let url = format!("{}{chat_endpoint}", self.config.api_base);
 
+        debug!("LocalAI Request: {url} {body}");
+
         let mut builder = client.post(url).json(&body);
         if let Some(api_key) = api_key {
             builder = builder.bearer_auth(api_key);

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -30,6 +30,37 @@ impl Model {
         }
     }
 
+    pub fn find(models: &[Self], value: &str) -> Option<Self> {
+        let mut model = None;
+        let (client_name, model_name) = match value.split_once(':') {
+            Some((client_name, model_name)) => {
+                if model_name.is_empty() {
+                    (client_name, None)
+                } else {
+                    (client_name, Some(model_name))
+                }
+            }
+            None => (value, None),
+        };
+        match model_name {
+            Some(model_name) => {
+                if let Some(found) = models.iter().find(|v| v.id() == value) {
+                    model = Some(found.clone());
+                } else if let Some(found) = models.iter().find(|v| v.client_name == client_name) {
+                    let mut found = found.clone();
+                    found.name = model_name.to_string();
+                    model = Some(found)
+                }
+            }
+            None => {
+                if let Some(found) = models.iter().find(|v| v.client_name == client_name) {
+                    model = Some(found.clone());
+                }
+            }
+        }
+        model
+    }
+
     pub fn id(&self) -> String {
         format!("{}:{}", self.client_name, self.name)
     }

--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -68,6 +68,8 @@ impl OpenAIClient {
 
         let url = format!("{api_base}/chat/completions");
 
+        debug!("OpenAI Request: {url} {body}");
+
         let mut builder = client.post(url).bearer_auth(api_key).json(&body);
 
         if let Some(organization_id) = &self.config.organization_id {

--- a/src/client/palm.rs
+++ b/src/client/palm.rs
@@ -70,6 +70,8 @@ impl PaLMClient {
 
         let url = format!("{API_BASE}{}:generateMessage?key={}", model, api_key);
 
+        debug!("PaLM Request: {url} {body}");
+
         let builder = client.post(url).json(&body);
 
         Ok(builder)

--- a/src/client/qianwen.rs
+++ b/src/client/qianwen.rs
@@ -68,6 +68,8 @@ impl QianwenClient {
         let stream = data.stream;
         let body = build_body(data, self.model.name.clone());
 
+        debug!("Qianwen Request: {API_URL} {body}");
+
         let mut builder = client.post(API_URL).bearer_auth(api_key).json(&body);
         if stream {
             builder = builder.header("X-DashScope-SSE", "enable");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -305,17 +305,9 @@ impl Config {
 
     pub fn set_model(&mut self, value: &str) -> Result<()> {
         let models = list_models(self);
-        let mut model = None;
-        let value = value.trim_end_matches(':');
-        if value.contains(':') {
-            if let Some(found) = models.iter().find(|v| v.id() == value) {
-                model = Some(found.clone());
-            }
-        } else if let Some(found) = models.iter().find(|v| v.client_name == value) {
-            model = Some(found.clone());
-        }
+        let model = Model::find(&models, value);
         match model {
-            None => bail!("Unknown model '{}'", value),
+            None => bail!("Invalid model '{}'", value),
             Some(model) => {
                 if let Some(session) = self.session.as_mut() {
                     session.set_model(model.clone())?;


### PR DESCRIPTION
This PR allows users to use models that are not in `--list-models`.

So users can experience the latest preview version of the model without having to wait for aichat to update.

```
aichat --model openai:gpt-3.5-turbo-1106
aichat --model openai:gpt-4-1106-preview

.model openai:gpt-3.5-turbo-1106
.model openai:gpt-4-1106-preview
```

