### PR TITLE
feat: add shell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,22 @@ We can also pipe the output of aichat which will disable interactive mode.
 aichat -e find all json files in current folder | pbcopy
 ```
 
+### Shell integration
+
+This is a **very handy feature**, which allows you to use `aichat` shell completions directly in your terminal, without the need to type `aichat` with prompt and arguments. Shell integration enables the use of ShellGPT with hotkeys in your terminal, supported by both Bash and ZSH shells. This feature puts `aichat` completions directly into terminal buffer (input line), allowing for immediate editing of suggested commands.
+
+![aichat-integration](https://github.com/sigoden/aichat/assets/4012553/9a9b17ea-977a-4bd8-8182-a0a96627573c)
+
+To install shell integration, run the following code:
+
+```sh
+sh_ext=bash # possible values: bash, fish, zsh, ps1
+curl -o aichat-integration.$sh_ext https://raw.githubusercontent.com/sigoden/aichat/main/scripts/integration.$sh_ext
+. aichat-integration.$sh_ext
+```
+
+After that restart your shell. You can invoke the completion with `alt+e` hotkey.
+
 ## License
 
 Copyright (c) 2023-2024 aichat-developers.

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ aichat -e find all json files in current folder | pbcopy
 
 ### Shell integration
 
-This is a **very handy feature**, which allows you to use `aichat` shell completions directly in your terminal, without the need to type `aichat` with prompt and arguments. Shell integration enables the use of ShellGPT with hotkeys in your terminal, supported by both Bash and ZSH shells. This feature puts `aichat` completions directly into terminal buffer (input line), allowing for immediate editing of suggested commands.
+This is a **very handy feature**, which allows you to use `aichat` shell completions directly in your terminal, without the need to type `aichat` with prompt and arguments. This feature puts `aichat` completions directly into terminal buffer (input line), allowing for immediate editing of suggested commands.
 
 ![aichat-integration](https://github.com/sigoden/aichat/assets/4012553/9a9b17ea-977a-4bd8-8182-a0a96627573c)
 

--- a/scripts/integration.bash
+++ b/scripts/integration.bash
@@ -1,0 +1,7 @@
+_aichat_bash() {
+    if [[ -n "$READLINE_LINE" ]]; then
+        READLINE_LINE=$(aichat -e "$READLINE_LINE")
+        READLINE_POINT=${#READLINE_LINE}
+    fi
+}
+bind -x '"\ee": _aichat_bash'

--- a/scripts/integration.fish
+++ b/scripts/integration.fish
@@ -1,0 +1,9 @@
+function _aichat_fish
+    set -l _old (commandline)
+    if test -n $_old
+        echo -n "⌛"
+        commandline -f repaint
+        commandline (aichat -e $_old)
+    end
+end
+bind \ee _aichat_fish

--- a/scripts/integration.ps1
+++ b/scripts/integration.ps1
@@ -1,0 +1,10 @@
+Set-PSReadLineKeyHandler -Chord "alt+e" -ScriptBlock {
+    $_old = $null
+    [Microsoft.PowerShell.PSConsoleReadline]::GetBufferState([ref]$_old, [ref]$null)
+    if ($_old) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::Insert('⌛')
+        $_new = (aichat -e $_old)
+        [Microsoft.PowerShell.PSConsoleReadLine]::DeleteLine()
+        [Microsoft.PowerShell.PSConsoleReadline]::Insert($_new)
+    }
+}

--- a/scripts/integration.zsh
+++ b/scripts/integration.zsh
@@ -1,0 +1,11 @@
+_aichat_zsh() {
+    if [[ -n "$BUFFER" ]]; then
+        local _old=$BUFFER
+        BUFFER+="⌛"
+        zle -I && zle redisplay
+        BUFFER=$(aichat -e "$_old")
+        zle end-of-line
+    fi
+}
+zle -N _aichat_zsh
+bindkey '\ee' _aichat_zsh


### PR DESCRIPTION
This is a **very handy feature**, which allows you to use `aichat` shell completions directly in your terminal, without the need to type `aichat` with prompt and arguments. This feature puts `aichat` completions directly into terminal buffer (input line), allowing for immediate editing of suggested commands.

![aichat-integration](https://github.com/sigoden/aichat/assets/4012553/9a9b17ea-977a-4bd8-8182-a0a96627573c)

To install shell integration, run the following code:

```sh
sh_ext=bash # possible values: bash, fish, zsh, ps1
curl -o aichat-integration.$sh_ext https://raw.githubusercontent.com/sigoden/aichat/main/scripts/integration.$sh_ext
. aichat-integration.$sh_ext