### PR TITLE
feat: compress session automaticlly

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ wrap_code: false                 # Whether wrap code block
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. values: emacs, vi
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
+compress_threshold: 0            # compress session if tokens exceed this value (>=1000)
 
 clients:
   - type: openai

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ wrap_code: false                 # Whether wrap code block
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. values: emacs, vi
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
-compress_threshold: 0            # Compress session if tokens exceed this value (>=1000)
+compress_threshold: 1000         # Compress session if tokens exceed this value (valid when >=1000)
 
 clients:
   - type: openai

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ wrap_code: false                 # Whether wrap code block
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. values: emacs, vi
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
-compress_threshold: 0            # compress session if tokens exceed this value (>=1000)
+compress_threshold: 0            # Compress session if tokens exceed this value (>=1000)
 
 clients:
   - type: openai

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Usage: .file <file>... [-- text...]
 > .set highlight false
 > .set save false
 > .set auto_copy true
+> .set compress_threshold 1000
 ```
 
 ## Command

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,11 @@ auto_copy: false                 # Automatically copy the last output to the cli
 keybindings: emacs               # REPL keybindings. (emacs, vi)
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
 
+# Compress session messages if tokens exceed this value (>=1000)
+compress_threshold: 0
+# The prompt for compress session messages
+compress_prompt: 'Summarize the discussion briefly in 200 words or less to use as a prompt for future context.'
+
 # Custom REPL prompt, see https://github.com/sigoden/aichat/wiki/Custom-REPL-Prompt
 left_prompt: '{color.green}{?session {session}{?role /}}{role}{color.cyan}{?session )}{!session >}{color.reset} '
 right_prompt: '{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{color.reset}'

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,8 +9,8 @@ auto_copy: false                 # Automatically copy the last output to the cli
 keybindings: emacs               # REPL keybindings. (emacs, vi)
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
 
-# Compress session if tokens exceed this value (>=1000)
-compress_threshold: 0
+# Compress session if tokens exceed this value (valid when >=1000)
+compress_threshold: 1000
 # The prompt for summarizing session messages
 summarize_prompt: 'Summarize the discussion briefly in 200 words or less to use as a prompt for future context.'
 # The prompt for the summary of the session

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,8 +11,10 @@ prelude: ''                      # Set a default role or session (role:<name>, s
 
 # Compress session messages if tokens exceed this value (>=1000)
 compress_threshold: 0
-# The prompt for compress session messages
-compress_prompt: 'Summarize the discussion briefly in 200 words or less to use as a prompt for future context.'
+# The prompt for summarizing session messages
+summarize_prompt: 'Summarize the discussion briefly in 200 words or less to use as a prompt for future context.'
+# The prompt for the summary of the session
+summary_prompt: 'This is a summary of the chat history as a recap: '
 
 # Custom REPL prompt, see https://github.com/sigoden/aichat/wiki/Custom-REPL-Prompt
 left_prompt: '{color.green}{?session {session}{?role /}}{role}{color.cyan}{?session )}{!session >}{color.reset} '

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,7 +9,7 @@ auto_copy: false                 # Automatically copy the last output to the cli
 keybindings: emacs               # REPL keybindings. (emacs, vi)
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
 
-# Compress session messages if tokens exceed this value (>=1000)
+# Compress session if tokens exceed this value (>=1000)
 compress_threshold: 0
 # The prompt for summarizing session messages
 summarize_prompt: 'Summarize the discussion briefly in 200 words or less to use as a prompt for future context.'

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -17,7 +17,7 @@ impl Message {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MessageRole {
     System,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -110,7 +110,7 @@ impl Default for Config {
             auto_copy: false,
             keybindings: Default::default(),
             prelude: String::new(),
-            compress_threshold: 1000,
+            compress_threshold: 2000,
             summarize_prompt: "Summarize the discussion briefly in 200 words or less to use as a prompt for future context.".to_string(),
             summary_prompt: "This is a summary of the chat history as a recap: ".into(),
             left_prompt: "{color.green}{?session {session}{?role /}}{role}{color.cyan}{?session )}{!session >}{color.reset} ".to_string(),
@@ -593,18 +593,12 @@ impl Config {
                     TEMP_SESSION_NAME,
                     self.model.clone(),
                     self.role.clone(),
-                    self.compress_threshold,
                 ));
             }
             Some(name) => {
                 let session_path = Self::session_file(name)?;
                 if !session_path.exists() {
-                    self.session = Some(Session::new(
-                        name,
-                        self.model.clone(),
-                        self.role.clone(),
-                        self.compress_threshold,
-                    ));
+                    self.session = Some(Session::new(name, self.model.clone(), self.role.clone()));
                 } else {
                     let session = Session::load(name, &session_path)?;
                     let model = session.model().to_string();
@@ -689,7 +683,7 @@ impl Config {
 
     pub fn should_compress_session(&mut self) -> bool {
         if let Some(sesion) = self.session.as_mut() {
-            if sesion.need_compress() {
+            if sesion.need_compress(self.compress_threshold) {
                 sesion.compressing = true;
                 return true;
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -500,6 +500,7 @@ impl Config {
                     "highlight ",
                     "dry_run ",
                     "auto_copy ",
+                    "compress_threshold",
                 ]
                 .into_iter()
                 .map(|v| v.to_string())
@@ -559,6 +560,10 @@ impl Config {
             "auto_copy" => {
                 let value = value.parse().with_context(|| "Invalid value")?;
                 self.auto_copy = value;
+            }
+            "compress_threshold" => {
+                let value = value.parse().with_context(|| "Invalid value")?;
+                self.compress_threshold = value;
             }
             _ => bail!("Unknown key `{key}`"),
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -110,7 +110,7 @@ impl Default for Config {
             auto_copy: false,
             keybindings: Default::default(),
             prelude: String::new(),
-            compress_threshold: 0,
+            compress_threshold: 1000,
             summarize_prompt: "Summarize the discussion briefly in 200 words or less to use as a prompt for future context.".to_string(),
             summary_prompt: "This is a summary of the chat history as a recap: ".into(),
             left_prompt: "{color.green}{?session {session}{?role /}}{role}{color.cyan}{?session )}{!session >}{color.reset} ".to_string(),

--- a/src/config/role.rs
+++ b/src/config/role.rs
@@ -72,7 +72,7 @@ For example if the prompt is "Hello world Python", you should return "print('Hel
         }
     }
 
-    pub fn info(&self) -> Result<String> {
+    pub fn export(&self) -> Result<String> {
         let output = serde_yaml::to_string(&self)
             .with_context(|| format!("Unable to show info about role {}", &self.name))?;
         Ok(output.trim_end().to_string())

--- a/src/config/role.rs
+++ b/src/config/role.rs
@@ -24,7 +24,6 @@ impl Role {
     pub const EXECUTE: &'static str = "__execute__";
     pub const DESCRIBE_COMMAND: &'static str = "__describe_command__";
     pub const CODE: &'static str = "__code__";
-    pub const HISTORY: &'static str = "__history__";
 
     pub fn for_execute() -> Self {
         let os = detect_os();
@@ -69,14 +68,6 @@ If there is a lack of details, provide most logical solution.
 You are not allowed to ask for more details.
 For example if the prompt is "Hello world Python", you should return "print('Hello world')"."#
                 .into(),
-            temperature: None,
-        }
-    }
-
-    pub fn for_history() -> Self {
-        Self {
-            name: Self::HISTORY.into(),
-            prompt: r#"This is a summary of the chat history as a recap: "#.into(),
             temperature: None,
         }
     }

--- a/src/config/role.rs
+++ b/src/config/role.rs
@@ -24,6 +24,7 @@ impl Role {
     pub const EXECUTE: &'static str = "__execute__";
     pub const DESCRIBE_COMMAND: &'static str = "__describe_command__";
     pub const CODE: &'static str = "__code__";
+    pub const HISTORY: &'static str = "__history__";
 
     pub fn for_execute() -> Self {
         let os = detect_os();
@@ -68,6 +69,14 @@ If there is a lack of details, provide most logical solution.
 You are not allowed to ask for more details.
 For example if the prompt is "Hello world Python", you should return "print('Hello world')"."#
                 .into(),
+            temperature: None,
+        }
+    }
+
+    pub fn for_history() -> Self {
+        Self {
+            name: Self::HISTORY.into(),
+            prompt: r#"This is a summary of the chat history as a recap: "#.into(),
             temperature: None,
         }
     }

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -271,10 +271,8 @@ impl Session {
     }
 
     pub fn clear_messages(&mut self) {
-        if self.messages.is_empty() {
-            return;
-        }
         self.messages.clear();
+        self.compressed_messages.clear();
         self.data_urls.clear();
         self.dirty = true;
     }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -268,6 +268,11 @@ impl Repl {
         ensure_model_capabilities(client.as_mut(), input.required_capabilities())?;
         let output = render_stream(&input, client.as_ref(), &self.config, self.abort.clone())?;
         self.config.write().save_message(input, &output)?;
+        if self.config.read().should_compress_session() {
+            let input = Input::from_str(&self.config.read().compress_prompt);
+            let summary = client.send_message(input)?;
+            self.config.write().compress_session(&summary)?;
+        }
         self.config.read().maybe_copy(&output);
         Ok(())
     }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -258,6 +258,9 @@ impl Repl {
         if text.is_empty() && files.is_empty() {
             return Ok(());
         }
+        while self.config.read().is_compressing_session() {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
         let input = if files.is_empty() {
             Input::from_str(text)
         } else {
@@ -268,12 +271,15 @@ impl Repl {
         ensure_model_capabilities(client.as_mut(), input.required_capabilities())?;
         let output = render_stream(&input, client.as_ref(), &self.config, self.abort.clone())?;
         self.config.write().save_message(input, &output)?;
-        if self.config.read().should_compress_session() {
-            let input = Input::from_str(&self.config.read().compress_prompt);
-            let summary = client.send_message(input)?;
-            self.config.write().compress_session(&summary)?;
-        }
         self.config.read().maybe_copy(&output);
+        if self.config.write().should_compress_session() {
+            let config = self.config.clone();
+            std::thread::spawn(move || -> anyhow::Result<()> {
+                let _ = compress_session(&config);
+                config.write().end_compressing_session();
+                Ok(())
+            });
+        }
         Ok(())
     }
 
@@ -421,6 +427,15 @@ fn parse_command(line: &str) -> Option<(&str, Option<&str>)> {
         }
         _ => None,
     }
+}
+
+fn compress_session(config: &GlobalConfig) -> Result<()> {
+    let input = Input::from_str(&config.read().summarize_prompt);
+    let mut client = init_client(config)?;
+    ensure_model_capabilities(client.as_mut(), input.required_capabilities())?;
+    let summary = client.send_message(input)?;
+    config.write().compress_session(&summary);
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There are three configuration items that control automatic session compression
```yaml
# Compress session messages if tokens exceed this value (valid only >=1000)
compress_threshold: 2000
# The prompt for summarizing session messages
summarize_prompt: 'Summarize the discussion briefly in 200 words or less to use as a prompt for future context.'
# The prompt for the summary of the session
summary_prompt: 'This is a summary of the chat history as a recap: '
```

When the total number of tokens in the session messages exceeds `compress_threshold`, aichat will automatically compress the session. 

Aichat will send a `summarize_prompt` with session messages to LLM to summarize the conversation, and then use the summary text prefixed with `summary_prompt`  and the last two messages as context for the next chat.

close #329  #280

This is a very opinion feature, welcome to test and give feedback.

