### PR TITLE
refactor: `ctrlc_exit` config default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ aichat -s session1 --info                       # Session info
 
 cat data.toml | aichat -c to json > data.json   # Pipe stdio/stdout
 
-aichat -f a.png -f b.png diff images            # Attach files
+aicaht -f data.toml -c to json > data.json      # Attach files
+
+aichat -f a.png -f b.png diff images            # Attach images
 ```
 
 ### Shell commands

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ highlight: true                  # Set false to turn highlight
 light_theme: false               # Whether to use a light theme
 wrap: no                         # Specify the text-wrapping mode (no, auto, <max-width>)
 wrap_code: false                 # Whether wrap code block
+ctrlc_exit: false                # Whether to exit REPL when Ctrl+C is pressed
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. values: emacs, vi
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,7 +6,7 @@ highlight: true                  # Set false to turn highlight
 light_theme: false               # Whether to use a light theme
 wrap: no                         # Specify the text-wrapping mode (no, auto, <max-width>)
 wrap_code: false                 # Whether wrap code block
-ctrlc_exit: true                 # Whether to exit REPL by pressing Ctrl+C twice
+ctrlc_exit: false                # Whether to exit REPL when Ctrl+C is pressed
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. (emacs, vi)
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,7 +62,7 @@ pub struct Config {
     pub wrap: Option<String>,
     /// Whether wrap code block
     pub wrap_code: bool,
-    /// Whether to exit REPL by pressing Ctrl+C twice
+    /// Whether to exit REPL when Ctrl+C is pressed
     pub ctrlc_exit: bool,
     /// Automatically copy the last output to the clipboard
     pub auto_copy: bool,
@@ -111,7 +111,7 @@ impl Default for Config {
             light_theme: false,
             wrap: None,
             wrap_code: false,
-            ctrlc_exit: true,
+            ctrlc_exit: false,
             auto_copy: false,
             keybindings: Default::default(),
             prelude: String::new(),


### PR DESCRIPTION
`ctrl_exit` defaulting to false is more appropriate,  related to #391