### PR TITLE
feat: clarify the beginning of the answer from LLM

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -21,7 +21,8 @@ pub async fn render_stream(
     if stdout().is_terminal() {
         let render_options = config.read().get_render_options()?;
         let mut render = MarkdownRender::init(render_options)?;
-        markdown_stream(rx, &mut render, &abort).await
+        let model_id = config.read().model_id.clone();
+        markdown_stream(rx, &mut render, &abort, &model_id).await
     } else {
         raw_stream(rx, &abort).await
     }


### PR DESCRIPTION
Resolves #474 

This is the first PR for this project, if I'm doing something wired, please let me know. 🙏
> [!NOTE]
> When I complete implementation this feature to not only REPL with sessions but also normal REPL too, I will open this PR.

## What this PR changes
I added a AI Assistant name to the beginning of the answer. Like below:

| Before | <img height="500" alt="image" src="https://github.com/sigoden/aichat/assets/49891479/7c64415d-86fa-4f6f-94c0-cd564d7df78b"> |
|--------|--------|
| After | <img height="500" alt="image" src="https://github.com/sigoden/aichat/assets/49891479/e2f30b7f-88cf-4741-af36-d6f7f3a36fb9">|