### PR TITLE
feat: add `extra_fields` to models of localai/ollama clients

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,6 +38,8 @@ clients:
     models:
       - name: mistral
         max_tokens: 8192
+        extra_fields:                                 # Optional field, set custom parameters
+          key: value
       - name: llava
         max_tokens: 8192
         capabilities: text,vision                     # Optional field, possible values: text, vision

--- a/src/client/localai.rs
+++ b/src/client/localai.rs
@@ -55,18 +55,7 @@ impl LocalAIClient {
         let api_key = self.get_api_key().ok();
 
         let mut body = openai_build_body(data, self.model.name.clone());
-
-        // merge fields from extra_fields into body
-        if let Some(extra_fields) = &self.model.extra_fields {
-            let extra_fields = extra_fields
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect::<serde_json::Map<String, serde_json::Value>>();
-
-            body.as_object_mut()
-                .unwrap()
-                .extend(extra_fields.into_iter());
-        }
+        self.model.merge_extra_fields(&mut body);
 
         let chat_endpoint = self
             .config

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -11,6 +11,7 @@ pub type TokensCountFactors = (usize, usize); // (per-messages, bias)
 pub struct Model {
     pub client_name: String,
     pub name: String,
+    pub extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub max_tokens: Option<usize>,
     pub tokens_count_factors: TokensCountFactors,
     pub capabilities: ModelCapabilities,
@@ -27,6 +28,7 @@ impl Model {
         Self {
             client_name: client_name.into(),
             name: name.into(),
+            extra_fields: None,
             max_tokens: None,
             tokens_count_factors: Default::default(),
             capabilities: ModelCapabilities::Text,
@@ -70,6 +72,11 @@ impl Model {
 
     pub fn set_capabilities(mut self, capabilities: ModelCapabilities) -> Self {
         self.capabilities = capabilities;
+        self
+    }
+
+    pub fn set_extra_fields(mut self, extra_fields: Option<serde_json::Map<String, serde_json::Value>>) -> Self {
+        self.extra_fields = extra_fields;
         self
     }
 
@@ -127,6 +134,7 @@ impl Model {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelConfig {
     pub name: String,
+    pub extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub max_tokens: Option<usize>,
     #[serde(deserialize_with = "deserialize_capabilities")]
     #[serde(default = "default_capabilities")]

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -11,8 +11,8 @@ pub type TokensCountFactors = (usize, usize); // (per-messages, bias)
 pub struct Model {
     pub client_name: String,
     pub name: String,
-    pub extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub max_tokens: Option<usize>,
+    pub extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub tokens_count_factors: TokensCountFactors,
     pub capabilities: ModelCapabilities,
 }
@@ -75,7 +75,10 @@ impl Model {
         self
     }
 
-    pub fn set_extra_fields(mut self, extra_fields: Option<serde_json::Map<String, serde_json::Value>>) -> Self {
+    pub fn set_extra_fields(
+        mut self,
+        extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> Self {
         self.extra_fields = extra_fields;
         self
     }
@@ -129,13 +132,23 @@ impl Model {
         }
         Ok(())
     }
+
+    pub fn merge_extra_fields(&self, body: &mut serde_json::Value) {
+        if let (Some(body), Some(extra_fields)) = (body.as_object_mut(), &self.extra_fields) {
+            for (k, v) in extra_fields {
+                if !body.contains_key(k) {
+                    body.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelConfig {
     pub name: String,
-    pub extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
     pub max_tokens: Option<usize>,
+    pub extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
     #[serde(deserialize_with = "deserialize_capabilities")]
     #[serde(default = "default_capabilities")]
     pub capabilities: ModelCapabilities,

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -69,6 +69,7 @@ impl OllamaClient {
                 Model::new(client_name, &v.name)
                     .set_capabilities(v.capabilities)
                     .set_max_tokens(v.max_tokens)
+                    .set_extra_fields(v.extra_fields.clone())
                     .set_tokens_count_factors(TOKENS_COUNT_FACTORS)
             })
             .collect()
@@ -77,7 +78,9 @@ impl OllamaClient {
     fn request_builder(&self, client: &ReqwestClient, data: SendData) -> Result<RequestBuilder> {
         let api_key = self.get_api_key().ok();
 
-        let body = build_body(data, self.model.name.clone())?;
+        let mut body = build_body(data, self.model.name.clone())?;
+
+        self.model.merge_extra_fields(&mut body);
 
         let chat_endpoint = self.config.chat_endpoint.as_deref().unwrap_or("/api/chat");
 


### PR DESCRIPTION
Because there are so many local AIs out there with a bunch of custom parameters you can set, this allows users to send in extra parameters to a local LLM runner, such as, e.g. `instruction_template: Alpaca`, so that Mixtral can take a system prompt.

Pretty novice Rustacean, so feel free to nitpick!