### PR TITLE
feat: Improve session handling

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,6 +8,7 @@ wrap_code: false                 # Whether wrap code block
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. (emacs, vi)
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)
+save_session: false              # Whether to save the session automatically
 
 # Compress session if tokens exceed this value (valid when >=1000)
 compress_threshold: 1000

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,13 +12,16 @@ pub struct Cli {
     /// Create or reuse a session
     #[clap(short = 's', long)]
     pub session: Option<Option<String>>,
+    /// Whether to save the session automatically
+    #[clap(long)]
+    pub save_session: bool,
     /// Execute commands using natural language
     #[clap(short = 'e', long)]
     pub execute: bool,
     /// Generate only code
     #[clap(short = 'c', long)]
     pub code: bool,
-    /// Attach files to the message to be sent.
+    /// Attach files to the message to be sent
     #[clap(short = 'f', long, num_args = 1.., value_name = "FILE")]
     pub file: Option<Vec<String>>,
     /// Disable syntax highlighting

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -630,7 +630,6 @@ impl Config {
             self.last_message = None;
             self.temperature = self.default_temperature;
             if session.dirty {
-                let mut name = session.name().to_string();
                 // If it's a temporary session, we'll always prompt to save on exit
                 // If it's named, we'll save automatically if they've set the save flag and prompt if they haven't
                 if !self.save || session.is_temp() {
@@ -642,11 +641,11 @@ impl Config {
                     if !ans {
                         return Ok(());
                     }
-                    if session.is_temp() {
-                        name = Text::new("Session name:").with_default(&name).prompt()?;
+                    while session.is_temp() || session.name().is_empty(){
+                        session.name = Text::new("Session name:").prompt()?;
                     }
                 }
-                let session_path = Self::session_file(&name)?;
+                let session_path = Self::session_file(&session.name())?;
                 let sessions_dir = session_path.parent().ok_or_else(|| {
                     anyhow!("Unable to save session file to {}", session_path.display())
                 })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,9 +111,6 @@ fn start_directive(
     no_stream: bool,
     code_mode: bool,
 ) -> Result<()> {
-    if let Some(session) = &config.read().session {
-        session.guard_save()?;
-    }
     let input = Input::new(
         text,
         include.unwrap_or_default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,9 @@ fn start_directive(
         let abort = create_abort_signal();
         render_stream(&input, client.as_ref(), config, abort)?
     };
+    // Save the message/session
     config.write().save_message(input, &output)?;
+    config.write().end_session(false)?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,9 @@ fn main() -> Result<()> {
     if let Some(wrap) = &cli.wrap {
         config.write().set_wrap(wrap)?;
     }
+    if cli.save_session {
+        config.write().save_session = true;
+    }
     if cli.light_theme {
         config.write().light_theme = true;
     }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -216,8 +216,6 @@ impl Repl {
                     }
                     Some(_) => unknown_command()?,
                     None => {
-                        // Sessions may need to save before exit
-                        self.config.write().end_session(true)?;
                         return Ok(true);
                     }
                 },

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -212,12 +212,12 @@ impl Repl {
                         self.config.write().clear_role()?;
                     }
                     Some("session") => {
-                        self.config.write().end_session()?;
+                        self.config.write().end_session(true)?;
                     }
                     Some(_) => unknown_command()?,
                     None => {
                         // Sessions may need to save before exit
-                        self.config.write().end_session()?;
+                        self.config.write().end_session(true)?;
                         return Ok(true);
                     }
                 },

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -216,6 +216,8 @@ impl Repl {
                     }
                     Some(_) => unknown_command()?,
                     None => {
+                        // Sessions may need to save before exit
+                        self.config.write().end_session()?;
                         return Ok(true);
                     }
                 },


### PR DESCRIPTION
This PR makes several changes to session handling. They're split into separate commits, and I'd be happy to split this up or make changes.

With this change, session management becomes a little simpler:

- Sessions will save when you trigger `.exit`, instead of only with `.exit session`.
- Sessions can be created, and saved, from a non-interactive request if `save: true` is set in the config.
- Sessions will never prompt to save on non-interactive requests.
- Sessions will only prompt to save if it's a temp session, or if `save: false` is set in the config
- It's now not possible to save a session with the `temp` name

There are a few further things I did _not_ change that might make sense. I'd be willing to make those adjustments here or in a follow up PR
- Using a separate `save-session` flag in the config file
- Save session messages after every message in the interactive chat, so that killing the aichat process will still result in saved messages.