### PR TITLE
fix: misspelled mistral model name

### DIFF
--- a/src/client/mistral.rs
+++ b/src/client/mistral.rs
@@ -14,7 +14,7 @@ const MODELS: [(&str, usize, &str); 5] = [
     // https://docs.mistral.ai/platform/endpoints/
     ("mistral-small-latest", 32000, "text"),
     ("mistral-medium-latest", 32000, "text"),
-    ("mistral-larget-latest", 32000, "text"),
+    ("mistral-large-latest", 32000, "text"),
     ("open-mistral-7b", 32000, "text"),
     ("open-mixtral-8x7b", 32000, "text"),
 ];


### PR DESCRIPTION
Hi
This contains a very minor fix for mistral model name mistral-larget-latest > mistral-large-latest