### PR TITLE
feat: support function calling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /tmp
+*.log

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -25,7 +25,7 @@ test-platform-env() {
 }
 
 # @cmd Test function calling
-# @option --model[`_choice_model`]
+# @option --model[?`_choice_model`]
 # @option --preset[=default|weather|multi-weathers]
 # @flag -S --no-stream
 # @arg text~
@@ -64,7 +64,7 @@ test-clients() {
 }
 
 # @cmd Test proxy server
-# @option -m --model[`_choice_model`]
+# @option -m --model[?`_choice_model`]
 # @flag -S --no-stream
 # @arg text~
 test-server() {

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -153,10 +153,7 @@ chat-gemini() {
     _wrapper curl -i "https://generativelanguage.googleapis.com/v1beta/models/${argc_model}:${method}?key=${GEMINI_API_KEY}" \
 -i -X POST \
 -H 'Content-Type: application/json' \
--d '{ 
-    "safetySettings":[{"category":"HARM_CATEGORY_HARASSMENT","threshold":"BLOCK_ONLY_HIGH"},{"category":"HARM_CATEGORY_HATE_SPEECH","threshold":"BLOCK_ONLY_HIGH"},{"category":"HARM_CATEGORY_SEXUALLY_EXPLICIT","threshold":"BLOCK_ONLY_HIGH"},{"category":"HARM_CATEGORY_DANGEROUS_CONTENT","threshold":"BLOCK_ONLY_HIGH"}],
-    "contents": '"$(_build_msg_gemini $*)"'
-}'
+-d "$(_build_body gemini "$@")" 
 }
 
 # @cmd List gemini models
@@ -178,13 +175,7 @@ chat-claude() {
 -H 'content-type: application/json' \
 -H 'anthropic-version: 2023-06-01' \
 -H "x-api-key: $CLAUDE_API_KEY" \
--d '{
-  "model": "'$argc_model'",
-  "messages": '"$(_build_msg $*)"',
-  "max_tokens": 4096,
-  "stream": '$stream'
-}
-'
+-d "$(_build_body claude "$@")"
 }
 
 # @cmd Chat with cohere api
@@ -221,11 +212,7 @@ chat-ollama() {
     _wrapper curl -i http://localhost:11434/api/chat \
 -X POST \
 -H 'Content-Type: application/json' \
--d '{
-    "model": "'$argc_model'",
-    "stream": '$stream',
-    "messages": '"$(_build_msg $*)"'
-}'
+-d "$(_build_body ollama "$@")"
 }
 
 # @cmd Chat with vertexai api
@@ -246,10 +233,7 @@ chat-vertexai() {
 -X POST \
 -H "Authorization: Bearer $api_key" \
 -H 'Content-Type: application/json' \
--d '{ 
-    "contents": '"$(_build_msg_gemini $*)"',
-    "generationConfig": {}
-}'
+-d "$(_build_body vertexai "$@")" 
 }
 
 # @cmd Chat with vertexai-claude api
@@ -266,12 +250,7 @@ chat-vertexai-claude() {
 -X POST \
 -H "Authorization: Bearer $api_key" \
 -H 'Content-Type: application/json' \
--d '{
-  "anthropic_version": "vertex-2023-10-16",
-  "messages": '"$(_build_msg $*)"',
-  "max_tokens": 4096,
-  "stream": '$stream'
-}'
+-d "$(_build_body vertexai-claude "$@")" 
 }
 
 # @cmd Chat with bedrock api
@@ -285,11 +264,7 @@ chat-bedrock() {
             body='{"prompt":"'"$*"'"}'
             ;;
         anthropic.*)
-            body='{
-  "anthropic_version": "vertex-2023-10-16",
-  "messages": '"$(_build_msg $*)"',
-  "max_tokens": 4096
-}'
+            body="$(_build_body bedrock-claude "$@")"
             ;;
         *)
             _die "Invalid model: $argc_model"
@@ -314,10 +289,7 @@ chat-cloudflare() {
     _wrapper curl -i "$url" \
 -X POST \
 -H "Authorization: Bearer $CLOUDFLARE_API_KEY" \
--d '{
-  "messages": '"$(_build_msg $*)"',
-  "stream": '$stream'
-}'
+-d "$(_build_body cloudflare "$@")" 
 }
 
 # @cmd Chat with replicate api
@@ -331,12 +303,8 @@ chat-replicate() {
 -X POST \
 -H "Authorization: Bearer $REPLICATE_API_KEY" \
 -H "Content-Type: application/json" \
--d '{	
-    "stream": '$stream',
-	"input": {
-      "prompt": "'"$*"'"
-	}
-}')"
+-d "$(_build_body replicate "$@")" \
+)"
     echo "$res"
     if [[ -n "$argc_no_stream" ]]; then
         prediction_url="$(echo "$res" | jq -r '.urls.get')"
@@ -373,10 +341,7 @@ chat-ernie() {
     url="https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat/$argc_model?access_token=$ACCESS_TOKEN"
     _wrapper curl -i "$url" \
 -X POST \
--d '{
-    "messages": '"$(_build_msg $*)"',
-    "stream": '$stream'
-}'
+-d "$(_build_body ernie "$@")"
 }
 
 
@@ -397,13 +362,7 @@ chat-qianwen() {
 -X POST \
 -H "Authorization: Bearer $QIANWEN_API_KEY" \
 -H 'Content-Type: application/json' $stream_args  \
--d '{
-    "model": "'$argc_model'",
-    "parameters": '"$parameters_args"',
-    "input":{
-        "messages": '"$(_build_msg $*)"'
-    }
-}'
+-d "$(_build_body qianwen "$@")"
 }
 
 _argc_before() {
@@ -420,12 +379,7 @@ _openai_chat() {
 -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $api_key" \
---data '{
-  "model": "'$argc_model'",
-  "messages": '"$(_build_msg $*)"',
-  "stream": '$stream'
-}
-'
+-d "$(_build_body openai "$@")"
 }
 
 _openai_models() {
@@ -460,35 +414,112 @@ _choice_openai_compatible_platform() {
     done
 }
 
-_build_msg() {
-    if [[ $# -eq 0 ]]; then
-        cat tmp/messages.json
-    else
-        echo '
-[
-    {
-        "role": "user",
-        "content": "'"$*"'"
-    }
-]
-'
-    fi
-}
+_build_body() {
+    kind="$1"
+    if [[ "$#" -eq 1 ]]; then
+        file="${BODY_FILE:-"tmp/body/$1.json"}"
+        if [[ -f "$file" ]]; then
+            cat "$file" | \
+            sed \
+                -e 's/"model": ".*"/"model": "'"$argc_model"'"/' \
+                -e 's/"stream": \(true\|false\)/"stream": '$stream'/' \
 
-_build_msg_gemini() {
-    if [[ $# -eq 0 ]]; then
-        cat tmp/messages.gemini.json
+
+        fi
     else
-        echo '
-[{
-    "role": "user",
-    "parts": [
+        shift
+        case "$kind" in
+        openai|ollama)
+            echo '{
+    "model": "'$argc_model'",
+    "messages": [
         {
-            "text": "'"$*"'"
+            "role": "user",
+            "content": "'"$*"'"
         }
-    ]
-}]
-'
+    ],
+    "stream": '$stream'
+}'
+            ;;
+        claude)
+            echo '{
+    "model": "'$argc_model'",
+    "messages": [
+        {
+            "role": "user",
+            "content": "'"$*"'"
+        }
+    ],
+    "max_tokens": 4096,
+    "stream": '$stream'
+}'
+
+            ;;
+        vertexai-claude|bedrock-claude)
+            echo '{
+    "anthropic_version": "vertex-2023-10-16",
+    "messages": [
+        {
+            "role": "user",
+            "content": "'"$*"'"
+        }
+    ],
+    "max_tokens": 4096,
+    "stream": '$stream'
+}'
+
+            ;;
+        gemini|vertexai)
+            echo '{
+    "contents": [{
+        "role": "user",
+        "parts": [
+            {
+                "text": "'"$*"'"
+            }
+        ]
+    }],
+    "safetySettings":[{"category":"HARM_CATEGORY_HARASSMENT","threshold":"BLOCK_ONLY_HIGH"},{"category":"HARM_CATEGORY_HATE_SPEECH","threshold":"BLOCK_ONLY_HIGH"},{"category":"HARM_CATEGORY_SEXUALLY_EXPLICIT","threshold":"BLOCK_ONLY_HIGH"},{"category":"HARM_CATEGORY_DANGEROUS_CONTENT","threshold":"BLOCK_ONLY_HIGH"}]
+}'
+            ;;
+        ernie|cloudflare)
+            echo '{
+    "messages": [
+        {
+            "role": "user",
+            "content": "'"$*"'"
+        }
+    ],
+    "stream": '$stream'
+}'
+            ;;
+        replicate)
+            echo '{
+    "stream": '$stream',
+	"input": {
+      "prompt": "'"$*"'"
+	}
+}'
+            ;;
+        qianwen)
+            echo '{
+    "model": "'$argc_model'",
+    "parameters": '"$parameters_args"',
+    "input":{
+        "messages": [
+            {
+                "role": "user",
+                "content": "'"$*"'"
+            }
+        ]
+    }
+}'
+            ;;
+        *)
+            _die "Unsupported build body for $kind"
+            ;;
+        esac
+
     fi
 }
 

--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -24,6 +24,34 @@ test-platform-env() {
     cargo run -- "$@"
 }
 
+# @cmd Test function calling
+# @option --model[`_choice_model`]
+# @option --preset[=default|weather|multi-weathers]
+# @flag -S --no-stream
+# @arg text~
+test-function-calling() {
+    args=(--role %functions%)
+    if [[ -n "$argc_model"  ]]; then
+      args+=("--model" "$argc_model")
+    fi
+    if [[ -n "$argc_no_stream" ]]; then
+        args+=("-S")
+    fi
+    if [[ -z "$argc_text" ]]; then
+        case "$argc_preset" in
+        multi-weathers)
+            text="what is the weather in London and Pairs?"
+            ;;
+        weather|*)
+            text="what is the weather in London?"
+            ;;
+        esac
+    else
+        text="${argc_text[*]}"
+    fi
+    cargo run -- "${args[@]}" "$text"
+}
+
 # @cmd Test clients
 # @arg clients+[`_choice_client`]
 test-clients() {
@@ -174,6 +202,7 @@ chat-claude() {
 -X POST \
 -H 'content-type: application/json' \
 -H 'anthropic-version: 2023-06-01' \
+-H 'anthropic-beta: tools-2024-05-16' \
 -H "x-api-key: $CLAUDE_API_KEY" \
 -d "$(_build_body claude "$@")"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "log",
  "mime_guess",
  "nu-ansi-term 0.50.0",
+ "num_cpus",
  "parking_lot",
  "reedline",
  "reqwest",
@@ -71,6 +72,7 @@ dependencies = [
  "simplelog",
  "syntect",
  "textwrap",
+ "threadpool",
  "time",
  "tokio",
  "tokio-graceful",
@@ -2227,6 +2229,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,6 @@ dependencies = [
  "aws-smithy-eventstream",
  "base64 0.22.1",
  "bincode",
- "bitflags 2.5.0",
  "bstr",
  "bytes",
  "chrono",
@@ -1071,6 +1070,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ log = "0.4.20"
 shell-words = "1.1.0"
 mime_guess = "2.0.4"
 sha2 = "0.10.8"
-bitflags = "2.4.1"
 unicode-width = "0.1.11"
 async-recursion = "1.1.0"
 http = "1.1.0"
@@ -52,7 +51,7 @@ http-body-util = "0.1"
 hyper = { version = "1.0", features = ["full"] }
 hyper-util = { version = "0.1", features = ["server-auto", "client-legacy"] }
 time = { version = "0.3.36", features = ["macros"] }
-indexmap = "2.2.6"
+indexmap = { version = "2.2.6", features = ["serde"] }
 hmac = "0.12.1"
 aws-smithy-eventstream = "0.60.4"
 urlencoding = "2.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ shell-words = "1.1.0"
 mime_guess = "2.0.4"
 sha2 = "0.10.8"
 unicode-width = "0.1.11"
-async-recursion = "1.1.0"
+async-recursion = "1.1.1"
 http = "1.1.0"
 http-body-util = "0.1"
 hyper = { version = "1.0", features = ["full"] }
@@ -56,6 +56,8 @@ hmac = "0.12.1"
 aws-smithy-eventstream = "0.60.4"
 urlencoding = "2.1.3"
 unicode-segmentation = "1.11.0"
+num_cpus = "1.16.0"
+threadpool = "1.8.1"
 
 [dependencies.reqwest]
 version = "0.12.0"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,9 @@ prelude: null                    # Set a default role or session to start with (
 # if unset fallback to $EDITOR and $VISUAL
 buffer_editor: null
 
+# Controls the function calling feature. For setup instructions, visit https://github.com/sigoden/llm-functions.
+function_calling: false
+
 # Compress session when token count reaches or exceeds this threshold (must be at least 1000)
 compress_threshold: 1000
 # Text prompt used for creating a concise summary of session message

--- a/models.yaml
+++ b/models.yaml
@@ -1,7 +1,6 @@
 # notes:
 #   - do not submit pull requests to add new models; this list will be updated in batches with new releases.
 #   - do not add any open-source LLMs except for the following: Mixtral, LLama-3, Gemma, Qwen, Phi-3, DeepSeek, Command-R, dbrx, Yi.
-#   - only model that supports parallel fucntion calling can have the `supports_function_calling` property set to true.
 
 - platform: openai
   # docs:
@@ -80,6 +79,7 @@
       max_output_tokens: 2048
       input_price: 0.5
       output_price: 1.5
+      supports_function_calling: true
     - name: gemini-1.0-pro-vision-latest
       max_input_tokens: 12288
       max_output_tokens: 4096
@@ -92,6 +92,7 @@
       input_price: 0.35
       output_price: 0.53
       supports_vision: true
+      supports_function_calling: true
     - name: gemini-1.5-pro-latest
       max_input_tokens: 1048576
       max_output_tokens: 8192
@@ -122,6 +123,7 @@
       input_price: 3
       output_price: 15
       supports_vision: true
+      supports_function_calling: true
     - name: claude-3-haiku-20240307
       max_input_tokens: 200000
       max_output_tokens: 4096
@@ -129,6 +131,7 @@
       input_price: 0.25
       output_price: 1.25
       supports_vision: true
+      supports_function_calling: true
 
 - platform: mistral
   # docs:
@@ -158,6 +161,7 @@
       max_input_tokens: 32000
       input_price: 8
       output_price: 24
+      supports_function_calling: true
 
 - platform: cohere
   # docs:
@@ -253,12 +257,13 @@
   # notes:
   #   - get max_output_tokens info from models doc
   models:
-    - name: gemini-1.0-pro
+    - name: gemini-1.0-pro-002
       max_input_tokens: 24568
       max_output_tokens: 8192
       input_price: 0.125
       output_price: 0.375
-    - name: gemini-1.0-pro-vision
+      supports_function_calling: true
+    - name: gemini-1.0-pro-vision-001
       max_input_tokens: 14336
       max_output_tokens: 2048
       input_price: 0.125

--- a/models.yaml
+++ b/models.yaml
@@ -15,33 +15,39 @@
       max_output_tokens: 4096
       input_price: 0.5
       output_price: 1.5
+      supports_function_calling: true
     - name: gpt-3.5-turbo-1106
       max_input_tokens: 16385
       max_output_tokens: 4096
       input_price: 1
       output_price: 2
+      supports_function_calling: true
     - name: gpt-4o
       max_input_tokens: 128000
       max_output_tokens: 4096
       input_price: 5
       output_price: 15
       supports_vision: true
+      supports_function_calling: true
     - name: gpt-4-turbo
       max_input_tokens: 128000
       max_output_tokens: 4096
       input_price: 10
       output_price: 30
       supports_vision: true
+      supports_function_calling: true
     - name: gpt-4-turbo-preview
       max_input_tokens: 128000
       max_output_tokens: 4096
       input_price: 10
       output_price: 30
+      supports_function_calling: true
     - name: gpt-4-1106-preview
       max_input_tokens: 128000
       max_output_tokens: 4096
       input_price: 10
       output_price: 30
+      supports_function_calling: true
     - name: gpt-4-vision-preview
       max_input_tokens: 128000
       max_output_tokens: 4096
@@ -73,6 +79,7 @@
       max_output_tokens: 2048
       input_price: 0.5
       output_price: 1.5
+      supports_function_calling: true
     - name: gemini-1.0-pro-vision-latest
       max_input_tokens: 12288
       max_output_tokens: 4096
@@ -85,12 +92,14 @@
       input_price: 0.35
       output_price: 0.53
       supports_vision: true
+      supports_function_calling: true
     - name: gemini-1.5-pro-latest
       max_input_tokens: 1048576
       max_output_tokens: 8192
       input_price: 3.5
       output_price: 10.5
       supports_vision: true
+      supports_function_calling: true
 
 - platform: claude
   # docs:
@@ -141,14 +150,17 @@
       max_input_tokens: 64000
       input_price: 2
       output_price: 6
+      supports_function_calling: true
     - name: mistral-small-latest
       max_input_tokens: 32000
       input_price: 2
       output_price: 6
+      supports_function_calling: true
     - name: mistral-large-latest
       max_input_tokens: 32000
       input_price: 8
       output_price: 24
+      supports_function_calling: true
 
 - platform: cohere
   # docs:
@@ -163,11 +175,13 @@
       max_output_tokens: 4000
       input_price: 0.5
       output_price: 1.5
+      supports_function_calling: true
     - name: command-r-plus
       max_input_tokens: 128000
       max_output_tokens: 4000
       input_price: 3
       output_price: 15
+      supports_function_calling: true
 
 - platform: perplexity
   # docs:
@@ -247,6 +261,7 @@
       max_output_tokens: 8192
       input_price: 0.125
       output_price: 0.375
+      supports_function_calling: true
     - name: gemini-1.0-pro-vision
       max_input_tokens: 14336
       max_output_tokens: 2048
@@ -387,6 +402,7 @@
   # docs:
   #   - https://replicate.com/docs
   #   - https://replicate.com/pricing
+  #   - https://replicate.com/docs/reference/http
   # notes:
   #   - max_output_tokens is required but unknown
   models:
@@ -695,20 +711,24 @@
       max_input_tokens: 16385
       input_price: 0.5
       output_price: 1.5
+      supports_function_calling: true
     - name: openai/gpt-4o
       max_input_tokens: 128000
       input_price: 5
       output_price: 15
       supports_vision: true
+      supports_function_calling: true
     - name: openai/gpt-4-turbo
       max_input_tokens: 128000
       input_price: 10
       output_price: 30
       supports_vision: true
+      supports_function_calling: true
     - name: openai/gpt-4-turbo-preview
       max_input_tokens: 128000
       input_price: 10
       output_price: 30
+      supports_function_calling: true
     - name: openai/gpt-4-vision-preview
       max_input_tokens: 128000
       max_output_tokens: 4096

--- a/models.yaml
+++ b/models.yaml
@@ -1,6 +1,7 @@
 # notes:
 #   - do not submit pull requests to add new models; this list will be updated in batches with new releases.
 #   - do not add any open-source LLMs except for the following: Mixtral, LLama-3, Gemma, Qwen, Phi-3, DeepSeek, Command-R, dbrx, Yi.
+#   - only model that supports parallel fucntion calling can have the `supports_function_calling` property set to true.
 
 - platform: openai
   # docs:
@@ -79,7 +80,6 @@
       max_output_tokens: 2048
       input_price: 0.5
       output_price: 1.5
-      supports_function_calling: true
     - name: gemini-1.0-pro-vision-latest
       max_input_tokens: 12288
       max_output_tokens: 4096
@@ -92,7 +92,6 @@
       input_price: 0.35
       output_price: 0.53
       supports_vision: true
-      supports_function_calling: true
     - name: gemini-1.5-pro-latest
       max_input_tokens: 1048576
       max_output_tokens: 8192
@@ -115,6 +114,7 @@
       input_price: 15
       output_price: 75
       supports_vision: true
+      supports_function_calling: true
     - name: claude-3-sonnet-20240229
       max_input_tokens: 200000
       max_output_tokens: 4096
@@ -150,17 +150,14 @@
       max_input_tokens: 64000
       input_price: 2
       output_price: 6
-      supports_function_calling: true
     - name: mistral-small-latest
       max_input_tokens: 32000
       input_price: 2
       output_price: 6
-      supports_function_calling: true
     - name: mistral-large-latest
       max_input_tokens: 32000
       input_price: 8
       output_price: 24
-      supports_function_calling: true
 
 - platform: cohere
   # docs:
@@ -261,7 +258,6 @@
       max_output_tokens: 8192
       input_price: 0.125
       output_price: 0.375
-      supports_function_calling: true
     - name: gemini-1.0-pro-vision
       max_input_tokens: 14336
       max_output_tokens: 2048

--- a/src/client/azure_openai.rs
+++ b/src/client/azure_openai.rs
@@ -1,7 +1,5 @@
 use super::openai::openai_build_body;
-use super::{
-    AzureOpenAIClient, ExtraConfig, Model, ModelConfig, PromptAction, PromptKind, SendData,
-};
+use super::{AzureOpenAIClient, ExtraConfig, Model, ModelData, PromptAction, PromptKind, SendData};
 
 use anyhow::Result;
 use reqwest::{Client as ReqwestClient, RequestBuilder};
@@ -12,7 +10,7 @@ pub struct AzureOpenAIConfig {
     pub name: Option<String>,
     pub api_base: Option<String>,
     pub api_key: Option<String>,
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -41,7 +39,8 @@ impl AzureOpenAIClient {
 
         let url = format!(
             "{}/openai/deployments/{}/chat/completions?api-version=2024-02-01",
-            &api_base, self.model.name
+            &api_base,
+            self.model.name()
         );
 
         debug!("AzureOpenAI Request: {url} {body}");

--- a/src/client/claude.rs
+++ b/src/client/claude.rs
@@ -83,9 +83,10 @@ pub async fn claude_send_message_streaming(
                         data["content_block"]["id"].as_str(),
                     ) {
                         if !function_name.is_empty() {
-                            let arguments: Value = function_arguments
-                                .parse()
-                                .context("Invalid call arguments: must be json")?;
+                            let arguments: Value =
+                                function_arguments.parse().with_context(|| {
+                                    format!("Tool call '{function_name}' is invalid: arguments must be in valid JSON format")
+                                })?;
                             handler.tool_call(ToolCall::new(
                                 function_name.clone(),
                                 arguments,
@@ -109,9 +110,9 @@ pub async fn claude_send_message_streaming(
                 }
                 "content_block_stop" => {
                     if !function_name.is_empty() {
-                        let arguments: Value = function_arguments
-                            .parse()
-                            .context("Invalid call arguments: must be json")?;
+                        let arguments: Value = function_arguments.parse().with_context(|| {
+                            format!("Tool call '{function_name}' is invalid: arguments must be in valid JSON format")
+                        })?;
                         handler.tool_call(ToolCall::new(
                             function_name.clone(),
                             arguments,

--- a/src/client/claude.rs
+++ b/src/client/claude.rs
@@ -93,7 +93,9 @@ pub fn claude_build_body(data: SendData, model: &Model) -> Result<Value> {
 
     let system_message = extract_system_message(&mut messages);
 
+    let mut is_tool_call = false;
     let mut network_image_urls = vec![];
+
     let messages: Vec<Value> = messages
         .into_iter()
         .map(|message| {
@@ -126,11 +128,19 @@ pub fn claude_build_body(data: SendData, model: &Model) -> Result<Value> {
                         }
                     })
                     .collect(),
-                MessageContent::ToolCall(_) => vec![],
+                MessageContent::ToolCall(_) => {
+                    is_tool_call = true;
+                    vec![]
+                },
             };
             json!({ "role": role, "content": content })
         })
         .collect();
+
+    
+    if is_tool_call {
+        bail!("The client does not support function calling",);
+    }
 
     if !network_image_urls.is_empty() {
         bail!(

--- a/src/client/claude.rs
+++ b/src/client/claude.rs
@@ -126,6 +126,7 @@ pub fn claude_build_body(data: SendData, model: &Model) -> Result<Value> {
                         }
                     })
                     .collect(),
+                MessageContent::ToolCall(_) => vec![],
             };
             json!({ "role": role, "content": content })
         })

--- a/src/client/cohere.rs
+++ b/src/client/cohere.rs
@@ -1,9 +1,9 @@
 use super::{
-    catch_error, extract_system_message, json_stream, message::*, CohereClient, CompletionDetails,
-    ExtraConfig, Model, ModelConfig, PromptAction, PromptKind, SendData, SseHandler,
+    catch_error, extract_system_message, json_stream, message::*, CohereClient, CompletionOutput,
+    ExtraConfig, Model, ModelData, PromptAction, PromptKind, SendData, SseHandler, ToolCall,
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -15,7 +15,7 @@ pub struct CohereConfig {
     pub name: Option<String>,
     pub api_key: Option<String>,
     #[serde(default)]
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -42,7 +42,7 @@ impl CohereClient {
 
 impl_client_trait!(CohereClient, send_message, send_message_streaming);
 
-async fn send_message(builder: RequestBuilder) -> Result<(String, CompletionDetails)> {
+async fn send_message(builder: RequestBuilder) -> Result<CompletionOutput> {
     let res = builder.send().await?;
     let status = res.status();
     let data: Value = res.json().await?;
@@ -50,6 +50,7 @@ async fn send_message(builder: RequestBuilder) -> Result<(String, CompletionDeta
         catch_error(&data, status.as_u16())?;
     }
 
+    debug!("non-stream-data: {data}");
     extract_completion(&data)
 }
 
@@ -62,9 +63,20 @@ async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandle
     } else {
         let handle = |data: &str| -> Result<()> {
             let data: Value = serde_json::from_str(data)?;
+            debug!("stream-data: {data}");
             if let Some("text-generation") = data["event_type"].as_str() {
                 if let Some(text) = data["text"].as_str() {
                     handler.text(text)?;
+                }
+            } else if let Some("tool-calls-generation") = data["event_type"].as_str() {
+                if let Some(tool_calls) = data["tool_calls"].as_array() {
+                    for call in tool_calls {
+                        if let (Some(name), Some(args)) =
+                            (call["name"].as_str(), call["parameters"].as_object())
+                        {
+                            handler.tool_call(ToolCall::new(name.to_string(), json!(args)))?;
+                        }
+                    }
                 }
             }
             Ok(())
@@ -79,6 +91,7 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
         mut messages,
         temperature,
         top_p,
+        functions,
         stream,
     } = data;
 
@@ -123,7 +136,7 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
     let message = message["message"].as_str().unwrap_or_default();
 
     let mut body = json!({
-        "model": &model.name,
+        "model": &model.name(),
         "message": message,
     });
 
@@ -148,18 +161,60 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
         body["stream"] = true.into();
     }
 
+    if let Some(functions) = functions {
+        body["tools"] = functions
+            .iter()
+            .map(|v| {
+                let required = v.parameters.required.clone().unwrap_or_default();
+                let mut parameter_definitions = json!({});
+                if let Some(properties) = &v.parameters.properties {
+                    for (key, value) in properties {
+                        let mut value: Value = json!(value);
+                        if value.is_object() && required.iter().any(|x| x == key) {
+                            value["required"] = true.into();
+                        }
+                        parameter_definitions[key] = value;
+                    }
+                }
+                json!({
+                    "name": v.name,
+                    "description": v.description,
+                    "parameter_definitions": parameter_definitions,
+                })
+            })
+            .collect();
+    }
     Ok(body)
 }
 
-fn extract_completion(data: &Value) -> Result<(String, CompletionDetails)> {
-    let text = data["text"]
-        .as_str()
-        .ok_or_else(|| anyhow!("Invalid response data: {data}"))?;
+fn extract_completion(data: &Value) -> Result<CompletionOutput> {
+    let text = data["text"].as_str().unwrap_or_default();
 
-    let details = CompletionDetails {
+    let tool_calls = if let Some(tool_calls) = data["tool_calls"].as_array() {
+        tool_calls
+            .iter()
+            .filter_map(|call| {
+                if let (Some(name), Some(args)) =
+                    (call["name"].as_str(), call["parameters"].as_object())
+                {
+                    Some(ToolCall::new(name.to_string(), json!(args)))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+    if text.is_empty() && tool_calls.is_empty() {
+        bail!("Invalid response data: {data}");
+    }
+    let output = CompletionOutput {
+        text: text.to_string(),
+        tool_calls,
         id: data["generation_id"].as_str().map(|v| v.to_string()),
         input_tokens: data["meta"]["billed_units"]["input_tokens"].as_u64(),
         output_tokens: data["meta"]["billed_units"]["output_tokens"].as_u64(),
     };
-    Ok((text.to_string(), details))
+    Ok(output)
 }

--- a/src/client/cohere.rs
+++ b/src/client/cohere.rs
@@ -121,11 +121,11 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
                     MessageRole::User => "USER",
                     _ => "CHATBOT",
                 };
-                let new_message = match message.content {
-                    MessageContent::Text(text) => json!({
+                match message.content {
+                    MessageContent::Text(text) => Some(json!({
                         "role": role,
                         "message": text,
-                    }),
+                    })),
                     MessageContent::Array(list) => {
                         let list: Vec<String> = list
                             .into_iter()
@@ -139,11 +139,10 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
                                 }
                             })
                             .collect();
-                        json!({ "role": role, "message": list.join("\n\n") })
+                        Some(json!({ "role": role, "message": list.join("\n\n") }))
                     }
-                    MessageContent::ToolCall(_) => json!({}),
-                };
-                Some(new_message)
+                    MessageContent::ToolCall(_) => None,
+                }
             }
         })
         .collect();

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -2,7 +2,7 @@ use super::{openai::OpenAIConfig, BuiltinModels, ClientConfig, Message, Model, S
 
 use crate::{
     config::{GlobalConfig, Input},
-    function::{run_tool_calls, FunctionDeclaration, ToolCall, ToolCallResult},
+    function::{eval_tool_calls, FunctionDeclaration, ToolCall, ToolCallResult},
     render::{render_error, render_stream},
     utils::{prompt_input_integer, prompt_input_string, tokenize, AbortSignal, PromptKind},
 };
@@ -448,7 +448,7 @@ pub async fn send_stream(
             if !output.is_empty() && !output.ends_with('\n') {
                 println!();
             }
-            Ok((output, run_tool_calls(config, calls)?))
+            Ok((output, eval_tool_calls(config, calls)?))
         }
         Err(err) => {
             if !output.is_empty() {

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -2,6 +2,7 @@ use super::{openai::OpenAIConfig, BuiltinModels, ClientConfig, Message, Model, S
 
 use crate::{
     config::{GlobalConfig, Input},
+    function::{run_tool_calls, FunctionDeclaration, ToolCall},
     render::{render_error, render_stream},
     utils::{prompt_input_integer, prompt_input_string, tokenize, AbortSignal, PromptKind},
 };
@@ -52,7 +53,7 @@ macro_rules! register_client {
         pub enum ClientModel {
             $(
                 #[serde(rename = $name)]
-                $config { models: Vec<ModelConfig> },
+                $config { models: Vec<ModelData> },
             )+
             #[serde(other)]
             Unknown,
@@ -73,7 +74,7 @@ macro_rules! register_client {
                 pub fn init(global_config: &$crate::config::GlobalConfig, model: &$crate::client::Model) -> Option<Box<dyn Client>> {
                     let config = global_config.read().clients.iter().find_map(|client_config| {
                         if let ClientConfig::$config(c) = client_config {
-                            if Self::name(c) == &model.client_name {
+                            if Self::name(c) == model.client_name() {
                                 return Some(c.clone())
                             }
                         }
@@ -113,22 +114,8 @@ macro_rules! register_client {
             None
             $(.or_else(|| $client::init(config, &model)))+
             .ok_or_else(|| {
-                anyhow::anyhow!("Unknown client '{}'", model.client_name)
+                anyhow::anyhow!("Unknown client '{}'", model.client_name())
             })
-        }
-
-        pub fn ensure_model_capabilities(client: &mut dyn Client, capabilities: $crate::client::ModelCapabilities) -> anyhow::Result<()> {
-            if !client.model().capabilities.contains(capabilities) {
-                let models = client.list_models();
-                if let Some(model) = models.into_iter().find(|v| v.capabilities.contains(capabilities)) {
-                    client.set_model(model);
-                } else {
-                    anyhow::bail!(
-                        "The current model is incapable of doing that."
-                    );
-                }
-            }
-            Ok(())
         }
 
         pub fn list_client_types() -> Vec<&'static str> {
@@ -213,7 +200,7 @@ macro_rules! impl_client_trait {
                 &self,
                 client: &reqwest::Client,
                 data: $crate::client::SendData,
-            ) -> anyhow::Result<(String, $crate::client::CompletionDetails)> {
+            ) -> anyhow::Result<$crate::client::CompletionOutput> {
                 let builder = self.request_builder(client, data)?;
                 $send_message(builder).await
             }
@@ -261,14 +248,16 @@ macro_rules! unsupported_model {
 pub trait Client: Sync + Send {
     fn config(&self) -> (&GlobalConfig, &Option<ExtraConfig>);
 
-    fn list_models(&self) -> Vec<Model>;
-
     fn name(&self) -> &str;
+
+    #[allow(unused)]
+    fn list_models(&self) -> Vec<Model>;
 
     fn model(&self) -> &Model;
 
     fn model_mut(&mut self) -> &mut Model;
 
+    #[allow(unused)]
     fn set_model(&mut self, model: Model);
 
     fn build_client(&self) -> Result<ReqwestClient> {
@@ -287,14 +276,15 @@ pub trait Client: Sync + Send {
         Ok(client)
     }
 
-    async fn send_message(&self, input: Input) -> Result<(String, CompletionDetails)> {
+    async fn send_message(&self, input: Input) -> Result<CompletionOutput> {
         let global_config = self.config().0;
         if global_config.read().dry_run {
             let content = input.echo_messages();
-            return Ok((content, CompletionDetails::default()));
+            return Ok(CompletionOutput::new(&content));
         }
         let client = self.build_client()?;
-        let data = input.prepare_send_data(false)?;
+
+        let data = input.prepare_send_data(self.model(), false)?;
         self.send_message_inner(&client, data)
             .await
             .with_context(|| "Failed to get answer")
@@ -324,7 +314,7 @@ pub trait Client: Sync + Send {
                     return Ok(());
                 }
                 let client = self.build_client()?;
-                let data = input.prepare_send_data(true)?;
+                let data = input.prepare_send_data(self.model(), true)?;
                 self.send_message_streaming_inner(&client, handler, data).await
             } => {
                 handler.done()?;
@@ -341,7 +331,7 @@ pub trait Client: Sync + Send {
         &self,
         client: &ReqwestClient,
         data: SendData,
-    ) -> Result<(String, CompletionDetails)>;
+    ) -> Result<CompletionOutput>;
 
     async fn send_message_streaming_inner(
         &self,
@@ -368,14 +358,26 @@ pub struct SendData {
     pub messages: Vec<Message>,
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
+    pub functions: Option<Vec<FunctionDeclaration>>,
     pub stream: bool,
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct CompletionDetails {
+pub struct CompletionOutput {
+    pub text: String,
+    pub tool_calls: Vec<ToolCall>,
     pub id: Option<String>,
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
+}
+
+impl CompletionOutput {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_string(),
+            ..Default::default()
+        }
+    }
 }
 
 pub type PromptAction<'a> = (&'a str, &'a str, bool, PromptKind);
@@ -431,19 +433,25 @@ pub async fn send_stream(
     abort: AbortSignal,
 ) -> Result<String> {
     let (tx, rx) = unbounded_channel();
-    let mut stream_handler = SseHandler::new(tx, abort.clone());
+    let mut handler = SseHandler::new(tx, abort.clone());
 
     let (send_ret, rend_ret) = tokio::join!(
-        client.send_message_streaming(input, &mut stream_handler),
+        client.send_message_streaming(input, &mut handler),
         render_stream(rx, config, abort.clone()),
     );
     if let Err(err) = rend_ret {
         render_error(err, config.read().highlight);
     }
-    let output = stream_handler.get_buffer().to_string();
+    let calls = handler.get_tool_calls();
+    let output = handler.get_buffer().to_string();
     match send_ret {
         Ok(_) => {
-            println!();
+            if !calls.is_empty() {
+                run_tool_calls(config, calls)?;
+            }
+            if calls.is_empty() && !output.ends_with('\n') {
+                println!();
+            }
             Ok(output)
         }
         Err(err) => {

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -445,12 +445,10 @@ pub async fn send_stream(
     let (output, calls) = handler.take();
     match send_ret {
         Ok(_) => {
-            let not_tool_call = calls.is_empty();
-            let tool_call_results = run_tool_calls(config, calls)?;
-            if not_tool_call && !output.ends_with('\n') {
+            if !output.is_empty() && !output.ends_with('\n') {
                 println!();
             }
-            Ok((output, tool_call_results))
+            Ok((output, run_tool_calls(config, calls)?))
         }
         Err(err) => {
             if !output.is_empty() {

--- a/src/client/ernie.rs
+++ b/src/client/ernie.rs
@@ -1,7 +1,7 @@
 use super::access_token::*;
 use super::{
-    maybe_catch_error, patch_system_message, sse_stream, Client, CompletionDetails, ErnieClient,
-    ExtraConfig, Model, ModelConfig, PromptAction, PromptKind, SendData, SsMmessage, SseHandler,
+    maybe_catch_error, patch_system_message, sse_stream, Client, CompletionOutput, ErnieClient,
+    ExtraConfig, Model, ModelData, PromptAction, PromptKind, SendData, SsMmessage, SseHandler,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -20,7 +20,7 @@ pub struct ErnieConfig {
     pub api_key: Option<String>,
     pub secret_key: Option<String>,
     #[serde(default)]
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -36,7 +36,7 @@ impl ErnieClient {
 
         let url = format!(
             "{API_BASE}/wenxinworkshop/chat/{}?access_token={access_token}",
-            &self.model.name,
+            &self.model.name(),
         );
 
         debug!("Ernie Request: {url} {body}");
@@ -78,7 +78,7 @@ impl Client for ErnieClient {
         &self,
         client: &ReqwestClient,
         data: SendData,
-    ) -> Result<(String, CompletionDetails)> {
+    ) -> Result<CompletionOutput> {
         self.prepare_access_token().await?;
         let builder = self.request_builder(client, data)?;
         send_message(builder).await
@@ -96,15 +96,17 @@ impl Client for ErnieClient {
     }
 }
 
-async fn send_message(builder: RequestBuilder) -> Result<(String, CompletionDetails)> {
+async fn send_message(builder: RequestBuilder) -> Result<CompletionOutput> {
     let data: Value = builder.send().await?.json().await?;
     maybe_catch_error(&data)?;
+    debug!("non-stream-data: {data}");
     extract_completion_text(&data)
 }
 
 async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandler) -> Result<()> {
     let handle = |message: SsMmessage| -> Result<bool> {
         let data: Value = serde_json::from_str(&message.data)?;
+        debug!("stream-data: {data}");
         if let Some(text) = data["result"].as_str() {
             handler.text(text)?;
         }
@@ -119,6 +121,7 @@ fn build_body(data: SendData, model: &Model) -> Value {
         mut messages,
         temperature,
         top_p,
+        functions: _,
         stream,
     } = data;
 
@@ -145,16 +148,18 @@ fn build_body(data: SendData, model: &Model) -> Value {
     body
 }
 
-fn extract_completion_text(data: &Value) -> Result<(String, CompletionDetails)> {
+fn extract_completion_text(data: &Value) -> Result<CompletionOutput> {
     let text = data["result"]
         .as_str()
         .ok_or_else(|| anyhow!("Invalid response data: {data}"))?;
-    let details = CompletionDetails {
+    let output = CompletionOutput {
+        text: text.to_string(),
+        tool_calls: vec![],
         id: data["id"].as_str().map(|v| v.to_string()),
         input_tokens: data["usage"]["prompt_tokens"].as_u64(),
         output_tokens: data["usage"]["completion_tokens"].as_u64(),
     };
-    Ok((text.to_string(), details))
+    Ok(output)
 }
 
 async fn fetch_access_token(

--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -1,5 +1,5 @@
 use super::vertexai::gemini_build_body;
-use super::{ExtraConfig, GeminiClient, Model, ModelConfig, PromptAction, PromptKind, SendData};
+use super::{ExtraConfig, GeminiClient, Model, ModelData, PromptAction, PromptKind, SendData};
 
 use anyhow::Result;
 use reqwest::{Client as ReqwestClient, RequestBuilder};
@@ -14,7 +14,7 @@ pub struct GeminiConfig {
     #[serde(rename = "safetySettings")]
     pub safety_settings: Option<serde_json::Value>,
     #[serde(default)]
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -34,7 +34,7 @@ impl GeminiClient {
 
         let body = gemini_build_body(data, &self.model, self.config.safety_settings.clone())?;
 
-        let model = &self.model.name;
+        let model = &self.model.name();
 
         let url = format!("{API_BASE}{}:{}?key={}", model, func, api_key);
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -6,6 +6,7 @@ mod model;
 mod prompt_format;
 mod sse_handler;
 
+pub use crate::function::ToolCall;
 pub use crate::utils::PromptKind;
 pub use common::*;
 pub use message::*;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -6,7 +6,7 @@ mod model;
 mod prompt_format;
 mod sse_handler;
 
-pub use crate::function::ToolCall;
+pub use crate::function::{ToolCall, ToolCallResult};
 pub use crate::utils::PromptKind;
 pub use common::*;
 pub use message::*;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -6,7 +6,7 @@ mod model;
 mod prompt_format;
 mod sse_handler;
 
-pub use crate::function::{ToolCall, ToolCallResult};
+pub use crate::function::{ToolCall, ToolResults};
 pub use crate::utils::PromptKind;
 pub use common::*;
 pub use message::*;

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -164,7 +164,7 @@ impl Model {
             .map(|v| match &v.content {
                 MessageContent::Text(text) => estimate_token_length(text),
                 MessageContent::Array(_) => 0,
-                MessageContent::ToolCall(_) => 0,
+                MessageContent::ToolResults(_) => 0,
             })
             .sum()
     }

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -161,11 +161,10 @@ impl Model {
     pub fn messages_tokens(&self, messages: &[Message]) -> usize {
         messages
             .iter()
-            .map(|v| {
-                match &v.content {
-                    MessageContent::Text(text) => estimate_token_length(text),
-                    MessageContent::Array(_) => 0, // TODO
-                }
+            .map(|v| match &v.content {
+                MessageContent::Text(text) => estimate_token_length(text),
+                MessageContent::Array(_) => 0,
+                MessageContent::ToolCall(_) => 0,
             })
             .sum()
     }

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -10,15 +10,8 @@ const BASIS_TOKENS: usize = 2;
 
 #[derive(Debug, Clone)]
 pub struct Model {
-    pub client_name: String,
-    pub name: String,
-    pub max_input_tokens: Option<usize>,
-    pub max_output_tokens: Option<isize>,
-    pub pass_max_tokens: bool,
-    pub input_price: Option<f64>,
-    pub output_price: Option<f64>,
-    pub capabilities: ModelCapabilities,
-    pub extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
+    client_name: String,
+    data: ModelData,
 }
 
 impl Default for Model {
@@ -31,30 +24,16 @@ impl Model {
     pub fn new(client_name: &str, name: &str) -> Self {
         Self {
             client_name: client_name.into(),
-            name: name.into(),
-            max_input_tokens: None,
-            max_output_tokens: None,
-            pass_max_tokens: false,
-            input_price: None,
-            output_price: None,
-            capabilities: ModelCapabilities::Text,
-            extra_fields: None,
+            data: ModelData::new(name),
         }
     }
 
-    pub fn from_config(client_name: &str, models: &[ModelConfig]) -> Vec<Self> {
+    pub fn from_config(client_name: &str, models: &[ModelData]) -> Vec<Self> {
         models
             .iter()
-            .map(|v| {
-                let mut model = Model::new(client_name, &v.name);
-                model
-                    .set_max_input_tokens(v.max_input_tokens)
-                    .set_max_tokens(v.max_output_tokens, v.pass_max_tokens)
-                    .set_input_price(v.input_price)
-                    .set_output_price(v.output_price)
-                    .set_supports_vision(v.supports_vision)
-                    .set_extra_fields(&v.extra_fields);
-                model
+            .map(|v| Model {
+                client_name: client_name.to_string(),
+                data: v.clone(),
             })
             .collect()
     }
@@ -77,7 +56,7 @@ impl Model {
                     model = Some((*found).clone());
                 } else if let Some(found) = models.iter().find(|v| v.client_name == client_name) {
                     let mut found = (*found).clone();
-                    found.name = model_name.to_string();
+                    found.data.name = model_name.to_string();
                     model = Some(found)
                 }
             }
@@ -91,43 +70,79 @@ impl Model {
     }
 
     pub fn id(&self) -> String {
-        format!("{}:{}", self.client_name, self.name)
+        format!("{}:{}", self.client_name, self.data.name)
+    }
+
+    pub fn client_name(&self) -> &str {
+        &self.client_name
+    }
+
+    pub fn name(&self) -> &str {
+        &self.data.name
+    }
+
+    pub fn data(&self) -> &ModelData {
+        &self.data
+    }
+
+    pub fn data_mut(&mut self) -> &mut ModelData {
+        &mut self.data
     }
 
     pub fn description(&self) -> String {
-        let max_input_tokens = format_option_value(&self.max_input_tokens);
-        let max_output_tokens = format_option_value(&self.max_output_tokens);
-        let input_price = format_option_value(&self.input_price);
-        let output_price = format_option_value(&self.output_price);
-        let vision = if self.capabilities.contains(ModelCapabilities::Vision) {
-            "👁"
-        } else {
-            ""
+        let ModelData {
+            max_input_tokens,
+            max_output_tokens,
+            input_price,
+            output_price,
+            supports_vision,
+            supports_function_calling,
+            ..
+        } = &self.data;
+        let max_input_tokens = format_option_value(max_input_tokens);
+        let max_output_tokens = format_option_value(max_output_tokens);
+        let input_price = format_option_value(input_price);
+        let output_price = format_option_value(output_price);
+        let mut capabilities = vec![];
+        if *supports_vision {
+            capabilities.push('👁');
         };
+        if *supports_function_calling {
+            capabilities.push('⚒');
+        };
+        let capabilities: String = capabilities
+            .into_iter()
+            .map(|v| format!("{v} "))
+            .collect::<Vec<String>>()
+            .join("");
         format!(
-            "{:>8} / {:>8}  |  {:>6} / {:>6}  {}",
-            max_input_tokens, max_output_tokens, input_price, output_price, vision
+            "{:>8} / {:>8}  |  {:>6} / {:>6}  {:>6}",
+            max_input_tokens, max_output_tokens, input_price, output_price, capabilities
         )
     }
 
+    pub fn max_input_tokens(&self) -> Option<usize> {
+        self.data.max_input_tokens
+    }
+
+    pub fn max_output_tokens(&self) -> Option<isize> {
+        self.data.max_output_tokens
+    }
+
     pub fn supports_vision(&self) -> bool {
-        self.capabilities.contains(ModelCapabilities::Vision)
+        self.data.supports_vision
+    }
+
+    pub fn supports_function_calling(&self) -> bool {
+        self.data.supports_function_calling
     }
 
     pub fn max_tokens_param(&self) -> Option<isize> {
-        if self.pass_max_tokens {
-            self.max_output_tokens
+        if self.data.pass_max_tokens {
+            self.data.max_output_tokens
         } else {
             None
         }
-    }
-
-    pub fn set_max_input_tokens(&mut self, max_input_tokens: Option<usize>) -> &mut Self {
-        match max_input_tokens {
-            None | Some(0) => self.max_input_tokens = None,
-            _ => self.max_input_tokens = max_input_tokens,
-        }
-        self
     }
 
     pub fn set_max_tokens(
@@ -136,43 +151,10 @@ impl Model {
         pass_max_tokens: bool,
     ) -> &mut Self {
         match max_output_tokens {
-            None | Some(0) => self.max_output_tokens = None,
-            _ => self.max_output_tokens = max_output_tokens,
+            None | Some(0) => self.data.max_output_tokens = None,
+            _ => self.data.max_output_tokens = max_output_tokens,
         }
-        self.pass_max_tokens = pass_max_tokens;
-        self
-    }
-
-    pub fn set_input_price(&mut self, input_price: Option<f64>) -> &mut Self {
-        match input_price {
-            None => self.input_price = None,
-            _ => self.input_price = input_price,
-        }
-        self
-    }
-
-    pub fn set_output_price(&mut self, output_price: Option<f64>) -> &mut Self {
-        match output_price {
-            None => self.output_price = None,
-            _ => self.output_price = output_price,
-        }
-        self
-    }
-
-    pub fn set_supports_vision(&mut self, supports_vision: bool) -> &mut Self {
-        if supports_vision {
-            self.capabilities |= ModelCapabilities::Vision;
-        } else {
-            self.capabilities &= !ModelCapabilities::Vision;
-        }
-        self
-    }
-
-    pub fn set_extra_fields(
-        &mut self,
-        extra_fields: &Option<serde_json::Map<String, serde_json::Value>>,
-    ) -> &mut Self {
-        self.extra_fields.clone_from(extra_fields);
+        self.data.pass_max_tokens = pass_max_tokens;
         self
     }
 
@@ -203,7 +185,7 @@ impl Model {
 
     pub fn max_input_tokens_limit(&self, messages: &[Message]) -> Result<()> {
         let total_tokens = self.total_tokens(messages) + BASIS_TOKENS;
-        if let Some(max_input_tokens) = self.max_input_tokens {
+        if let Some(max_input_tokens) = self.data.max_input_tokens {
             if total_tokens >= max_input_tokens {
                 bail!("Exceed max input tokens limit")
             }
@@ -212,7 +194,7 @@ impl Model {
     }
 
     pub fn merge_extra_fields(&self, body: &mut serde_json::Value) {
-        if let (Some(body), Some(extra_fields)) = (body.as_object_mut(), &self.extra_fields) {
+        if let (Some(body), Some(extra_fields)) = (body.as_object_mut(), &self.data.extra_fields) {
             for (key, extra_field) in extra_fields {
                 if body.contains_key(key) {
                     if let (Some(sub_body), Some(extra_field)) =
@@ -232,30 +214,33 @@ impl Model {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct ModelConfig {
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ModelData {
     pub name: String,
     pub max_input_tokens: Option<usize>,
     pub max_output_tokens: Option<isize>,
+    #[serde(default)]
+    pub pass_max_tokens: bool,
     pub input_price: Option<f64>,
     pub output_price: Option<f64>,
     #[serde(default)]
     pub supports_vision: bool,
     #[serde(default)]
-    pub pass_max_tokens: bool,
+    pub supports_function_calling: bool,
     pub extra_fields: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+impl ModelData {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct BuiltinModels {
     pub platform: String,
-    pub models: Vec<ModelConfig>,
-}
-
-bitflags::bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq)]
-    pub struct ModelCapabilities: u32 {
-        const Text = 0b00000001;
-        const Vision = 0b00000010;
-    }
+    pub models: Vec<ModelData>,
 }

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -143,7 +143,8 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
                     }
                     let content = content.join("\n\n");
                     json!({ "role": role, "content": content, "images": images })
-                }
+                },
+                MessageContent::ToolCall(_) => json!({}),
             }
         })
         .collect();

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -145,8 +145,8 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
                     }
                     let content = content.join("\n\n");
                     json!({ "role": role, "content": content, "images": images })
-                },
-                MessageContent::ToolCall(_) => {
+                }
+                MessageContent::ToolResults(_) => {
                     is_tool_call = true;
                     json!({ "role": role })
                 }

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -109,7 +109,9 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
         stream,
     } = data;
 
+    let mut is_tool_call = false;
     let mut network_image_urls = vec![];
+
     let messages: Vec<Value> = messages
         .into_iter()
         .map(|message| {
@@ -144,10 +146,17 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
                     let content = content.join("\n\n");
                     json!({ "role": role, "content": content, "images": images })
                 },
-                MessageContent::ToolCall(_) => json!({}),
+                MessageContent::ToolCall(_) => {
+                    is_tool_call = true;
+                    json!({ "role": role })
+                }
             }
         })
         .collect();
+
+    if is_tool_call {
+        bail!("The client does not support function calling",);
+    }
 
     if !network_image_urls.is_empty() {
         bail!(

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -1,5 +1,5 @@
 use super::{
-    catch_error, message::*, CompletionDetails, ExtraConfig, Model, ModelConfig, OllamaClient,
+    catch_error, message::*, CompletionOutput, ExtraConfig, Model, ModelData, OllamaClient,
     PromptAction, PromptKind, SendData, SseHandler,
 };
 
@@ -15,7 +15,7 @@ pub struct OllamaConfig {
     pub api_base: Option<String>,
     pub api_auth: Option<String>,
     pub chat_endpoint: Option<String>,
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -59,17 +59,18 @@ impl OllamaClient {
 
 impl_client_trait!(OllamaClient, send_message, send_message_streaming);
 
-async fn send_message(builder: RequestBuilder) -> Result<(String, CompletionDetails)> {
+async fn send_message(builder: RequestBuilder) -> Result<CompletionOutput> {
     let res = builder.send().await?;
     let status = res.status();
     let data = res.json().await?;
     if !status.is_success() {
         catch_error(&data, status.as_u16())?;
     }
+    debug!("non-stream-data: {data}");
     let text = data["message"]["content"]
         .as_str()
         .ok_or_else(|| anyhow!("Invalid response data: {data}"))?;
-    Ok((text.to_string(), CompletionDetails::default()))
+    Ok(CompletionOutput::new(text))
 }
 
 async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandler) -> Result<()> {
@@ -86,6 +87,7 @@ async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandle
                 continue;
             }
             let data: Value = serde_json::from_slice(&chunk)?;
+            debug!("stream-data: {data}");
             if data["done"].is_boolean() {
                 if let Some(text) = data["message"]["content"].as_str() {
                     handler.text(text)?;
@@ -103,6 +105,7 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
         messages,
         temperature,
         top_p,
+        functions: _,
         stream,
     } = data;
 
@@ -153,7 +156,7 @@ fn build_body(data: SendData, model: &Model) -> Result<Value> {
     }
 
     let mut body = json!({
-        "model": &model.name,
+        "model": &model.name(),
         "messages": messages,
         "stream": stream,
         "options": {},

--- a/src/client/openai_compatible.rs
+++ b/src/client/openai_compatible.rs
@@ -2,7 +2,7 @@ use crate::client::OPENAI_COMPATIBLE_PLATFORMS;
 
 use super::openai::openai_build_body;
 use super::{
-    ExtraConfig, Model, ModelConfig, OpenAICompatibleClient, PromptAction, PromptKind, SendData,
+    ExtraConfig, Model, ModelData, OpenAICompatibleClient, PromptAction, PromptKind, SendData,
 };
 
 use anyhow::Result;
@@ -16,7 +16,7 @@ pub struct OpenAICompatibleConfig {
     pub api_key: Option<String>,
     pub chat_endpoint: Option<String>,
     #[serde(default)]
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -44,7 +44,7 @@ impl OpenAICompatibleClient {
                 match OPENAI_COMPATIBLE_PLATFORMS
                     .into_iter()
                     .find_map(|(name, api_base)| {
-                        if name == self.model.client_name {
+                        if name == self.model.client_name() {
                             Some(api_base.to_string())
                         } else {
                             None

--- a/src/client/prompt_format.rs
+++ b/src/client/prompt_format.rs
@@ -108,7 +108,7 @@ pub fn generate_prompt(messages: &[Message], format: PromptFormat) -> anyhow::Re
                 }
                 parts.join("\n\n")
             }
-            MessageContent::ToolCall(_) => String::new(),
+            MessageContent::ToolResults(_) => String::new(),
         };
         match role {
             MessageRole::System => prompt.push_str(&format!(
@@ -120,7 +120,6 @@ pub fn generate_prompt(messages: &[Message], format: PromptFormat) -> anyhow::Re
             MessageRole::User => {
                 prompt.push_str(&format!("{user_pre_message}{content}{user_post_message}"))
             }
-            MessageRole::Tool => {}
         }
     }
     if !image_urls.is_empty() {

--- a/src/client/prompt_format.rs
+++ b/src/client/prompt_format.rs
@@ -108,6 +108,7 @@ pub fn generate_prompt(messages: &[Message], format: PromptFormat) -> anyhow::Re
                 }
                 parts.join("\n\n")
             }
+            MessageContent::ToolCall(_) => String::new(),
         };
         match role {
             MessageRole::System => prompt.push_str(&format!(
@@ -119,6 +120,7 @@ pub fn generate_prompt(messages: &[Message], format: PromptFormat) -> anyhow::Re
             MessageRole::User => {
                 prompt.push_str(&format!("{user_pre_message}{content}{user_post_message}"))
             }
+            MessageRole::Tool => {}
         }
     }
     if !image_urls.is_empty() {

--- a/src/client/qianwen.rs
+++ b/src/client/qianwen.rs
@@ -157,6 +157,7 @@ fn build_body(data: SendData, model: &Model, is_vl: bool) -> Result<(Value, bool
                             }
                         })
                         .collect(),
+                    MessageContent::ToolCall(_) => vec![],
                 };
                 json!({ "role": role, "content": content })
             })

--- a/src/client/qianwen.rs
+++ b/src/client/qianwen.rs
@@ -1,6 +1,6 @@
 use super::{
-    maybe_catch_error, message::*, sse_stream, Client, CompletionDetails, ExtraConfig, Model,
-    ModelConfig, PromptAction, PromptKind, QianwenClient, SendData, SsMmessage, SseHandler,
+    maybe_catch_error, message::*, sse_stream, Client, CompletionOutput, ExtraConfig, Model,
+    ModelData, PromptAction, PromptKind, QianwenClient, SendData, SsMmessage, SseHandler,
 };
 
 use crate::utils::{base64_decode, sha256};
@@ -26,7 +26,7 @@ pub struct QianwenConfig {
     pub name: Option<String>,
     pub api_key: Option<String>,
     #[serde(default)]
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -62,7 +62,7 @@ impl QianwenClient {
     }
 
     fn is_vl(&self) -> bool {
-        self.model.name.starts_with("qwen-vl")
+        self.model.name().starts_with("qwen-vl")
     }
 }
 
@@ -74,9 +74,9 @@ impl Client for QianwenClient {
         &self,
         client: &ReqwestClient,
         mut data: SendData,
-    ) -> Result<(String, CompletionDetails)> {
+    ) -> Result<CompletionOutput> {
         let api_key = self.get_api_key()?;
-        patch_messages(&self.model.name, &api_key, &mut data.messages).await?;
+        patch_messages(self.model.name(), &api_key, &mut data.messages).await?;
         let builder = self.request_builder(client, data)?;
         send_message(builder, self.is_vl()).await
     }
@@ -88,16 +88,17 @@ impl Client for QianwenClient {
         mut data: SendData,
     ) -> Result<()> {
         let api_key = self.get_api_key()?;
-        patch_messages(&self.model.name, &api_key, &mut data.messages).await?;
+        patch_messages(self.model.name(), &api_key, &mut data.messages).await?;
         let builder = self.request_builder(client, data)?;
         send_message_streaming(builder, handler, self.is_vl()).await
     }
 }
 
-async fn send_message(builder: RequestBuilder, is_vl: bool) -> Result<(String, CompletionDetails)> {
+async fn send_message(builder: RequestBuilder, is_vl: bool) -> Result<CompletionOutput> {
     let data: Value = builder.send().await?.json().await?;
     maybe_catch_error(&data)?;
 
+    debug!("non-stream-data: {data}");
     extract_completion_text(&data, is_vl)
 }
 
@@ -109,6 +110,7 @@ async fn send_message_streaming(
     let handle = |message: SsMmessage| -> Result<bool> {
         let data: Value = serde_json::from_str(&message.data)?;
         maybe_catch_error(&data)?;
+        debug!("stream-data: {data}");
         if is_vl {
             if let Some(text) =
                 data["output"]["choices"][0]["message"]["content"][0]["text"].as_str()
@@ -129,6 +131,7 @@ fn build_body(data: SendData, model: &Model, is_vl: bool) -> Result<(Value, bool
         messages,
         temperature,
         top_p,
+        functions: _,
         stream,
     } = data;
 
@@ -184,7 +187,7 @@ fn build_body(data: SendData, model: &Model, is_vl: bool) -> Result<(Value, bool
     }
 
     let body = json!({
-        "model": &model.name,
+        "model": &model.name(),
         "input": input,
         "parameters": parameters
     });
@@ -192,7 +195,7 @@ fn build_body(data: SendData, model: &Model, is_vl: bool) -> Result<(Value, bool
     Ok((body, has_upload))
 }
 
-fn extract_completion_text(data: &Value, is_vl: bool) -> Result<(String, CompletionDetails)> {
+fn extract_completion_text(data: &Value, is_vl: bool) -> Result<CompletionOutput> {
     let err = || anyhow!("Invalid response data: {data}");
     let text = if is_vl {
         data["output"]["choices"][0]["message"]["content"][0]["text"]
@@ -201,13 +204,15 @@ fn extract_completion_text(data: &Value, is_vl: bool) -> Result<(String, Complet
     } else {
         data["output"]["text"].as_str().ok_or_else(err)?
     };
-    let details = CompletionDetails {
+    let output = CompletionOutput {
+        text: text.to_string(),
+        tool_calls: vec![],
         id: data["request_id"].as_str().map(|v| v.to_string()),
         input_tokens: data["usage"]["input_tokens"].as_u64(),
         output_tokens: data["usage"]["output_tokens"].as_u64(),
     };
 
-    Ok((text.to_string(), details))
+    Ok(output)
 }
 
 /// Patch messages, upload embedded images to oss

--- a/src/client/qianwen.rs
+++ b/src/client/qianwen.rs
@@ -158,7 +158,7 @@ fn build_body(data: SendData, model: &Model, is_vl: bool) -> Result<(Value, bool
                             }
                         })
                         .collect(),
-                    MessageContent::ToolCall(_) => {
+                    MessageContent::ToolResults(_) => {
                         is_tool_call = true;
                         vec![]
                     }

--- a/src/client/qianwen.rs
+++ b/src/client/qianwen.rs
@@ -136,6 +136,7 @@ fn build_body(data: SendData, model: &Model, is_vl: bool) -> Result<(Value, bool
     } = data;
 
     let mut has_upload = false;
+    let mut is_tool_call = false;
     let input = if is_vl {
         let messages: Vec<Value> = messages
             .into_iter()
@@ -157,7 +158,10 @@ fn build_body(data: SendData, model: &Model, is_vl: bool) -> Result<(Value, bool
                             }
                         })
                         .collect(),
-                    MessageContent::ToolCall(_) => vec![],
+                    MessageContent::ToolCall(_) => {
+                        is_tool_call = true;
+                        vec![]
+                    }
                 };
                 json!({ "role": role, "content": content })
             })
@@ -171,6 +175,9 @@ fn build_body(data: SendData, model: &Model, is_vl: bool) -> Result<(Value, bool
             "messages": messages,
         })
     };
+    if is_tool_call {
+        bail!("The client does not support function calling",);
+    }
 
     let mut parameters = json!({});
     if stream {

--- a/src/client/sse_handler.rs
+++ b/src/client/sse_handler.rs
@@ -56,12 +56,11 @@ impl SseHandler {
         self.abort.clone()
     }
 
-    pub fn get_buffer(&self) -> &str {
-        &self.buffer
-    }
-
-    pub fn get_tool_calls(&self) -> &[ToolCall] {
-        &self.tool_calls
+    pub fn take(self) -> (String, Vec<ToolCall>) {
+        let Self {
+            buffer, tool_calls, ..
+        } = self;
+        (buffer, tool_calls)
     }
 
     fn safe_ret(&self, ret: Result<()>) -> Result<()> {

--- a/src/client/sse_handler.rs
+++ b/src/client/sse_handler.rs
@@ -3,10 +3,13 @@ use crate::utils::AbortSignal;
 use anyhow::{Context, Result};
 use tokio::sync::mpsc::UnboundedSender;
 
+use super::ToolCall;
+
 pub struct SseHandler {
     sender: UnboundedSender<SseEvent>,
-    buffer: String,
     abort: AbortSignal,
+    buffer: String,
+    tool_calls: Vec<ToolCall>,
 }
 
 impl SseHandler {
@@ -15,11 +18,12 @@ impl SseHandler {
             sender,
             abort,
             buffer: String::new(),
+            tool_calls: Vec::new(),
         }
     }
 
     pub fn text(&mut self, text: &str) -> Result<()> {
-        // debug!("ReplyText: {}", text);
+        // debug!("HandleText: {}", text);
         if text.is_empty() {
             return Ok(());
         }
@@ -33,7 +37,7 @@ impl SseHandler {
     }
 
     pub fn done(&mut self) -> Result<()> {
-        // debug!("ReplyDone");
+        // debug!("HandleDone");
         let ret = self
             .sender
             .send(SseEvent::Done)
@@ -42,12 +46,22 @@ impl SseHandler {
         Ok(())
     }
 
-    pub fn get_buffer(&self) -> &str {
-        &self.buffer
+    pub fn tool_call(&mut self, call: ToolCall) -> Result<()> {
+        // debug!("HandleCall: {:?}", call);
+        self.tool_calls.push(call);
+        Ok(())
     }
 
     pub fn get_abort(&self) -> AbortSignal {
         self.abort.clone()
+    }
+
+    pub fn get_buffer(&self) -> &str {
+        &self.buffer
+    }
+
+    pub fn get_tool_calls(&self) -> &[ToolCall] {
+        &self.tool_calls
     }
 
     fn safe_ret(&self, ret: Result<()>) -> Result<()> {

--- a/src/client/vertexai.rs
+++ b/src/client/vertexai.rs
@@ -1,8 +1,7 @@
-use super::access_token::*;
+use super::{access_token::*, ToolCall};
 use super::{
-    catch_error, json_stream, message::*, patch_system_message, Client, CompletionDetails,
-    ExtraConfig, Model, ModelConfig, PromptAction, PromptKind, SendData, SseHandler,
-    VertexAIClient,
+    catch_error, json_stream, message::*, patch_system_message, Client, CompletionOutput,
+    ExtraConfig, Model, ModelData, PromptAction, PromptKind, SendData, SseHandler, VertexAIClient,
 };
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -22,7 +21,7 @@ pub struct VertexAIConfig {
     #[serde(rename = "safetySettings")]
     pub safety_settings: Option<Value>,
     #[serde(default)]
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -46,7 +45,7 @@ impl VertexAIClient {
             true => "streamGenerateContent",
             false => "generateContent",
         };
-        let url = format!("{base_url}/google/models/{}:{func}", self.model.name);
+        let url = format!("{base_url}/google/models/{}:{func}", self.model.name());
 
         let body = gemini_build_body(data, &self.model, self.config.safety_settings.clone())?;
 
@@ -66,7 +65,7 @@ impl Client for VertexAIClient {
         &self,
         client: &ReqwestClient,
         data: SendData,
-    ) -> Result<(String, CompletionDetails)> {
+    ) -> Result<CompletionOutput> {
         prepare_gcloud_access_token(client, self.name(), &self.config.adc_file).await?;
         let builder = self.request_builder(client, data)?;
         gemini_send_message(builder).await
@@ -84,13 +83,14 @@ impl Client for VertexAIClient {
     }
 }
 
-pub async fn gemini_send_message(builder: RequestBuilder) -> Result<(String, CompletionDetails)> {
+pub async fn gemini_send_message(builder: RequestBuilder) -> Result<CompletionOutput> {
     let res = builder.send().await?;
     let status = res.status();
     let data: Value = res.json().await?;
     if !status.is_success() {
         catch_error(&data, status.as_u16())?;
     }
+    debug!("non-stream-data: {data}");
     gemini_extract_completion_text(&data)
 }
 
@@ -105,8 +105,28 @@ pub async fn gemini_send_message_streaming(
         catch_error(&data, status.as_u16())?;
     } else {
         let handle = |value: &str| -> Result<()> {
-            let value: Value = serde_json::from_str(value)?;
-            handler.text(gemini_extract_text(&value)?)?;
+            let data: Value = serde_json::from_str(value)?;
+            debug!("stream-data: {data}");
+            if let Some(text) = data["candidates"][0]["content"]["parts"][0]["text"].as_str() {
+                if !text.is_empty() {
+                    handler.text(text)?;
+                }
+            } else if let Some("SAFETY") = data["promptFeedback"]["blockReason"]
+                .as_str()
+                .or_else(|| data["candidates"][0]["finishReason"].as_str())
+            {
+                bail!("Content Blocked")
+            } else if let Some(parts) = data["candidates"][0]["content"]["parts"].as_array() {
+                for part in parts {
+                    if let (Some(name), Some(args)) = (
+                        part["functionCall"]["name"].as_str(),
+                        part["functionCall"]["args"].as_object(),
+                    ) {
+                        handler.tool_call(ToolCall::new(name.to_string(), json!(args)))?;
+                    }
+                }
+            }
+
             Ok(())
         };
         json_stream(res.bytes_stream(), handle).await?;
@@ -114,30 +134,46 @@ pub async fn gemini_send_message_streaming(
     Ok(())
 }
 
-fn gemini_extract_completion_text(data: &Value) -> Result<(String, CompletionDetails)> {
-    let text = gemini_extract_text(data)?;
-    let details = CompletionDetails {
+fn gemini_extract_completion_text(data: &Value) -> Result<CompletionOutput> {
+    let text = data["candidates"][0]["content"]["parts"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+
+    let tool_calls = if let Some(parts) = data["candidates"][0]["content"]["parts"].as_array() {
+        parts
+            .iter()
+            .filter_map(|part| {
+                if let (Some(name), Some(args)) = (
+                    part["functionCall"]["name"].as_str(),
+                    part["functionCall"]["args"].as_object(),
+                ) {
+                    Some(ToolCall::new(name.to_string(), json!(args)))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+    if text.is_empty() && tool_calls.is_empty() {
+        if let Some("SAFETY") = data["promptFeedback"]["blockReason"]
+            .as_str()
+            .or_else(|| data["candidates"][0]["finishReason"].as_str())
+        {
+            bail!("Content Blocked")
+        } else {
+            bail!("Invalid response data: {data}");
+        }
+    }
+    let output = CompletionOutput {
+        text: text.to_string(),
+        tool_calls,
         id: None,
         input_tokens: data["usageMetadata"]["promptTokenCount"].as_u64(),
         output_tokens: data["usageMetadata"]["candidatesTokenCount"].as_u64(),
     };
-    Ok((text.to_string(), details))
-}
-
-fn gemini_extract_text(data: &Value) -> Result<&str> {
-    match data["candidates"][0]["content"]["parts"][0]["text"].as_str() {
-        Some(text) => Ok(text),
-        None => {
-            if let Some("SAFETY") = data["promptFeedback"]["blockReason"]
-                .as_str()
-                .or_else(|| data["candidates"][0]["finishReason"].as_str())
-            {
-                bail!("Blocked by safety settings，consider adjusting `safetySettings` in the client configuration")
-            } else {
-                bail!("Invalid response data: {data}")
-            }
-        }
-    }
+    Ok(output)
 }
 
 pub(crate) fn gemini_build_body(
@@ -149,6 +185,7 @@ pub(crate) fn gemini_build_body(
         mut messages,
         temperature,
         top_p,
+        functions,
         stream: _,
     } = data;
 
@@ -209,6 +246,10 @@ pub(crate) fn gemini_build_body(
     }
     if let Some(v) = top_p {
         body["generationConfig"]["topP"] = v.into();
+    }
+
+    if let Some(functions) = functions {
+        body["tools"] = json!([{ "functionDeclarations": *functions }]);
     }
 
     Ok(body)

--- a/src/client/vertexai_claude.rs
+++ b/src/client/vertexai_claude.rs
@@ -2,7 +2,7 @@ use super::access_token::*;
 use super::claude::{claude_build_body, claude_send_message, claude_send_message_streaming};
 use super::vertexai::prepare_gcloud_access_token;
 use super::{
-    Client, CompletionDetails, ExtraConfig, Model, ModelConfig, PromptAction, PromptKind, SendData,
+    Client, CompletionOutput, ExtraConfig, Model, ModelData, PromptAction, PromptKind, SendData,
     SseHandler, VertexAIClaudeClient,
 };
 
@@ -18,7 +18,7 @@ pub struct VertexAIClaudeConfig {
     pub location: Option<String>,
     pub adc_file: Option<String>,
     #[serde(default)]
-    pub models: Vec<ModelConfig>,
+    pub models: Vec<ModelData>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -39,7 +39,7 @@ impl VertexAIClaudeClient {
         let base_url = format!("https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/publishers");
         let url = format!(
             "{base_url}/anthropic/models/{}:streamRawPredict",
-            self.model.name
+            self.model.name()
         );
 
         let mut body = claude_build_body(data, &self.model)?;
@@ -64,7 +64,7 @@ impl Client for VertexAIClaudeClient {
         &self,
         client: &ReqwestClient,
         data: SendData,
-    ) -> Result<(String, CompletionDetails)> {
+    ) -> Result<CompletionOutput> {
         prepare_gcloud_access_token(client, self.name(), &self.config.adc_file).await?;
         let builder = self.request_builder(client, data)?;
         claude_send_message(builder).await

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -120,7 +120,13 @@ impl Input {
         output: String,
         tool_call_results: Vec<ToolCallResult>,
     ) -> Self {
-        self.tool_call = Some((tool_call_results, output));
+        match self.tool_call.as_mut() {
+            Some(exist_tool_call_results) => {
+                exist_tool_call_results.0.extend(tool_call_results);
+                exist_tool_call_results.1 = output;
+            }
+            None => self.tool_call = Some((tool_call_results, output)),
+        }
         self
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,6 +10,7 @@ use crate::client::{
     create_client_config, list_client_types, list_models, ClientConfig, Model,
     OPENAI_COMPATIBLE_PLATFORMS,
 };
+use crate::function::Function;
 use crate::render::{MarkdownRender, RenderOptions};
 use crate::utils::{
     format_option_value, fuzzy_match, get_env_name, light_theme_from_colorfgbg, now, render_prompt,
@@ -41,6 +42,7 @@ const CONFIG_FILE_NAME: &str = "config.yaml";
 const ROLES_FILE_NAME: &str = "roles.yaml";
 const MESSAGES_FILE_NAME: &str = "messages.md";
 const SESSIONS_DIR_NAME: &str = "sessions";
+const FUNCTIONS_DIR_NAME: &str = "functions";
 
 const CLIENTS_FIELD: &str = "clients";
 
@@ -69,6 +71,7 @@ pub struct Config {
     pub keybindings: Keybindings,
     pub prelude: Option<String>,
     pub buffer_editor: Option<String>,
+    pub function_calling: bool,
     pub compress_threshold: usize,
     pub summarize_prompt: Option<String>,
     pub summary_prompt: Option<String>,
@@ -83,6 +86,8 @@ pub struct Config {
     pub session: Option<Session>,
     #[serde(skip)]
     pub model: Model,
+    #[serde(skip)]
+    pub function: Function,
     #[serde(skip)]
     pub working_mode: WorkingMode,
     #[serde(skip)]
@@ -106,6 +111,7 @@ impl Default for Config {
             keybindings: Default::default(),
             prelude: None,
             buffer_editor: None,
+            function_calling: false,
             compress_threshold: 2000,
             summarize_prompt: None,
             summary_prompt: None,
@@ -116,6 +122,7 @@ impl Default for Config {
             role: None,
             session: None,
             model: Default::default(),
+            function: Default::default(),
             working_mode: WorkingMode::Command,
             last_message: None,
         }
@@ -141,6 +148,8 @@ impl Config {
         if let Some(wrap) = config.wrap.clone() {
             config.set_wrap(&wrap)?;
         }
+
+        config.function = Function::init(&Self::functions_dir()?)?;
 
         config.working_mode = working_mode;
         config.load_roles()?;
@@ -215,7 +224,7 @@ impl Config {
     pub fn save_message(&mut self, input: Input, output: &str) -> Result<()> {
         self.last_message = Some((input.clone(), output.to_string()));
 
-        if self.dry_run {
+        if self.dry_run || output.is_empty() {
             return Ok(());
         }
 
@@ -273,6 +282,10 @@ impl Config {
 
     pub fn sessions_dir() -> Result<PathBuf> {
         Self::local_path(SESSIONS_DIR_NAME)
+    }
+
+    pub fn functions_dir() -> Result<PathBuf> {
+        Self::local_path(FUNCTIONS_DIR_NAME)
     }
 
     pub fn session_file(name: &str) -> Result<PathBuf> {
@@ -428,6 +441,8 @@ impl Config {
             ),
             ("temperature", format_option_value(&temperature)),
             ("top_p", format_option_value(&top_p)),
+            ("function_calling", self.function_calling.to_string()),
+            ("compress_threshold", self.compress_threshold.to_string()),
             ("dry_run", self.dry_run.to_string()),
             ("save", self.save.to_string()),
             ("save_session", format_option_value(&self.save_session)),
@@ -438,11 +453,11 @@ impl Config {
             ("auto_copy", self.auto_copy.to_string()),
             ("keybindings", self.keybindings.stringify().into()),
             ("prelude", format_option_value(&self.prelude)),
-            ("compress_threshold", self.compress_threshold.to_string()),
             ("config_file", display_path(&Self::config_file()?)),
             ("roles_file", display_path(&Self::roles_file()?)),
             ("messages_file", display_path(&Self::messages_file()?)),
             ("sessions_dir", display_path(&Self::sessions_dir()?)),
+            ("functions_dir", display_path(&Self::functions_dir()?)),
         ];
         let output = items
             .iter()
@@ -508,6 +523,7 @@ impl Config {
                     "max_output_tokens",
                     "temperature",
                     "top_p",
+                    "function_calling",
                     "compress_threshold",
                     "save",
                     "save_session",
@@ -523,10 +539,11 @@ impl Config {
             (values, args[0])
         } else if args.len() == 2 {
             let values = match args[0] {
-                "max_output_tokens" => match self.model.max_output_tokens {
+                "max_output_tokens" => match self.model.max_output_tokens() {
                     Some(v) => vec![v.to_string()],
                     None => vec![],
                 },
+                "function_calling" => complete_bool(self.function_calling),
                 "save" => complete_bool(self.save),
                 "save_session" => {
                     let save_session = if let Some(session) = &self.session {
@@ -573,6 +590,10 @@ impl Config {
             "top_p" => {
                 let value = parse_value(value)?;
                 self.set_top_p(value);
+            }
+            "function_calling" => {
+                let value = value.parse().with_context(|| "Invalid value")?;
+                self.function_calling = value;
             }
             "compress_threshold" => {
                 let value = parse_value(value)?;
@@ -792,11 +813,14 @@ impl Config {
     fn generate_prompt_context(&self) -> HashMap<&str, String> {
         let mut output = HashMap::new();
         output.insert("model", self.model.id());
-        output.insert("client_name", self.model.client_name.clone());
-        output.insert("model_name", self.model.name.clone());
+        output.insert("client_name", self.model.client_name().to_string());
+        output.insert("model_name", self.model.name().to_string());
         output.insert(
             "max_input_tokens",
-            self.model.max_input_tokens.unwrap_or_default().to_string(),
+            self.model
+                .max_input_tokens()
+                .unwrap_or_default()
+                .to_string(),
         );
         if let Some(temperature) = self.temperature {
             if temperature != 0.0 {
@@ -884,8 +908,8 @@ impl Config {
     }
 
     fn load_config_file(config_path: &Path) -> Result<Self> {
-        let ctx = || format!("Failed to load config at {}", config_path.display());
-        let content = read_to_string(config_path).with_context(ctx)?;
+        let content = read_to_string(config_path)
+            .with_context(|| format!("Failed to load config at {}", config_path.display()))?;
         let config: Self = serde_yaml::from_str(&content).map_err(|err| {
             let err_msg = err.to_string();
             let err_msg = if err_msg.starts_with(&format!("{}: ", CLIENTS_FIELD)) {

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -124,7 +124,7 @@ impl Session {
             data["save_session"] = save_session.into();
         }
         data["total_tokens"] = tokens.into();
-        if let Some(context_window) = self.model.max_input_tokens {
+        if let Some(context_window) = self.model.max_input_tokens() {
             data["max_input_tokens"] = context_window.into();
         }
         if percent != 0.0 {
@@ -161,7 +161,7 @@ impl Session {
             items.push(("compress_threshold", compress_threshold.to_string()));
         }
 
-        if let Some(max_input_tokens) = self.model.max_input_tokens {
+        if let Some(max_input_tokens) = self.model.max_input_tokens() {
             items.push(("max_input_tokens", max_input_tokens.to_string()));
         }
 
@@ -202,7 +202,7 @@ impl Session {
 
     pub fn tokens_and_percent(&self) -> (usize, f32) {
         let tokens = self.tokens();
-        let max_input_tokens = self.model.max_input_tokens.unwrap_or_default();
+        let max_input_tokens = self.model.max_input_tokens().unwrap_or_default();
         let percent = if max_input_tokens == 0 {
             0.0
         } else {

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -1,5 +1,5 @@
 use super::input::resolve_data_url;
-use super::{Config, Input, Model};
+use super::{Config, Input, Model, Role};
 
 use crate::client::{Message, MessageContent, MessageRole};
 use crate::render::MarkdownRender;
@@ -17,15 +17,20 @@ pub const TEMP_SESSION_NAME: &str = "temp";
 pub struct Session {
     #[serde(rename(serialize = "model", deserialize = "model"))]
     model_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     top_p: Option<f64>,
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    function_filter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     save_session: Option<bool>,
     messages: Vec<Message>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     data_urls: HashMap<String, String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     compressed_messages: Vec<Message>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     compress_threshold: Option<usize>,
     #[serde(skip)]
     pub name: String,
@@ -41,13 +46,14 @@ pub struct Session {
 
 impl Session {
     pub fn new(config: &Config, name: &str) -> Self {
-        Self {
+        let mut session = Self {
             model_id: config.model.id(),
             temperature: config.temperature,
             top_p: config.top_p,
+            function_filter: None,
             save_session: config.save_session,
-            messages: vec![],
-            compressed_messages: vec![],
+            messages: Default::default(),
+            compressed_messages: Default::default(),
             compress_threshold: None,
             data_urls: Default::default(),
             name: name.to_string(),
@@ -55,7 +61,11 @@ impl Session {
             dirty: false,
             compressing: false,
             model: config.model.clone(),
+        };
+        if let Some(role) = &config.role {
+            session.set_role_properties(role);
         }
+        session
     }
 
     pub fn load(name: &str, path: &Path) -> Result<Self> {
@@ -84,6 +94,10 @@ impl Session {
 
     pub fn top_p(&self) -> Option<f64> {
         self.top_p
+    }
+
+    pub fn function_filter(&self) -> Option<&str> {
+        self.function_filter.as_deref()
     }
 
     pub fn save_session(&self) -> Option<bool> {
@@ -120,12 +134,15 @@ impl Session {
         if let Some(top_p) = self.top_p() {
             data["top_p"] = top_p.into();
         }
+        if let Some(function_filter) = self.function_filter() {
+            data["function_filter"] = function_filter.into();
+        }
         if let Some(save_session) = self.save_session() {
             data["save_session"] = save_session.into();
         }
         data["total_tokens"] = tokens.into();
-        if let Some(context_window) = self.model.max_input_tokens() {
-            data["max_input_tokens"] = context_window.into();
+        if let Some(max_input_tokens) = self.model.max_input_tokens() {
+            data["max_input_tokens"] = max_input_tokens.into();
         }
         if percent != 0.0 {
             data["total/max"] = format!("{}%", percent).into();
@@ -151,6 +168,10 @@ impl Session {
         }
         if let Some(top_p) = self.top_p() {
             items.push(("top_p", top_p.to_string()));
+        }
+
+        if let Some(function_filter) = self.function_filter() {
+            items.push(("function_filter", function_filter.into()));
         }
 
         if let Some(save_session) = self.save_session() {
@@ -192,6 +213,7 @@ impl Session {
                             message.content.render_input(resolve_url_fn)
                         ));
                     }
+                    MessageRole::Tool => {}
                 }
             }
         }
@@ -226,6 +248,16 @@ impl Session {
         }
     }
 
+    pub fn set_functions(&mut self, function_filter: Option<&str>) {
+        self.function_filter = function_filter.map(|v| v.to_string());
+    }
+
+    pub fn set_role_properties(&mut self, role: &Role) {
+        self.set_temperature(role.temperature);
+        self.set_top_p(role.top_p);
+        self.set_functions(role.function_filter.as_deref());
+    }
+
     pub fn set_save_session(&mut self, value: Option<bool>) {
         if self.save_session != value {
             self.save_session = value;
@@ -251,10 +283,10 @@ impl Session {
 
     pub fn compress(&mut self, prompt: String) {
         self.compressed_messages.append(&mut self.messages);
-        self.messages.push(Message {
-            role: MessageRole::System,
-            content: MessageContent::Text(prompt),
-        });
+        self.messages.push(Message::new(
+            MessageRole::System,
+            MessageContent::Text(prompt),
+        ));
         self.dirty = true;
     }
 
@@ -300,16 +332,14 @@ impl Session {
             }
         }
         if need_add_msg {
-            self.messages.push(Message {
-                role: MessageRole::User,
-                content: input.to_message_content(),
-            });
+            self.messages
+                .push(Message::new(MessageRole::User, input.message_content()));
         }
         self.data_urls.extend(input.data_urls());
-        self.messages.push(Message {
-            role: MessageRole::Assistant,
-            content: MessageContent::Text(output.to_string()),
-        });
+        self.messages.push(Message::new(
+            MessageRole::Assistant,
+            MessageContent::Text(output.to_string()),
+        ));
         self.dirty = true;
         Ok(())
     }
@@ -340,10 +370,7 @@ impl Session {
                 .extend(self.compressed_messages[self.compressed_messages.len() - 2..].to_vec());
         }
         if need_add_msg {
-            messages.push(Message {
-                role: MessageRole::User,
-                content: input.to_message_content(),
-            });
+            messages.push(Message::new(MessageRole::User, input.message_content()));
         }
         messages
     }

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -213,7 +213,6 @@ impl Session {
                             message.content.render_input(resolve_url_fn)
                         ));
                     }
-                    MessageRole::Tool => {}
                 }
             }
         }

--- a/src/function.rs
+++ b/src/function.rs
@@ -228,14 +228,14 @@ impl ToolCall {
             };
             if proceed {
                 #[cfg(windows)]
-                let name = polyfill_cmd_name(name, &config.read().function.bin_dir);
+                let name = polyfill_cmd_name(&name, &config.read().function.bin_dir);
                 spawn_command(&name, &arguments, envs)?;
             }
             None
         } else {
             println!("{}", dimmed_text(&prompt_text));
             #[cfg(windows)]
-            let name = polyfill_cmd_name(name, &config.read().function.bin_dir);
+            let name = polyfill_cmd_name(&name, &config.read().function.bin_dir);
             let (success, stdout, stderr) = exec_command(&name, &arguments, envs)?;
             if stderr.is_empty() {
                 eprintln!("{}", error_text(&stderr));

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,5 +1,4 @@
 use crate::{
-    client::{MessageToolCall, MessageToolCallFunction},
     config::GlobalConfig,
     utils::{dimmed_text, error_text, exec_command, spawn_command},
 };
@@ -21,6 +20,8 @@ const DECLARATIONS_FILE_PATH: &str = "functions.json";
 lazy_static! {
     static ref THREAD_POOL: ThreadPool = ThreadPool::new(num_cpus::get());
 }
+
+pub type ToolResults = (Vec<ToolCallResult>, String);
 
 pub fn run_tool_calls(config: &GlobalConfig, calls: Vec<ToolCall>) -> Result<Vec<ToolCallResult>> {
     let mut output = vec![];
@@ -67,17 +68,6 @@ pub struct ToolCallResult {
 impl ToolCallResult {
     pub fn new(call: ToolCall, output: Value) -> Self {
         Self { call, output }
-    }
-
-    pub fn build_message(&self) -> MessageToolCall {
-        MessageToolCall {
-            id: self.call.id.clone(),
-            typ: "function".into(),
-            function: MessageToolCallFunction {
-                name: self.call.name.clone(),
-                arguments: self.call.arguments.clone(),
-            },
-        }
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,0 +1,216 @@
+use crate::{config::GlobalConfig, utils::exec_command};
+
+use anyhow::{anyhow, bail, Context, Result};
+use fancy_regex::Regex;
+use indexmap::{IndexMap, IndexSet};
+use inquire::Confirm;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{collections::HashMap, fs, path::Path};
+
+const BIN_DIR_NAME: &str = "bin";
+const DECLARATIONS_FILE_PATH: &str = "functions.json";
+
+pub fn run_tool_calls(config: &GlobalConfig, calls: &[ToolCall]) -> Result<()> {
+    for call in calls {
+        call.run(config)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Function {
+    names: IndexSet<String>,
+    declarations: Vec<FunctionDeclaration>,
+    env_path: Option<String>,
+}
+
+impl Function {
+    pub fn init(functions_dir: &Path) -> Result<Self> {
+        let bin_dir = functions_dir.join(BIN_DIR_NAME);
+        let env_path = if bin_dir.exists() {
+            prepend_env_path(&bin_dir).ok()
+        } else {
+            None
+        };
+
+        let declarations_file = functions_dir.join(DECLARATIONS_FILE_PATH);
+
+        let declarations: Vec<FunctionDeclaration> = if declarations_file.exists() {
+            let ctx = || {
+                format!(
+                    "Failed to load function declarations at {}",
+                    declarations_file.display()
+                )
+            };
+            let content = fs::read_to_string(&declarations_file).with_context(ctx)?;
+            serde_json::from_str(&content).with_context(ctx)?
+        } else {
+            vec![]
+        };
+
+        let func_names = declarations.iter().map(|v| v.name.clone()).collect();
+
+        Ok(Self {
+            names: func_names,
+            declarations,
+            env_path,
+        })
+    }
+
+    pub fn filtered_declarations(&self, filters: &[String]) -> Vec<FunctionDeclaration> {
+        if filters.is_empty() {
+            vec![]
+        } else if filters.len() == 1 && filters[0] == "*" {
+            self.declarations.clone()
+        } else if let Ok(re) = Regex::new(&filters.join("|")) {
+            self.declarations
+                .iter()
+                .filter(|v| re.is_match(&v.name).unwrap_or_default())
+                .cloned()
+                .collect()
+        } else {
+            vec![]
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FunctionConfig {
+    pub enable: bool,
+    pub declarations_file: String,
+    pub functions_dir: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionDeclaration {
+    pub name: String,
+    pub description: String,
+    pub parameters: JsonSchema,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonSchema {
+    #[serde(rename = "type")]
+    pub type_value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<IndexMap<String, JsonSchema>>,
+    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    pub enum_value: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ToolCall {
+    pub name: String,
+    pub args: Value,
+}
+
+impl ToolCall {
+    pub fn new(name: String, args: Value) -> Self {
+        Self { name, args }
+    }
+
+    pub fn run(&self, config: &GlobalConfig) -> Result<()> {
+        let name = &self.name;
+        if !config.read().function.names.contains(name) {
+            bail!("Invalid call: {name} {}", self.args);
+        }
+        let args = if self.args.is_object() {
+            self.args.clone()
+        } else if let Some(args) = self.args.as_str() {
+            let args: Value =
+                serde_json::from_str(args).map_err(|_| anyhow!("Invalid call args: {args}"))?;
+            args
+        } else {
+            bail!("Invalid call args: {}", self.args);
+        };
+        let args = convert_args(&args);
+
+        let prompt_text = format!(
+            "call {} {}",
+            name,
+            args.iter()
+                .map(|v| shell_words::quote(v).to_string())
+                .collect::<Vec<String>>()
+                .join(" ")
+        );
+
+        let envs = if let Some(env_path) = config.read().function.env_path.clone() {
+            let mut envs = HashMap::new();
+            envs.insert("PATH".into(), env_path);
+            Some(envs)
+        } else {
+            None
+        };
+
+        let ans = Confirm::new(&prompt_text).with_default(true).prompt()?;
+        if ans {
+            exec_command(name, &args, envs)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn convert_args(args: &Value) -> Vec<String> {
+    let mut options: Vec<String> = Vec::new();
+
+    if let Value::Object(map) = args {
+        for (key, value) in map {
+            let key = key.replace('_', "-");
+            match value {
+                Value::Bool(true) => {
+                    options.push(format!("--{key}"));
+                }
+                Value::String(s) => {
+                    options.push(format!("--{key}"));
+                    options.push(s.to_string());
+                }
+                Value::Array(arr) => {
+                    for item in arr {
+                        if let Value::String(s) = item {
+                            options.push(format!("--{key}"));
+                            options.push(s.to_string());
+                        }
+                    }
+                }
+                _ => {} // Ignore other types
+            }
+        }
+    }
+    options
+}
+
+fn prepend_env_path(bin_dir: &Path) -> Result<String> {
+    let current_path = std::env::var("PATH").context("No PATH environment variable")?;
+
+    let new_path = if cfg!(target_os = "windows") {
+        format!("{};{}", bin_dir.display(), current_path)
+    } else {
+        format!("{}:{}", bin_dir.display(), current_path)
+    };
+    Ok(new_path)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_convert_args() {
+        let args = serde_json::json!({
+          "foo": true,
+          "bar": "val",
+          "baz": ["v1", "v2"]
+        });
+        assert_eq!(
+            convert_args(&args),
+            vec!["--foo", "--bar", "val", "--baz", "v1", "--baz", "v2"]
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use crate::utils::{create_abort_signal, extract_block, run_spinner, spawn_comman
 use anyhow::{bail, Result};
 use async_recursion::async_recursion;
 use clap::Parser;
+use function::need_send_call_results;
 use inquire::{Select, Text};
 use is_terminal::IsTerminal;
 use parking_lot::RwLock;
@@ -174,7 +175,7 @@ async fn start_directive(
         .write()
         .save_message(&input, &output, &tool_call_results)?;
     config.write().end_session()?;
-    if !tool_call_results.is_empty() {
+    if need_send_call_results(&tool_call_results) {
         start_directive(
             config,
             input.merge_tool_call(output, tool_call_results),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use crate::config::{
     Config, GlobalConfig, Input, InputContext, WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE,
     SHELL_ROLE,
 };
-use crate::function::run_tool_calls;
+use crate::function::eval_tool_calls;
 use crate::render::{render_error, MarkdownRender};
 use crate::repl::Repl;
 use crate::utils::{create_abort_signal, extract_block, run_spinner, spawn_command, CODE_BLOCK_RE};
@@ -150,7 +150,7 @@ async fn start_directive(
             text, tool_calls, ..
         } = client.send_message(input.clone()).await?;
         if !tool_calls.is_empty() {
-            (String::new(), run_tool_calls(config, tool_calls)?)
+            (String::new(), eval_tool_calls(config, tool_calls)?)
         } else {
             let text = if extract_code && text.trim_start().starts_with("```") {
                 extract_block(&text)

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use crate::config::{
 use crate::function::eval_tool_calls;
 use crate::render::{render_error, MarkdownRender};
 use crate::repl::Repl;
-use crate::utils::{create_abort_signal, extract_block, run_spinner, spawn_command, CODE_BLOCK_RE};
+use crate::utils::{create_abort_signal, extract_block, run_command, run_spinner, CODE_BLOCK_RE};
 
 use anyhow::{bail, Result};
 use async_recursion::async_recursion;
@@ -234,7 +234,7 @@ async fn shell_execute(
             match answer {
                 "✅ Execute" => {
                     debug!("{} {:?}", shell, &[shell_arg, &eval_str]);
-                    let code = spawn_command(shell, &[shell_arg, &eval_str], None)?;
+                    let code = run_command(shell, &[shell_arg, &eval_str], None)?;
                     if code != 0 {
                         process::exit(code);
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ async fn start_directive(
     if !tool_call_results.is_empty() {
         start_directive(
             config,
-            Input::tool_call(input, tool_call_results),
+            input.merge_tool_call(output, tool_call_results),
             no_stream,
             code_mode,
         )

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,12 +4,11 @@ mod stream;
 pub use self::markdown::{MarkdownRender, RenderOptions};
 use self::stream::{markdown_stream, raw_stream};
 
-use crate::utils::AbortSignal;
+use crate::utils::{error_text, AbortSignal};
 use crate::{client::SseEvent, config::GlobalConfig};
 
 use anyhow::Result;
 use is_terminal::IsTerminal;
-use nu_ansi_term::{Color, Style};
 use std::io::stdout;
 use tokio::sync::mpsc::UnboundedReceiver;
 
@@ -30,8 +29,7 @@ pub async fn render_stream(
 pub fn render_error(err: anyhow::Error, highlight: bool) {
     let err = format!("{err:?}");
     if highlight {
-        let style = Style::new().fg(Color::Red);
-        eprintln!("{}", style.paint(err));
+        eprintln!("{}", error_text(&err));
     } else {
         eprintln!("{err}");
     }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -420,7 +420,12 @@ async fn ask(config: &GlobalConfig, abort: AbortSignal, input: Input) -> Result<
     if tool_call_results.is_empty() {
         Ok(())
     } else {
-        ask(config, abort, input.tool_call(tool_call_results)).await
+        ask(
+            config,
+            abort,
+            input.merge_tool_call(output, tool_call_results),
+        )
+        .await
     }
 }
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -8,6 +8,7 @@ use self::prompt::ReplPrompt;
 
 use crate::client::send_stream;
 use crate::config::{GlobalConfig, Input, InputContext, State};
+use crate::function::need_send_call_results;
 use crate::render::render_error;
 use crate::utils::{create_abort_signal, set_text, AbortSignal};
 
@@ -417,15 +418,15 @@ async fn ask(config: &GlobalConfig, abort: AbortSignal, input: Input) -> Result<
             config.write().end_compressing_session();
         });
     }
-    if tool_call_results.is_empty() {
-        Ok(())
-    } else {
+    if need_send_call_results(&tool_call_results) {
         ask(
             config,
             abort,
             input.merge_tool_call(output, tool_call_results),
         )
         .await
+    } else {
+        Ok(())
     }
 }
 

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -1,0 +1,65 @@
+use std::{collections::HashMap, env, ffi::OsStr, process::Command};
+
+pub fn detect_os() -> String {
+    let os = env::consts::OS;
+    if os == "linux" {
+        if let Ok(contents) = std::fs::read_to_string("/etc/os-release") {
+            for line in contents.lines() {
+                if let Some(id) = line.strip_prefix("ID=") {
+                    return format!("{os}/{id}");
+                }
+            }
+        }
+    }
+    os.to_string()
+}
+
+pub fn detect_shell() -> (String, String, &'static str) {
+    let os = env::consts::OS;
+    if os == "windows" {
+        if env::var("NU_VERSION").is_ok() {
+            ("nushell".into(), "nu.exe".into(), "-c")
+        } else if let Some(ret) = env::var("PSModulePath").ok().and_then(|v| {
+            let v = v.to_lowercase();
+            if v.split(';').count() >= 3 {
+                if v.contains("powershell\\7\\") {
+                    Some(("pwsh".into(), "pwsh.exe".into(), "-c"))
+                } else {
+                    Some(("powershell".into(), "powershell.exe".into(), "-Command"))
+                }
+            } else {
+                None
+            }
+        }) {
+            ret
+        } else {
+            ("cmd".into(), "cmd.exe".into(), "/C")
+        }
+    } else if env::var("NU_VERSION").is_ok() {
+        ("nushell".into(), "nu".into(), "-c")
+    } else {
+        let shell_cmd = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let shell_name = match shell_cmd.rsplit_once('/') {
+            Some((_, name)) => name.to_string(),
+            None => shell_cmd.clone(),
+        };
+        let shell_name = if shell_name == "nu" {
+            "nushell".into()
+        } else {
+            shell_name
+        };
+        (shell_name, shell_cmd, "-c")
+    }
+}
+
+pub fn exec_command<T: AsRef<OsStr>>(
+    cmd: &str,
+    args: &[T],
+    envs: Option<HashMap<String, String>>,
+) -> anyhow::Result<i32> {
+    let status = Command::new(cmd)
+        .args(args.iter())
+        .envs(envs.unwrap_or_default())
+        .status()?;
+    Ok(status.code().unwrap_or_default())
+}

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -54,7 +54,7 @@ pub fn detect_shell() -> (String, String, &'static str) {
     }
 }
 
-pub fn spawn_command<T: AsRef<OsStr>>(
+pub fn run_command<T: AsRef<OsStr>>(
     cmd: &str,
     args: &[T],
     envs: Option<HashMap<String, String>>,
@@ -66,7 +66,7 @@ pub fn spawn_command<T: AsRef<OsStr>>(
     Ok(status.code().unwrap_or_default())
 }
 
-pub fn exec_command<T: AsRef<OsStr>>(
+pub fn run_command_with_output<T: AsRef<OsStr>>(
     cmd: &str,
     args: &[T],
     envs: Option<HashMap<String, String>>,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -130,8 +130,23 @@ pub fn error_text(input: &str) -> String {
         .to_string()
 }
 
+pub fn warning_text(input: &str) -> String {
+    nu_ansi_term::Style::new()
+        .fg(nu_ansi_term::Color::Yellow)
+        .paint(input)
+        .to_string()
+}
+
 pub fn dimmed_text(input: &str) -> String {
     nu_ansi_term::Style::new().dimmed().paint(input).to_string()
+}
+
+pub fn indent_text(text: &str, spaces: usize) -> String {
+    let indent_size = " ".repeat(spaces);
+    text.lines()
+        .map(|line| format!("{}{}", indent_size, line))
+        .collect::<Vec<String>>()
+        .join("\n")
 }
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 mod abort_signal;
 mod clipboard;
+mod command;
 mod crypto;
 mod prompt_input;
 mod render_prompt;
@@ -7,6 +8,7 @@ mod spinner;
 
 pub use self::abort_signal::{create_abort_signal, AbortSignal};
 pub use self::clipboard::set_text;
+pub use self::command::*;
 pub use self::crypto::*;
 pub use self::prompt_input::*;
 pub use self::render_prompt::render_prompt;
@@ -15,7 +17,6 @@ pub use self::spinner::run_spinner;
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
 use std::env;
-use std::process::Command;
 
 lazy_static! {
     pub static ref CODE_BLOCK_RE: Regex = Regex::new(r"(?ms)```\w*(.*)```").unwrap();
@@ -77,67 +78,6 @@ pub fn light_theme_from_colorfgbg(colorfgbg: &str) -> Option<bool> {
 
     let light = v > 128.0;
     Some(light)
-}
-
-pub fn detect_os() -> String {
-    let os = env::consts::OS;
-    if os == "linux" {
-        if let Ok(contents) = std::fs::read_to_string("/etc/os-release") {
-            for line in contents.lines() {
-                if let Some(id) = line.strip_prefix("ID=") {
-                    return format!("{os}/{id}");
-                }
-            }
-        }
-    }
-    os.to_string()
-}
-
-pub fn detect_shell() -> (String, String, &'static str) {
-    let os = env::consts::OS;
-    if os == "windows" {
-        if env::var("NU_VERSION").is_ok() {
-            ("nushell".into(), "nu.exe".into(), "-c")
-        } else if let Some(ret) = env::var("PSModulePath").ok().and_then(|v| {
-            let v = v.to_lowercase();
-            if v.split(';').count() >= 3 {
-                if v.contains("powershell\\7\\") {
-                    Some(("pwsh".into(), "pwsh.exe".into(), "-c"))
-                } else {
-                    Some(("powershell".into(), "powershell.exe".into(), "-Command"))
-                }
-            } else {
-                None
-            }
-        }) {
-            ret
-        } else {
-            ("cmd".into(), "cmd.exe".into(), "/C")
-        }
-    } else if env::var("NU_VERSION").is_ok() {
-        ("nushell".into(), "nu".into(), "-c")
-    } else {
-        let shell_cmd = env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
-        let shell_name = match shell_cmd.rsplit_once('/') {
-            Some((_, name)) => name.to_string(),
-            None => shell_cmd.clone(),
-        };
-        let shell_name = if shell_name == "nu" {
-            "nushell".into()
-        } else {
-            shell_name
-        };
-        (shell_name, shell_cmd, "-c")
-    }
-}
-
-pub fn run_command(eval_str: &str) -> anyhow::Result<i32> {
-    let (_shell_name, shell_cmd, shell_arg) = detect_shell();
-    let status = Command::new(shell_cmd)
-        .arg(shell_arg)
-        .arg(eval_str)
-        .status()?;
-    Ok(status.code().unwrap_or_default())
 }
 
 pub fn extract_block(input: &str) -> String {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -123,6 +123,17 @@ pub fn fuzzy_match(text: &str, pattern: &str) -> bool {
     pattern_index == pattern_chars.len()
 }
 
+pub fn error_text(input: &str) -> String {
+    nu_ansi_term::Style::new()
+        .fg(nu_ansi_term::Color::Red)
+        .paint(input)
+        .to_string()
+}
+
+pub fn dimmed_text(input: &str) -> String {
+    nu_ansi_term::Style::new().dimmed().paint(input).to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Why use LLM function calling?

LLM function calling is a powerful technique that allows Large Language Models (LLMs) to interact with external tools and data sources. This significantly enhances their capabilities and opens up exciting possibilities for various applications. 

## AIChat LLM Functions

AIChat implements function calling by running an external tool. 

I created a new repo [https://github.com/sigoden/llm-functions](https://github.com/sigoden/llm-functions) and write some tools that cooperate with function calls.

You can configure function calling feature according to its readme.

**The client types that currently support function calling are: openai, claude, gemini and cohere.**

Function calling in AIChat must work with a role or session.

A `function_filter` field is added to the role/session. It controls which functions are used.

AIChat provides a built-in `%functions%` role whose `function_filter` is `.*`, matching all functions.

In AIChat, the roles are smiliar to GPTs.

```yaml
- name: myfuncs
  prompt: ''
  function_filter: func_foo|func_bar|func_.*
```

## Function Types

### Retrieve Type
The function returns JSON data.
AIChat retrieves the data and send it to LLM for further processing.
AIChat does not ask permission to run the function or print the output.

### Execute Type
The function can do anything. 
AIChat will ask permission before running the function.

![image](https://github.com/sigoden/aichat/assets/4012553/711067b8-dd23-443d-840a-5556697ab075)

**AIChat categorizes functions starting with "may_" as "execute" type and all others as "retrieve" type.**


## Conclusion

close #507