### PR TITLE
refactor: improve creating config for openai-compatible client

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -46,7 +46,8 @@ clients:
     api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
   # Any openai-compatible API providers 
-  - type: openai-compatible                           # Renamed from localai
+  - type: openai-compatible
+    name: localai
     api_base: http://localhost:8080/v1
     api_key: sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     chat_endpoint: /chat/completions                  # Optional field

--- a/src/client/openai_compatible.rs
+++ b/src/client/openai_compatible.rs
@@ -23,7 +23,8 @@ openai_compatible_client!(OpenAICompatibleClient);
 impl OpenAICompatibleClient {
     config_get_fn!(api_key, get_api_key);
 
-    pub const PROMPTS: [PromptType<'static>; 4] = [
+    pub const PROMPTS: [PromptType<'static>; 5] = [
+        ("name", "Platform Name:", true, PromptKind::String),
         ("api_base", "API Base:", true, PromptKind::String),
         ("api_key", "API Key:", false, PromptKind::String),
         ("models[].name", "Model Name:", true, PromptKind::String),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1046,8 +1046,9 @@ fn create_config_file(config_path: &Path) -> Result<()> {
     let client = Select::new("Platform:", list_client_types()).prompt()?;
 
     let mut config = serde_json::json!({});
-    config["model"] = client.into();
-    config[CLIENTS_FIELD] = create_client_config(client)?;
+    let (model, clients_config) = create_client_config(client)?;
+    config["model"] = model.into();
+    config[CLIENTS_FIELD] = clients_config;
 
     let config_data = serde_yaml::to_string(&config).with_context(|| "Failed to create config")?;
 


### PR DESCRIPTION
Allow creating config for openai-compatible client that accepts a `name` argument.

```
> Platform: openai-compatible
> Platform Name: localai
> API Base: http://localhost:8080/v1
> API Key: 
> Model Name: llama2
> Max Input Tokens: 8192
✨ Saved config file to /tmp/aichat/config.yaml
```