### PR TITLE
fix: do not attempt to deserialize zero byte chunks in ollama stream

### DIFF
--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -121,6 +121,9 @@ async fn send_message_streaming(builder: RequestBuilder, handler: &mut ReplyHand
         let mut stream = res.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk?;
+            if chunk.is_empty() {
+              continue;
+            }
             let data: Value = serde_json::from_slice(&chunk)?;
             if data["done"].is_boolean() {
                 if let Some(text) = data["message"]["content"].as_str() {


### PR DESCRIPTION
I put an Nginx reverse proxy in front of Ollama and it returns a zero byte chunk at the end of the stream (I don't know why). This defensive measure avoids the issue by ignoring zero byte chunks.