### PR TITLE
refactor: render multiline indicator

### DIFF
--- a/src/repl/prompt.rs
+++ b/src/repl/prompt.rs
@@ -30,7 +30,7 @@ impl Prompt for ReplPrompt {
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<str> {
-        Cow::Borrowed("")
+        Cow::Borrowed("... ")
     }
 
     fn render_prompt_history_search_indicator(


### PR DESCRIPTION
multiline indicator is good enough to distinguish input/output text

![image](https://github.com/sigoden/aichat/assets/4012553/1701fbcf-de7c-4366-b552-6b579f917df7)

close #474 
