### PR TITLE
refactor: remove path existence indicator from info

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -365,10 +365,7 @@ impl Config {
     }
 
     pub fn sys_info(&self) -> Result<String> {
-        let display_path = |path: &Path| {
-            let state = if path.exists() { "" } else { " ⚠️" };
-            format!("{}{state}", path.display())
-        };
+        let display_path = |path: &Path| path.display().to_string();
         let temperature = self
             .temperature
             .map_or_else(|| String::from("-"), |v| v.to_string());


### PR DESCRIPTION
⚠️ causes misunderstanding, see #281.
```
config_file         /Users/owner/Library/Application Support/aichat/config.yaml
roles_file          /Users/owner/Library/Application Support/aichat/roles.yaml
messages_file       /Users/owner/Library/Application Support/aichat/messages.md
sessions_dir        /Users/owner/Library/Application Support/aichat/sessions ⚠️
```