### PR TITLE
feat: add `ctrlc_exit` option to control REPL exit by ctrl+c

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,7 @@ highlight: true                  # Set false to turn highlight
 light_theme: false               # Whether to use a light theme
 wrap: no                         # Specify the text-wrapping mode (no, auto, <max-width>)
 wrap_code: false                 # Whether wrap code block
+ctrlc_exit: true                 # Whether to exit REPL by pressing Ctrl+C twice
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. (emacs, vi)
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,6 +62,8 @@ pub struct Config {
     pub wrap: Option<String>,
     /// Whether wrap code block
     pub wrap_code: bool,
+    /// Whether to exit REPL by pressing Ctrl+C twice
+    pub ctrlc_exit: bool,
     /// Automatically copy the last output to the clipboard
     pub auto_copy: bool,
     /// REPL keybindings. (emacs, vi)
@@ -109,6 +111,7 @@ impl Default for Config {
             light_theme: false,
             wrap: None,
             wrap_code: false,
+            ctrlc_exit: true,
             auto_copy: false,
             keybindings: Default::default(),
             prelude: String::new(),

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -103,6 +103,7 @@ impl Repl {
         self.banner();
 
         let mut already_ctrlc = false;
+        let ctrlc_exit = self.config.read().ctrlc_exit;
 
         loop {
             if self.abort.aborted_ctrld() {
@@ -117,8 +118,8 @@ impl Repl {
                     already_ctrlc = false;
                     self.abort.reset();
                     match self.handle(&line) {
-                        Ok(quit) => {
-                            if quit {
+                        Ok(exit) => {
+                            if exit {
                                 break;
                             }
                         }
@@ -130,7 +131,7 @@ impl Repl {
                 }
                 Ok(Signal::CtrlC) => {
                     self.abort.set_ctrlc();
-                    if already_ctrlc {
+                    if already_ctrlc && ctrlc_exit {
                         break;
                     }
                     already_ctrlc = true;


### PR DESCRIPTION
close #385