### PR TITLE
refactor: use `json_stream` for ollama to improve reliability

### DIFF
--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -83,7 +83,7 @@ async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandle
 
         let stream = res.bytes_stream();
         let handle = |message: &str| -> Result<()> {
-            let data: Value = serde_json::from_str(&message)?;
+            let data: Value = serde_json::from_str(message)?;
             debug!("stream-data: {data}");
 
             if data["done"].is_boolean() {

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -4,7 +4,6 @@ use super::{
 
 
 use anyhow::{anyhow, bail, Result};
-use futures_util::StreamExt;
 use reqwest::{Client as ReqwestClient, RequestBuilder};
 use serde::Deserialize;
 use serde_json::{json, Value};

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -1,7 +1,7 @@
 use super::{
-    catch_error, message::*, Client, CompletionOutput, ExtraConfig, Model, ModelData, ModelPatches,
-    OllamaClient, PromptAction, PromptKind, SendData, SseHandler,
+    catch_error, message::*, Client, CompletionOutput, ExtraConfig, Model, ModelData, ModelPatches, OllamaClient, PromptAction, PromptKind, SendData, SseHandler, json_stream
 };
+
 
 use anyhow::{anyhow, bail, Result};
 use futures_util::StreamExt;
@@ -81,14 +81,12 @@ async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandle
         let data = res.json().await?;
         catch_error(&data, status.as_u16())?;
     } else {
-        let mut stream = res.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk?;
-            if chunk.is_empty() {
-                continue;
-            }
-            let data: Value = serde_json::from_slice(&chunk)?;
+
+        let stream = res.bytes_stream();
+        let handle = |message: &str| -> Result<()> {
+            let data: Value = serde_json::from_str(&message)?;
             debug!("stream-data: {data}");
+
             if data["done"].is_boolean() {
                 if let Some(text) = data["message"]["content"].as_str() {
                     handler.text(text)?;
@@ -96,8 +94,13 @@ async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandle
             } else {
                 bail!("Invalid response data: {data}")
             }
-        }
+
+            Ok(())
+        };
+
+        json_stream(stream, handle).await?;
     }
+
     Ok(())
 }
 

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -1,7 +1,7 @@
 use super::{
-    catch_error, message::*, Client, CompletionOutput, ExtraConfig, Model, ModelData, ModelPatches, OllamaClient, PromptAction, PromptKind, SendData, SseHandler, json_stream
+    catch_error, json_stream, message::*, Client, CompletionOutput, ExtraConfig, Model, ModelData,
+    ModelPatches, OllamaClient, PromptAction, PromptKind, SendData, SseHandler,
 };
-
 
 use anyhow::{anyhow, bail, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
@@ -80,8 +80,6 @@ async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandle
         let data = res.json().await?;
         catch_error(&data, status.as_u16())?;
     } else {
-
-        let stream = res.bytes_stream();
         let handle = |message: &str| -> Result<()> {
             let data: Value = serde_json::from_str(message)?;
             debug!("stream-data: {data}");
@@ -97,7 +95,7 @@ async fn send_message_streaming(builder: RequestBuilder, handler: &mut SseHandle
             Ok(())
         };
 
-        json_stream(stream, handle).await?;
+        json_stream(res.bytes_stream(), handle).await?;
     }
 
     Ok(())


### PR DESCRIPTION
Fixes #548.

Instead of assuming that the streamed response will be a complete valid JSON line, use the `json_stream` function to handle cases where the server has not fully returned the line of JSON yet. This fixes cases where ollama is reverse proxied, and the proxy is not streaming exactly the same way as ollama does.