### PR TITLE
fix: deprecation warning of .read command

### DIFF
--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -211,7 +211,7 @@ impl Repl {
                         .with_context(|| "Failed to copy the last output")?;
                 }
                 ".read" => {
-                    println!(r#"Deprecated. Use '.read' instead."#);
+                    println!(r#"Deprecated. Use '.file' instead."#);
                 }
                 ".file" => match args {
                     Some(args) => {


### PR DESCRIPTION
Hi @sigoden,

First up, thanks ford providing this handy program! 👍 ❤️ 
I began using the tool today, and while examining the source code, I believe I've identified a minor discrepancy in the deprecation warning for the now-deprecated `.read` command.

best
Nico