### PR TITLE
add running cost to session

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -24,7 +24,7 @@ summary_prompt: 'This is a summary of the chat history as a recap: '
 
 # Custom REPL prompt, see https://github.com/sigoden/aichat/wiki/Custom-REPL-Prompt
 left_prompt: '{color.green}{?session {session}{?role /}}{role}{color.cyan}{?session )}{!session >}{color.reset} '
-right_prompt: '{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{color.reset}'
+right_prompt: '{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{?running_cost , ~{running_cost} so far}{?context_cost , ~{context_cost} per message} {color.reset}'
 
 clients:
   # All clients have the following configuration:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -804,10 +804,12 @@ impl Config {
         if let Some(session) = &self.session {
             output.insert("session", session.name().to_string());
             output.insert("dirty", session.dirty.to_string());
-            let (tokens, percent) = session.tokens_and_percent();
+            let (tokens, percent, cost) = session.context_info();
             output.insert("consume_tokens", tokens.to_string());
+            output.insert("context_cost", format!("${:.2}", cost).to_string());
             output.insert("consume_percent", percent.to_string());
             output.insert("user_messages_len", session.user_messages_len().to_string());
+            output.insert("running_cost", format!("${:.2}", session.cost.running_cost()));
         }
 
         if self.highlight {

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,7 @@ async fn start_directive(
     no_stream: bool,
     code_mode: bool,
 ) -> Result<()> {
+    cl100k_base_singleton();
     let mut client = input.create_client()?;
     ensure_model_capabilities(client.as_mut(), input.required_capabilities())?;
     input.maybe_print_input_tokens();


### PR DESCRIPTION
Use the session's current model to estimate the cost of sending context + message, and keep a running total of the current session's cost. Works when saving and restoring session. Updates default example prompt to mention cost:

![cost](https://github.com/sigoden/aichat/assets/14118328/2ddb5f0d-22bb-4713-aa68-24c7c7544adc)
