### PR TITLE
feat: add `config.prelude` to allow setting default role/session

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ wrap: no                         # Specify the text-wrapping mode (no, auto, <ma
 wrap_code: false                 # Whether wrap code block
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. values: emacs, vi
+prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
 
 clients:
   - type: openai
@@ -141,7 +142,7 @@ The Chat REPL supports:
 .info                    Print system info
 .edit                    Multi-line editing (CTRL+S to finish)
 .model                   Switch LLM model
-.role                    Use role
+.role                    Use a role
 .info role               Show role info
 .exit role               Leave current role
 .session                 Start a context-aware chat session

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,7 +6,8 @@ light_theme: false               # Whether to use a light theme
 wrap: no                         # Specify the text-wrapping mode (no, auto, <max-width>)
 wrap_code: false                 # Whether wrap code block
 auto_copy: false                 # Automatically copy the last output to the clipboard
-keybindings: emacs               # REPL keybindings. values: emacs, vi
+keybindings: emacs               # REPL keybindings. (emacs, vi)
+prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
 
 clients:
   # All clients have the following configuration:

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ fn main() -> Result<()> {
         println!("{}", info);
         exit(0);
     }
+    config.write().onstart()?;
     let no_stream = cli.no_stream;
     let client = init_client(&config)?;
     if stdin().is_terminal() {

--- a/src/render/repl.rs
+++ b/src/render/repl.rs
@@ -83,7 +83,7 @@ fn repl_render_stream_inner(
                         queue!(writer, style::Print(&buffer),)?;
 
                         // No guarantee the buffer width of the buffer will not exceed the number of columns.
-                        // So we calcuate the number of rows needed, rather than setting it directly to 1.
+                        // So we calculate the number of rows needed, rather than setting it directly to 1.
                         buffer_rows = need_rows(&buffer, columns);
                     } else {
                         buffer = format!("{buffer}{text}");

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -32,7 +32,7 @@ const REPL_COMMANDS: [(&str, &str); 14] = [
     (".info", "Print system info"),
     (".edit", "Multi-line editing (CTRL+S to finish)"),
     (".model", "Switch LLM model"),
-    (".role", "Use role"),
+    (".role", "Use a role"),
     (".info role", "Show role info"),
     (".exit role", "Leave current role"),
     (".session", "Start a context-aware chat session"),


### PR DESCRIPTION
For those who want aichat to enter a session after startup, you can set it as follows:
```
prelude: session:mysession
```

For those who want aichat to use a role after startup, you can set it as follows:
```
prelude: role:myrole
```

close #220 