### PR TITLE
Make REPL indicators user-customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ light_theme: false               # Whether to use a light theme
 wrap: no                         # Specify the text-wrapping mode (no, auto, <max-width>)
 wrap_code: false                 # Whether wrap code block
 auto_copy: false                 # Automatically copy the last output to the clipboard
-keybindings: emacs               # REPL keybindings. values: emacs, vi
+keybindings: emacs               # REPL keybindings. (emacs, vi)
+repl_prompt_indicator: 〉        # REPL indicator
+repl_separator: ''               # REPL separator between session/role and indicator.
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
 
 clients:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,6 +7,8 @@ wrap: no                         # Specify the text-wrapping mode (no, auto, <ma
 wrap_code: false                 # Whether wrap code block
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. (emacs, vi)
+repl_prompt_indicator: 〉        # REPL indicator
+repl_separator: ''               # REPL separator between session/role and indicator.
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
 
 clients:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -68,6 +68,8 @@ pub struct Config {
     pub prelude: String,
     /// Setup clients
     pub clients: Vec<ClientConfig>,
+    /// String to show as the prompt indicator.
+    pub repl_prompt_indicator: String,
     /// Predefined roles
     #[serde(skip)]
     pub roles: Vec<Role>,
@@ -100,6 +102,7 @@ impl Default for Config {
             keybindings: Default::default(),
             prelude: String::new(),
             clients: vec![ClientConfig::default()],
+            repl_prompt_indicator: String::from("〉"),
             roles: vec![],
             role: None,
             session: None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -391,6 +391,7 @@ impl Config {
             ("save", self.save.to_string()),
             ("highlight", self.highlight.to_string()),
             ("light_theme", self.light_theme.to_string()),
+            ("repl_prompt_indicator", self.repl_prompt_indicator.clone()),
             ("wrap", wrap),
             ("wrap_code", self.wrap_code.to_string()),
             ("auto_copy", self.auto_copy.to_string()),
@@ -403,7 +404,7 @@ impl Config {
         ];
         let output = items
             .iter()
-            .map(|(name, value)| format!("{name:<20}{value}"))
+            .map(|(name, value)| format!("{name:<23}{value}"))
             .collect::<Vec<String>>()
             .join("\n");
         Ok(output)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -68,8 +68,10 @@ pub struct Config {
     pub prelude: String,
     /// Setup clients
     pub clients: Vec<ClientConfig>,
-    /// String to show as the prompt indicator.
+    /// Prompt indicator in the REPL.
     pub repl_prompt_indicator: String,
+    /// Separator between session/role and indicator in REPL.
+    pub repl_separator: String,
     /// Predefined roles
     #[serde(skip)]
     pub roles: Vec<Role>,
@@ -103,6 +105,7 @@ impl Default for Config {
             prelude: String::new(),
             clients: vec![ClientConfig::default()],
             repl_prompt_indicator: String::from("〉"),
+            repl_separator: String::from(""),
             roles: vec![],
             role: None,
             session: None,

--- a/src/repl/prompt.rs
+++ b/src/repl/prompt.rs
@@ -38,10 +38,11 @@ impl Prompt for ReplPrompt {
     }
 
     fn render_prompt_indicator(&self, _prompt_mode: reedline::PromptEditMode) -> Cow<str> {
+        let indicator = self.config.read().repl_prompt_indicator.clone();
         if self.config.read().session.is_some() {
-            Cow::Borrowed("）")
+            Cow::Owned(format!(":{}", indicator))
         } else {
-            Cow::Borrowed("〉")
+            Cow::Owned(indicator)
         }
     }
 

--- a/src/repl/prompt.rs
+++ b/src/repl/prompt.rs
@@ -24,10 +24,14 @@ impl ReplPrompt {
 
 impl Prompt for ReplPrompt {
     fn render_prompt_left(&self) -> Cow<str> {
-        if let Some(session) = &self.config.read().session {
-            Cow::Owned(session.name().to_string())
-        } else if let Some(role) = &self.config.read().role {
-            Cow::Owned(role.name.clone())
+        let config = &self.config.read();
+
+        if let Some(session) = &config.session {
+            let left = session.name().to_string();
+            Cow::Owned(format!("{}{}", left, config.repl_separator))
+        } else if let Some(role) = &config.role {
+            let left = role.name.clone();
+            Cow::Owned(format!("{}{}", left, config.repl_separator))
         } else {
             Cow::Borrowed("")
         }
@@ -39,11 +43,7 @@ impl Prompt for ReplPrompt {
 
     fn render_prompt_indicator(&self, _prompt_mode: reedline::PromptEditMode) -> Cow<str> {
         let indicator = self.config.read().repl_prompt_indicator.clone();
-        if self.config.read().session.is_some() {
-            Cow::Owned(format!(":{}", indicator))
-        } else {
-            Cow::Owned(indicator)
-        }
+        Cow::Owned(indicator)
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {


### PR DESCRIPTION
Hello, not sure if you're accepting PRs on this one, but here's some novice Rust if you'd like some! 😅 

----

The default REPL indicator is not customizable, which can make things confusing if you happen to use the same character for your regular shell prompt.[^1]

This PR makes makes the prompt indicator configurable, giving users a way to work around conflicts with their shell prompt. The existing prompt indicator is the default if left uncustomized.

In the example below, I've set the prompt to read `gpt>`.

```
❯ cargo run
   Compiling aichat v0.11.0 (/Users/chris/src/chrisbarrett/aichat)
    Finished dev [unoptimized + debuginfo] target(s) in 2.14s
     Running `target/debug/aichat`
Welcome to aichat 0.11.0
Type ".help" for more information.
gpt>
```
![image](https://github.com/sigoden/aichat/assets/836504/22137c94-a64e-4c1f-954f-55f3312f6dcd)

Happy to make any changes you'd like, and no sweat if you're not interested. :) Cheers publishing a helpful program!

[^1]:  In particular,  the [pure](https://github.com/sindresorhus/pure) zsh prompt uses the same character, making it difficult to tell at a glance whether you're in a shell or an aichat session if you happen to use that!