### PR TITLE
fix: not dirty session when updating properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ model               openai:gpt-3.5-turbo
 temperature         -
 dry_run             false
 save                true
+save_session        true
 highlight           true
 light_theme         false
 wrap                no

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -361,10 +361,11 @@ impl Config {
         }
     }
 
-    pub fn set_compress_threshold(&mut self, value: usize) {
-        self.compress_threshold = value;
+    pub fn set_compress_threshold(&mut self, value: Option<usize>) {
         if let Some(session) = self.session.as_mut() {
             session.set_compress_threshold(value);
+        } else {
+            self.compress_threshold = value.unwrap_or_default();
         }
     }
 
@@ -561,7 +562,12 @@ impl Config {
                 self.set_temperature(value);
             }
             "compress_threshold" => {
-                let value = value.parse().with_context(|| "Invalid value")?;
+                let value = if unset {
+                    None
+                } else {
+                    let value = value.parse().with_context(|| "Invalid value")?;
+                    Some(value)
+                };
                 self.set_compress_threshold(value);
             }
             "save" => {

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -195,20 +195,33 @@ impl Session {
     }
 
     pub fn set_temperature(&mut self, value: Option<f64>) {
-        self.temperature = value;
+        if self.temperature != value {
+            self.temperature = value;
+            self.dirty = true;
+        }
     }
 
     pub fn set_save_session(&mut self, value: bool) {
-        self.save_session = value;
+        if self.save_session != value {
+            self.save_session = value;
+            self.dirty = true;
+        }
     }
 
-    pub fn set_compress_threshold(&mut self, value: usize) {
-        self.compress_threshold = Some(value);
+    pub fn set_compress_threshold(&mut self, value: Option<usize>) {
+        if self.compress_threshold != value {
+            self.compress_threshold = value;
+            self.dirty = true;
+        }
     }
 
     pub fn set_model(&mut self, model: Model) -> Result<()> {
-        self.model_id = model.id();
-        self.model = model;
+        let model_id = model.id();
+        if self.model_id != model_id {
+            self.model_id = model_id;
+            self.model = model;
+            self.dirty = true;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
After running following repl commands, the session should be marked as drity.
```
.model openai
.set temperature 0.8
.set compress_threshold 1200
.set save_session true
```