### PR TITLE
feat: ctrlc won't exit repl and remove `ctrlc_exit` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ highlight: true                  # Set false to turn highlight
 light_theme: false               # Whether to use a light theme
 wrap: no                         # Specify the text-wrapping mode (no, auto, <max-width>)
 wrap_code: false                 # Whether wrap code block
-ctrlc_exit: false                # Whether to exit REPL when Ctrl+C is pressed
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. values: emacs, vi
 prelude: ''                      # Set a default role or session (role:<name>, session:<name>)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,7 +6,6 @@ highlight: true                  # Set false to turn highlight
 light_theme: false               # Whether to use a light theme
 wrap: no                         # Specify the text-wrapping mode (no, auto, <max-width>)
 wrap_code: false                 # Whether wrap code block
-ctrlc_exit: false                # Whether to exit REPL when Ctrl+C is pressed
 auto_copy: false                 # Automatically copy the last output to the clipboard
 keybindings: emacs               # REPL keybindings. (emacs, vi)
 prelude: null                    # Set a default role or session (role:<name>, session:<name>)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -63,8 +63,6 @@ pub struct Config {
     pub wrap: Option<String>,
     /// Whether wrap code block
     pub wrap_code: bool,
-    /// Whether to exit REPL when Ctrl+C is pressed
-    pub ctrlc_exit: bool,
     /// Automatically copy the last output to the clipboard
     pub auto_copy: bool,
     /// REPL keybindings. (emacs, vi)
@@ -114,7 +112,6 @@ impl Default for Config {
             light_theme: false,
             wrap: None,
             wrap_code: false,
-            ctrlc_exit: false,
             auto_copy: false,
             keybindings: Default::default(),
             prelude: None,

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -102,20 +102,13 @@ impl Repl {
     pub fn run(&mut self) -> Result<()> {
         self.banner();
 
-        let mut already_ctrlc = false;
-        let ctrlc_exit = self.config.read().ctrlc_exit;
-
         loop {
             if self.abort.aborted_ctrld() {
                 break;
             }
-            if self.abort.aborted_ctrlc() && !already_ctrlc {
-                already_ctrlc = true;
-            }
             let sig = self.editor.read_line(&self.prompt);
             match sig {
                 Ok(Signal::Success(line)) => {
-                    already_ctrlc = false;
                     self.abort.reset();
                     match self.handle(&line) {
                         Ok(exit) => {
@@ -131,15 +124,7 @@ impl Repl {
                 }
                 Ok(Signal::CtrlC) => {
                     self.abort.set_ctrlc();
-                    if ctrlc_exit {
-                        if already_ctrlc {
-                            break;
-                        }
-                        already_ctrlc = true;
-                        println!("(To exit, press Ctrl+C again or Ctrl+D or type .exit)\n");
-                    } else {
-                        println!("(To exit, press Ctrl+D or type .exit)\n");
-                    }
+                    println!("(To exit, press Ctrl+D or type .exit)\n");
                 }
                 Ok(Signal::CtrlD) => {
                     self.abort.set_ctrld();
@@ -425,8 +410,8 @@ fn dump_repl_help() {
         r###"{head}
 
 Type ::: to begin multi-line editing, type ::: to end it.
-Press Ctrl+O to open an buffer editor to modify the current prompt.
-Press Ctrl+C to abort aichat, Ctrl+D to exit the REPL"###,
+Press Ctrl+O to open an editor to edit line input.
+Press Ctrl+C to cancel reply, Ctrl+D to exit REPL"###,
     );
 }
 


### PR DESCRIPTION
One keybinding should do one thing. We already have `ctrl+d` to exit the REPL, so use `ctrl+c` only to cancel the reply.