### PR TITLE
fix: unable to build on android using termux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ base64 = "0.21.0"
 rustc-hash = "1.1.0"
 bstr = "1.3.0"
 nu-ansi-term = "0.47.0"
-arboard = { version = "3.2.0", default-features = false }
 async-trait = "0.1.74"
 textwrap = "0.16.0"
 ansi_colours = "1.2.2"
@@ -52,6 +51,9 @@ default-features = false
 version = "5.0.0"
 default-features = false
 features = ["parsing", "regex-onig", "plist-load"]
+
+[target.'cfg(not(any(target_os = "android", target_os = "emscripten")))'.dependencies]
+arboard = { version = "3.2.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/src/utils/clipboard.rs
+++ b/src/utils/clipboard.rs
@@ -1,11 +1,11 @@
-use arboard::Clipboard;
 use lazy_static::lazy_static;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+#[cfg(not(any(target_os = "android", target_os = "emscripten")))]
 lazy_static! {
-    static ref CLIPBOARD: Arc<Mutex<Option<Clipboard>>> =
-        Arc::new(Mutex::new(Clipboard::new().ok()));
+    static ref CLIPBOARD: Arc<Mutex<Option<arboard::Clipboard>>> =
+        Arc::new(Mutex::new(arboard::Clipboard::new().ok()));
 }
 
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]

--- a/src/utils/clipboard.rs
+++ b/src/utils/clipboard.rs
@@ -1,0 +1,24 @@
+use arboard::Clipboard;
+use lazy_static::lazy_static;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref CLIPBOARD: Arc<Mutex<Option<Clipboard>>> =
+        Arc::new(Mutex::new(Clipboard::new().ok()));
+}
+
+#[cfg(not(any(target_os = "android", target_os = "emscripten")))]
+pub fn set_text(text: &str) -> anyhow::Result<()> {
+    let mut clipboard = CLIPBOARD.lock().unwrap();
+    match clipboard.as_mut() {
+        Some(clipboard) => clipboard.set_text(text)?,
+        None => anyhow::bail!("No available clipboard"),
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "android", target_os = "emscripten"))]
+pub fn set_text(text: &str) -> anyhow::Result<()> {
+    anyhow::bail!("No available clipboard")
+}

--- a/src/utils/clipboard.rs
+++ b/src/utils/clipboard.rs
@@ -1,11 +1,7 @@
-use lazy_static::lazy_static;
-use std::sync::Arc;
-use std::sync::Mutex;
-
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
-lazy_static! {
-    static ref CLIPBOARD: Arc<Mutex<Option<arboard::Clipboard>>> =
-        Arc::new(Mutex::new(arboard::Clipboard::new().ok()));
+lazy_static::lazy_static! {
+    static ref CLIPBOARD: std::sync::Arc<std::sync::Mutex<Option<arboard::Clipboard>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(arboard::Clipboard::new().ok()));
 }
 
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
@@ -19,6 +15,6 @@ pub fn set_text(text: &str) -> anyhow::Result<()> {
 }
 
 #[cfg(any(target_os = "android", target_os = "emscripten"))]
-pub fn set_text(text: &str) -> anyhow::Result<()> {
+pub fn set_text(_text: &str) -> anyhow::Result<()> {
     anyhow::bail!("No available clipboard")
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,9 +1,11 @@
 mod abort_signal;
+mod clipboard;
 mod prompt_input;
 mod split_line;
 mod tiktoken;
 
 pub use self::abort_signal::{create_abort_signal, AbortSignal};
+pub use self::clipboard::set_text;
 pub use self::prompt_input::*;
 pub use self::split_line::*;
 pub use self::tiktoken::cl100k_base_singleton;


### PR DESCRIPTION
The arboard-rs does not works on termux.

In order to enable aichat to be built on termux, we need to:

- move clipboard related functions to utils/clipboard.rs
- add cfg macro to ignore them in android

fix termux/termux-packages#18422
