### PR TITLE
feat: generate completion scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,8 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "clap_complete",
+ "clap_complete_nushell",
  "crossbeam",
  "crossterm 0.27.0",
  "dirs",
@@ -350,6 +352,25 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0e48e026ce7df2040239117d25e4e79714907420c70294a5ce4b6bbe6a7b6"
+dependencies = [
+ "clap",
+ "clap_complete",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ mime_guess = "2.0.4"
 sha2 = "0.10.8"
 bitflags = "2.4.1"
 unicode-width = "0.1.11"
+clap_complete = "4.5.1"
+clap_complete_nushell = "4.5.1"
 
 [dependencies.reqwest]
 version = "0.12.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
-use clap::Parser;
+use clap::{CommandFactory, Parser, ValueEnum};
+use clap_complete::{generate, shells};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -36,6 +37,9 @@ pub struct Cli {
     /// Use light theme
     #[clap(long)]
     pub light_theme: bool,
+    /// Generate completion script
+    #[arg(long = "completions", value_name = "SHELL", value_enum)]
+    pub completions: Option<Shell>,
     /// Run in dry run mode
     #[clap(long)]
     pub dry_run: bool,
@@ -69,4 +73,31 @@ impl Cli {
         }
         Some(text)
     }
+    pub fn generate_completion_script(shell: Shell) -> Vec<u8> {
+        let mut output: Vec<u8> = vec![];
+        let mut command = Cli::command();
+        let bin_name = env!("CARGO_PKG_NAME");
+        match shell {
+            Shell::Bash => generate(shells::Bash, &mut command, bin_name, &mut output),
+            Shell::Zsh => generate(shells::Zsh, &mut command, bin_name, &mut output),
+            Shell::Fish => generate(shells::Fish, &mut command, bin_name, &mut output),
+            Shell::Powershell => generate(shells::PowerShell, &mut command, bin_name, &mut output),
+            Shell::Nushell => generate(
+                clap_complete_nushell::Nushell,
+                &mut command,
+                bin_name,
+                &mut output,
+            ),
+        };
+        output
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+    Powershell,
+    Nushell,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,12 @@ use utils::{cl100k_base_singleton, create_abort_signal};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    if let Some(shell) = cli.completions {
+        let script = Cli::generate_completion_script(shell);
+        let script = std::str::from_utf8(&script)?;
+        println!("{script}");
+        return Ok(());
+    }
     let text = cli.text();
     let config = Arc::new(RwLock::new(Config::init(text.is_none())?));
     if cli.list_roles {


### PR DESCRIPTION
use `--completions <SHELL>` to generate completion script for the SHELL.
```
--completions <SHELL>  Generate completion script [possible values: bash, zsh, fish, powershell, nushell
```
```
aichat --completions bash
```

clap_complete don't support arg dynamic completion (clap-rs/clap#5449), so `--model`,  `--role` and `--session` have no completion candidate.

fix #392 
