### PR TITLE
feat: extend `.read` to support files and messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shell-words",
  "simplelog",
  "syntect",
  "textwrap",
@@ -1652,6 +1653,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ ansi_colours = "1.2.2"
 reqwest-eventsource = "0.5.0"
 simplelog = "0.12.1"
 log = "0.4.20"
+shell-words = "1.1.0"
 
 [dependencies.reqwest]
 version = "0.11.14"

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The Chat REPL supports:
 .exit session            End the current session
 .set                     Modify the configuration parameters
 .copy                    Copy the last reply to the clipboard
-.read                    Import from file and submit
+.read                    Read files into the message and submit
 .exit                    Exit the REPL
 
 Type ::: to begin multi-line editing, type ::: to end it.


### PR DESCRIPTION
```
.read <files>...[ -- <text>...]
```

```
.read message.txt
.read config.yaml -- convert to toml
.read a.json b.json -- combile two json files
```