### PR TITLE
refactor: change header of messages saved to markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "syntect",
  "textwrap",
  "tokio",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ shell-words = "1.1.0"
 mime_guess = "2.0.4"
 sha2 = "0.10.8"
 bitflags = "2.4.1"
+unicode-width = "0.1.11"
 
 [dependencies.reqwest]
 version = "0.11.14"

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -12,6 +12,7 @@ use std::{
     io::Read,
     path::{Path, PathBuf},
 };
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 const IMAGE_EXTS: [&str; 5] = ["png", "jpeg", "jpg", "webp", "gif"];
 
@@ -76,6 +77,25 @@ impl Input {
 
     pub fn data_urls(&self) -> HashMap<String, String> {
         self.data_urls.clone()
+    }
+
+    pub fn summary(&self) -> String {
+        let text = &self.text;
+        if text.width_cjk() > 70 {
+            let mut sum_width = 0;
+            let mut chars = vec![];
+            for c in text.chars() {
+                sum_width += c.width_cjk().unwrap_or(1);
+                if sum_width > 67 {
+                    chars.extend(['.', '.', '.']);
+                    break;
+                }
+                chars.push(c);
+            }
+            chars.into_iter().collect()
+        } else {
+            text.clone()
+        }
     }
 
     pub fn render(&self) -> String {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -230,14 +230,15 @@ impl Config {
             return Ok(());
         }
         let timestamp = now();
+        let summary = input.summary();
         let input_markdown = input.render();
         let output = match self.role.as_ref() {
             None => {
-                format!("# CHAT:[{timestamp}]\n{input_markdown}\n--------\n{output}\n--------\n\n",)
+                format!("# CHAT: {summary} [{timestamp}]\n{input_markdown}\n--------\n{output}\n--------\n\n",)
             }
             Some(v) => {
                 format!(
-                    "# CHAT:[{timestamp}] ({})\n{input_markdown}\n--------\n{output}\n--------\n\n",
+                    "# CHAT: {summary} [{timestamp}] ({})\n{input_markdown}\n--------\n{output}\n--------\n\n",
                     v.name,
                 )
             }


### PR DESCRIPTION
The header contains the summary of the question now.

close #316 