### PR TITLE
feat: support RAG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adobe-cmap-parser"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261a937a307ddc70a1605dec925987d7256adb00232161a1855ef9cc820bd8d5"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +85,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "path-absolutize",
+ "pdf-extract",
  "pretty_assertions",
  "rand",
  "reedline",
@@ -727,6 +737,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +855,15 @@ name = "error-code"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+
+[[package]]
+name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "eventsource-stream"
@@ -1369,6 +1461,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd1bc4d24ad230d21fb898d1116b1801d7adfc449d42026475862ab48b11e70e"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1505,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lopdf"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e775e4ee264e8a87d50a9efef7b67b4aa988cf94e75630859875fc347e6c872b"
+dependencies = [
+ "encoding_rs",
+ "flate2",
+ "itoa",
+ "linked-hash-map",
+ "log",
+ "md5",
+ "nom",
+ "time",
+ "weezl",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1538,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1817,6 +1938,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdf-extract"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3423481005e61b95855d53d7b6c0bcc514b4fbab45d165776d6e42c0a1642b22"
+dependencies = [
+ "adobe-cmap-parser",
+ "encoding",
+ "euclid",
+ "lopdf",
+ "postscript",
+ "type1-encoding-parser",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +2019,18 @@ dependencies = [
  "serde",
  "time",
 ]
+
+[[package]]
+name = "pom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
+name = "postscript"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "powerfmt"
@@ -2868,6 +3016,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "type1-encoding-parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d6cc09e1a99c7e01f2afe4953789311a1c50baebbdac5b477ecf78e2e92a5b"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,6 +3346,12 @@ checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "widestring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +60,7 @@ dependencies = [
  "fancy-regex",
  "futures-util",
  "hmac",
+ "hnsw_rs",
  "http",
  "http-body-util",
  "hyper",
@@ -62,6 +75,8 @@ dependencies = [
  "nu-ansi-term 0.50.0",
  "num_cpus",
  "parking_lot",
+ "path-absolutize",
+ "pretty_assertions",
  "rand",
  "reedline",
  "reqwest",
@@ -86,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +119,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anndists"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4747593401c8d692fb589ac2a208a27ef968b95f9392af837728933348fc199c"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "lazy_static",
+ "log",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rayon",
 ]
 
 [[package]]
@@ -471,6 +510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +534,16 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -503,6 +562,31 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
@@ -578,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +725,31 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "equivalent"
@@ -844,7 +959,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -908,6 +1023,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -934,6 +1053,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hnsw_rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4594a6fe509cc5d6549fd56af7e6435c476e59e3bc498efa4aafcd4311b6d66"
+dependencies = [
+ "anndists",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "hashbrown",
+ "indexmap",
+ "lazy_static",
+ "log",
+ "mmap-rs",
+ "num-traits",
+ "num_cpus",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -990,6 +1134,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1257,6 +1407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1429,15 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1315,12 +1483,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "mmap-rs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86968d85441db75203c34deefd0c88032f275aaa85cee19a1dcfff6ae9df56da"
+dependencies = [
+ "bitflags 1.3.2",
+ "combine",
+ "libc",
+ "mach2",
+ "nix 0.26.4",
+ "sysctl",
+ "thiserror",
+ "widestring",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "newline-converter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1601,6 +1799,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1897,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1961,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2286,6 +2532,20 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
+dependencies = [
+ "bitflags 2.5.0",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
  "thiserror",
  "walkdir",
 ]
@@ -2931,6 +3191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +3226,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows"
@@ -3157,7 +3432,7 @@ dependencies = [
  "derive-new",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "os_pipe",
  "tempfile",
  "thiserror",
@@ -3184,6 +3459,32 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ num_cpus = "1.16.0"
 threadpool = "1.8.1"
 json-patch = { version = "2.0.0", default-features = false }
 bitflags = "2.5.0"
+path-absolutize = "3.1.1"
+hnsw_rs = "0.3.0"
 
 [dependencies.reqwest]
 version = "0.12.0"
@@ -81,6 +83,7 @@ arboard = { version = "3.3.0", default-features = false, features = ["wayland-da
 arboard = { version = "3.3.0", default-features = false }
 
 [dev-dependencies]
+pretty_assertions = "1.4.0"
 rand = "0.8.5"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ json-patch = { version = "2.0.0", default-features = false }
 bitflags = "2.5.0"
 path-absolutize = "3.1.1"
 hnsw_rs = "0.3.0"
+pdf-extract = "0.7.7"
 
 [dependencies.reqwest]
 version = "0.12.0"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Upon first launch, AIChat will guide you through the configuration process.
 > No config file, create a new one? Yes
 > AI Platform: openai
 > API Key: <your_api_key_here>
-✨ Saved config file to <config-dir>/aichat/config.yaml
+✨ Saved config file to '<config-dir>/aichat/config.yaml'
 ```
 
 Feel free to adjust the configuration according to your needs.

--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ AIChat is an all-in-one AI CLI tool that accesses 100+ LLMs across 20+ AI platfo
 
 ## Supported AI Platforms
 
-- OpenAI GPT-3.5/GPT-4 (paid, vision, RAG, function-calling)
-- Gemini: Gemini-1.0/Gemini-1.5 (free, paid, vision, RAG, function-calling)
+- OpenAI GPT-3.5/GPT-4 (paid, vision, embedding, function-calling)
+- Gemini: Gemini-1.0/Gemini-1.5 (free, paid, vision, embedding, function-calling)
 - Claude: Claude-3 (vision, paid, function-calling)
-- Mistral (paid, RAG, function-calling)
-- Cohere: Command-R/Command-R+ (paid, RAG, function-calling)
+- Mistral (paid, embedding, function-calling)
+- Cohere: Command-R/Command-R+ (paid, embedding, function-calling)
 - Perplexity: Llama-3/Mixtral (paid)
 - Groq: Llama-3/Mixtral/Gemma (free)
-- Ollama (free, local, RAG)
-- Azure OpenAI (paid, vision, RAG, function-calling)
-- VertexAI: Gemini-1.0/Gemini-1.5 (paid, vision, RAG, function-calling)
+- Ollama (free, local, embedding)
+- Azure OpenAI (paid, vision, embedding, function-calling)
+- VertexAI: Gemini-1.0/Gemini-1.5 (paid, vision, embedding, function-calling)
 - VertexAI-Claude: Claude-3 (paid, vision)
 - Bedrock: Llama-3/Claude-3/Mistral (paid, vision)
 - Cloudflare (free, paid, vision)
 - Replicate (paid)
 - Ernie (paid)
-- Qianwen (paid, vision, RAG)
+- Qianwen (paid, vision, embedding)
 - Moonshot (paid)
 - ZhipuAI: GLM-3.5/GLM-4 (paid, vision)
 - Deepseek (paid)
@@ -69,7 +69,7 @@ Upon first launch, AIChat will guide you through the configuration process.
 > No config file, create a new one? Yes
 > AI Platform: openai
 > API Key: <your_api_key_here>
-✨ Saved config file to '<config-dir>/aichat/config.yaml'
+✨ Saved config file to '<user-config-dir>/aichat/config.yaml'
 ```
 
 Feel free to adjust the configuration according to your needs.
@@ -340,6 +340,19 @@ Usage: .file <file>... [-- text...]
 ```
 
 > The capability to process images through `.file` command depends on the current model’s vision support.
+
+### `.rag` - chat with your documents and knowledge bases.
+
+```
+> .rag test1
+> Select embedding model: openai:text-embedding-3-small
+> Set chunk size: 2000
+> Add document paths: tmp/files/paul_graham_essay.txt
+✨ Saved rag to '<user-config-dir>/aichat/rags/test5.bin'
+
+#test1> What did the author do growing up?
+The author mainly focused on writing and programming growing up ...
+```
 
 ### `.set` - adjust settings (non-persistent)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ AIChat is an all-in-one AI CLI tool that accesses 100+ LLMs across 20+ AI platfo
 - **Chat-REPL**: Powerful and feature-rich interactive chat interface.
 - **Custom Roles**: Tailor LLM behavior with customizable roles.
 - **Unlimited Sessions**: Automatic message compression for endless conversations.
+- **RAG**: Get answers enriched with context from your documents and knowledge bases.
 - **Function Calling**: Connect LLMs to external tools seamlessly.
 - **Execute Commands**: Use natural language to run shell commands.
 - **Shell Auto-Completion**: AI-based auto-completion for shell commands.
@@ -25,22 +26,22 @@ AIChat is an all-in-one AI CLI tool that accesses 100+ LLMs across 20+ AI platfo
 
 ## Supported AI Platforms
 
-- OpenAI GPT-3.5/GPT-4 (paid, vision, function-calling)
-- Gemini: Gemini-1.0/Gemini-1.5 (free, paid, vision, function-calling)
+- OpenAI GPT-3.5/GPT-4 (paid, vision, RAG, function-calling)
+- Gemini: Gemini-1.0/Gemini-1.5 (free, paid, vision, RAG, function-calling)
 - Claude: Claude-3 (vision, paid, function-calling)
-- Mistral (paid, function-calling)
-- Cohere: Command-R/Command-R+ (paid, function-calling)
+- Mistral (paid, RAG, function-calling)
+- Cohere: Command-R/Command-R+ (paid, RAG, function-calling)
 - Perplexity: Llama-3/Mixtral (paid)
 - Groq: Llama-3/Mixtral/Gemma (free)
-- Ollama (free, local)
-- Azure OpenAI (paid)
-- VertexAI: Gemini-1.0/Gemini-1.5 (paid, vision, function-calling)
+- Ollama (free, local, RAG)
+- Azure OpenAI (paid, vision, RAG, function-calling)
+- VertexAI: Gemini-1.0/Gemini-1.5 (paid, vision, RAG, function-calling)
 - VertexAI-Claude: Claude-3 (paid, vision)
 - Bedrock: Llama-3/Claude-3/Mistral (paid, vision)
 - Cloudflare (free, paid, vision)
 - Replicate (paid)
 - Ernie (paid)
-- Qianwen (paid, vision)
+- Qianwen (paid, vision, RAG)
 - Moonshot (paid)
 - ZhipuAI: GLM-3.5/GLM-4 (paid, vision)
 - Deepseek (paid)
@@ -346,6 +347,8 @@ Usage: .file <file>... [-- text...]
 .set max_output_tokens 4096
 .set temperature 1.2
 .set top_p 0.8
+.set rag_top_k 4
+.set function_calling true
 .set compress_threshold 1000
 .set dry_run true
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AIChat is an all-in-one AI CLI tool that accesses 100+ LLMs across 20+ AI platfo
 - **Chat-REPL**: Powerful and feature-rich interactive chat interface.
 - **Custom Roles**: Tailor LLM behavior with customizable roles.
 - **Unlimited Sessions**: Automatic message compression for endless conversations.
-- **RAG**: Get answers enriched with context from your documents and knowledge bases.
+- **RAG Retrieval**: Get answer enhanced by your knowledge base..
 - **Function Calling**: Connect LLMs to external tools seamlessly.
 - **Execute Commands**: Use natural language to run shell commands.
 - **Shell Auto-Completion**: AI-based auto-completion for shell commands.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -56,7 +56,8 @@ clients:
   #       supports_function_calling: true
   #     - name: xxxx
   #       mode: embedding                             # Embedding model
-  #       max_chunk_size: 2048                        
+  #       max_input_tokens: 2048
+  #       default_chunk_size: 2000                        
   #       max_concurrent_chunks: 100
   #   patches: 
   #     <regex>:                                      # The regex to match model names, e.g. '.*' 'gpt-4o' 'gpt-4o|gpt-4-.*'

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,17 @@ buffer_editor: null
 # Controls the function calling feature. For setup instructions, visit https://github.com/sigoden/llm-functions.
 function_calling: false
 
+# Specify the embedding model to use
+embedding_model: null
+
+rag_prompt: |
+  Use the following context as your learned knowledge to answer the question
+  <context>
+  __CONTEXT__
+  </context>
+
+  __INPUT__
+
 # Compress session when token count reaches or exceeds this threshold (must be at least 1000)
 compress_threshold: 4000
 # Text prompt used for creating a concise summary of session message
@@ -26,7 +37,7 @@ summarize_prompt: 'Summarize the discussion briefly in 200 words or less to use 
 summary_prompt: 'This is a summary of the chat history as a recap: '
 
 # Custom REPL prompt, see https://github.com/sigoden/aichat/wiki/Custom-REPL-Prompt
-left_prompt: '{color.green}{?session {session}{?role /}}{role}{color.cyan}{?session )}{!session >}{color.reset} '
+left_prompt: '{color.green}{?session {session}{?role /}}{role}{?rag #{rag}{color.cyan}{?session )}{!session >}{color.reset} '
 right_prompt: '{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{color.reset}'
 
 clients:
@@ -40,7 +51,7 @@ clients:
   #       supports_function_calling: true
   #   patches: 
   #     <regex>:                                      # The regex to match model names, e.g. '.*' 'gpt-4o' 'gpt-4o|gpt-4-.*'
-  #       request_body:                               # The JSON to be merged with the request body.
+  #       chat_completions_body:                      # The JSON to be merged with the request body.
   #   extra:
   #     proxy: socks5://127.0.0.1:1080                # Set https/socks5 proxy. ENV: HTTPS_PROXY/https_proxy/ALL_PROXY/all_proxy
   #     connect_timeout: 10                           # Set timeout in seconds for connect to api
@@ -66,7 +77,7 @@ clients:
     api_key: xxx                                      # ENV: {client}_API_KEY
     patches:
       '.*':                                           
-        request_body:                                 # Override safetySettings for all models
+        chat_completions_body:                        # Override safetySettings for all models
           safetySettings:
             - category: HARM_CATEGORY_HARASSMENT
               threshold: BLOCK_NONE
@@ -130,7 +141,7 @@ clients:
     adc_file: <path-to/gcloud/application_default_credentials.json> 
     patches:
       'gemini-.*':
-        request_body:                                 # Override safetySettings for all gemini models
+        chat_completions_body:                        # Override safetySettings for all gemini models
           safetySettings:
             - category: HARM_CATEGORY_HARASSMENT
               threshold: BLOCK_ONLY_HIGH

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,19 +15,23 @@ prelude: null                    # Set a default role or session to start with (
 # if unset fallback to $EDITOR and $VISUAL
 buffer_editor: null
 
-# Controls the function calling feature. For setup instructions, visit https://github.com/sigoden/llm-functions.
+# Controls the function calling feature. For setup instructions, visit https://github.com/sigoden/llm-functions
 function_calling: false
 
-# Specify the embedding model to use
+# Specifies the embedding model to use
 embedding_model: null
 
-rag_prompt: |
-  Use the following context as your learned knowledge to answer the question
+# Determines how many relevant documents are retrieved
+rag_top_k: 4
+
+# Defines the query structure using variables like __CONTEXT__ and __INPUT__ to tailor searches to specific needs
+rag_template: |
+  Answer the following question based only on the provided context:
   <context>
   __CONTEXT__
   </context>
 
-  __INPUT__
+  Question: __INPUT__
 
 # Compress session when token count reaches or exceeds this threshold (must be at least 1000)
 compress_threshold: 4000
@@ -45,13 +49,18 @@ clients:
   # - type: xxxx
   #   name: xxxx                                      # Only use it to distinguish clients with the same client type. Optional
   #   models:
-  #     - name: xxxx                                  # The model name
+  #     - name: xxxx
+  #       mode: chat                                  # Chat model
   #       max_input_tokens: 100000
   #       supports_vision: true
   #       supports_function_calling: true
+  #     - name: xxxx
+  #       mode: embedding                             # Embedding model
+  #       max_chunk_size: 2048                        
+  #       max_concurrent_chunks: 100
   #   patches: 
   #     <regex>:                                      # The regex to match model names, e.g. '.*' 'gpt-4o' 'gpt-4o|gpt-4-.*'
-  #       chat_completions_body:                      # The JSON to be merged with the request body.
+  #       chat_completions_body:                      # The JSON to be merged with the chat completions request body.
   #   extra:
   #     proxy: socks5://127.0.0.1:1080                # Set https/socks5 proxy. ENV: HTTPS_PROXY/https_proxy/ALL_PROXY/all_proxy
   #     connect_timeout: 10                           # Set timeout in seconds for connect to api
@@ -118,10 +127,12 @@ clients:
   - type: ollama
     api_base: http://localhost:11434                  # ENV: {client}_API_BASE
     api_auth: Basic xxx                               # ENV: {client}_API_AUTH
-    chat_endpoint: /api/chat                          # Optional
     models:                                           # Required
       - name: llama3
         max_input_tokens: 8192
+      - name: all-minilm:l6-v2
+        mode: embedding
+        max_chunk_size: 1000
 
   # See https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart
   - type: azure-openai

--- a/models.yaml
+++ b/models.yaml
@@ -65,6 +65,18 @@
       max_output_tokens: 4096
       input_price: 60
       output_price: 120
+    - name: text-embedding-3-large
+      mode: embedding
+      max_input_tokens: 8191
+      dimension: 3072
+    - name: text-embedding-3-small
+      mode: embedding
+      max_input_tokens: 8191
+      dimension: 1536
+    - name: text-embedding-ada-002
+      mode: embedding
+      max_input_tokens: 8191
+      dimension: 1536
 
 - platform: gemini 
   # docs:

--- a/models.yaml
+++ b/models.yaml
@@ -67,16 +67,12 @@
       output_price: 120
     - name: text-embedding-3-large
       mode: embedding
-      max_input_tokens: 8191
-      dimension: 3072
+      max_chunk_size: 8191
+      max_concurrent_chunks: 100
     - name: text-embedding-3-small
       mode: embedding
-      max_input_tokens: 8191
-      dimension: 1536
-    - name: text-embedding-ada-002
-      mode: embedding
-      max_input_tokens: 8191
-      dimension: 1536
+      max_chunk_size: 8191
+      max_concurrent_chunks: 100
 
 - platform: gemini 
   # docs:
@@ -112,6 +108,10 @@
       output_price: 10.5
       supports_vision: true
       supports_function_calling: true
+    - name: text-embedding-004
+      mode: embedding
+      max_chunk_size: 2048
+      max_concurrent_chunks: 1
 
 - platform: claude
   # docs:
@@ -174,6 +174,9 @@
       input_price: 8
       output_price: 24
       supports_function_calling: true
+    - name: mistral-embed
+      mode: embedding
+      max_chunk_size: 8092
 
 - platform: cohere
   # docs:
@@ -195,6 +198,14 @@
       input_price: 3
       output_price: 15
       supports_function_calling: true
+    - name: embed-english-v3.0
+      mode: embedding
+      max_chunk_size: 1000
+      max_concurrent_chunks: 96
+    - name: embed-multilingual-v3.0
+      mode: embedding
+      max_chunk_size: 1000
+      max_concurrent_chunks: 96
 
 - platform: perplexity
   # docs:
@@ -293,6 +304,14 @@
       input_price: 1.25
       output_price: 3.75
       supports_vision: true
+    - name: text-embedding-004
+      mode: embedding
+      max_chunk_size: 3072
+      max_concurrent_chunks: 5
+    - name: text-multilingual-embedding-002
+      mode: embedding
+      max_chunk_size: 3072
+      max_concurrent_chunks: 5
 
 - platform: vertexai-claude
   # docs:
@@ -521,6 +540,10 @@
       input_price: 2.8
       output_price: 2.8
       supports_vision: true
+    - name: text-embedding-v2
+      mode: embedding
+      max_chunk_size: 2048
+      max_concurrent_chunks: 5
 
 - platform: moonshot
   # docs:

--- a/models.yaml
+++ b/models.yaml
@@ -67,11 +67,13 @@
       output_price: 120
     - name: text-embedding-3-large
       mode: embedding
-      max_chunk_size: 8191
+      max_input_tokens: 8191
+      default_chunk_size: 8000
       max_concurrent_chunks: 100
     - name: text-embedding-3-small
       mode: embedding
-      max_chunk_size: 8191
+      max_input_tokens: 8191
+      default_chunk_size: 8000
       max_concurrent_chunks: 100
 
 - platform: gemini 
@@ -110,8 +112,8 @@
       supports_function_calling: true
     - name: text-embedding-004
       mode: embedding
-      max_chunk_size: 2048
-      max_concurrent_chunks: 1
+      max_input_tokens: 2048
+      default_chunk_size: 2000
 
 - platform: claude
   # docs:
@@ -176,7 +178,8 @@
       supports_function_calling: true
     - name: mistral-embed
       mode: embedding
-      max_chunk_size: 8092
+      max_input_tokens: 8092
+      default_chunk_size: 8000
 
 - platform: cohere
   # docs:
@@ -200,11 +203,13 @@
       supports_function_calling: true
     - name: embed-english-v3.0
       mode: embedding
-      max_chunk_size: 1000
+      max_input_tokens: 512
+      default_chunk_size: 1000
       max_concurrent_chunks: 96
     - name: embed-multilingual-v3.0
       mode: embedding
-      max_chunk_size: 1000
+      max_input_tokens: 512
+      default_chunk_size: 1000
       max_concurrent_chunks: 96
 
 - platform: perplexity
@@ -306,11 +311,13 @@
       supports_vision: true
     - name: text-embedding-004
       mode: embedding
-      max_chunk_size: 3072
+      max_input_tokens: 3072
+      default_chunk_size: 3000
       max_concurrent_chunks: 5
     - name: text-multilingual-embedding-002
       mode: embedding
-      max_chunk_size: 3072
+      max_input_tokens: 3072
+      default_chunk_size: 3000
       max_concurrent_chunks: 5
 
 - platform: vertexai-claude
@@ -542,7 +549,8 @@
       supports_vision: true
     - name: text-embedding-v2
       mode: embedding
-      max_chunk_size: 2048
+      max_input_tokens: 2048
+      default_chunk_size: 2000
       max_concurrent_chunks: 5
 
 - platform: moonshot

--- a/src/client/bedrock.rs
+++ b/src/client/bedrock.rs
@@ -1,8 +1,6 @@
-use super::{
-    catch_error, claude::*, prompt_format::*, BedrockClient, ChatCompletionsData,
-    ChatCompletionsOutput, Client, ExtraConfig, Model, ModelData, ModelPatches, PromptAction,
-    PromptKind, SseHandler,
-};
+use super::*;
+use super::claude::*;
+use super::prompt_format::*;
 
 use crate::utils::{base64_decode, encode_uri, hex_encode, hmac_sha256, sha256};
 
@@ -102,7 +100,7 @@ impl BedrockClient {
         let headers = IndexMap::new();
 
         let mut body = build_chat_completions_body(data, &self.model, model_category)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         let builder = aws_fetch(
             client,

--- a/src/client/claude.rs
+++ b/src/client/claude.rs
@@ -1,9 +1,4 @@
-use super::{
-    catch_error, extract_system_message, message::*, sse_stream, ChatCompletionsData,
-    ChatCompletionsOutput, ClaudeClient, Client, ExtraConfig, ImageUrl, MessageContent,
-    MessageContentPart, Model, ModelData, ModelPatches, PromptAction, PromptKind, SseHandler,
-    SseMmessage, ToolCall,
-};
+use super::*;
 
 use anyhow::{bail, Context, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
@@ -36,7 +31,7 @@ impl ClaudeClient {
         let api_key = self.get_api_key().ok();
 
         let mut body = claude_build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         let url = API_BASE;
 

--- a/src/client/cloudflare.rs
+++ b/src/client/cloudflare.rs
@@ -1,7 +1,4 @@
-use super::{
-    catch_error, sse_stream, ChatCompletionsData, ChatCompletionsOutput, Client, CloudflareClient,
-    ExtraConfig, Model, ModelData, ModelPatches, PromptAction, PromptKind, SseHandler, SseMmessage,
-};
+use super::*;
 
 use anyhow::{anyhow, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
@@ -39,7 +36,7 @@ impl CloudflareClient {
         let api_key = self.get_api_key()?;
 
         let mut body = build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         let url = format!(
             "{API_BASE}/accounts/{account_id}/ai/run/{}",

--- a/src/client/cohere.rs
+++ b/src/client/cohere.rs
@@ -1,11 +1,12 @@
 use super::*;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-const API_URL: &str = "https://api.cohere.ai/v1/chat";
+const CHAT_COMPLETIONS_API_URL: &str = "https://api.cohere.ai/v1/chat";
+const EMBEDDINGS_API_URL: &str = "https://api.cohere.ai/v1/embed";
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct CohereConfig {
@@ -33,9 +34,36 @@ impl CohereClient {
         let mut body = build_chat_completions_body(data, &self.model)?;
         self.patch_chat_completions_body(&mut body);
 
-        let url = API_URL;
+        let url = CHAT_COMPLETIONS_API_URL;
 
-        debug!("Cohere Request: {url} {body}");
+        debug!("Cohere Chat Completions Request: {url} {body}");
+
+        let builder = client.post(url).bearer_auth(api_key).json(&body);
+
+        Ok(builder)
+    }
+
+    fn embeddings_builder(
+        &self,
+        client: &ReqwestClient,
+        data: EmbeddingsData,
+    ) -> Result<RequestBuilder> {
+        let api_key = self.get_api_key()?;
+
+        let input_type = match data.query {
+            true => "search_query",
+            false => "search_document",
+        };
+
+        let body = json!({
+            "model": self.model.name(),
+            "texts": data.texts,
+            "input_type": input_type,
+        });
+
+        let url = EMBEDDINGS_API_URL;
+
+        debug!("Cohere Embeddings Request: {url} {body}");
 
         let builder = client.post(url).bearer_auth(api_key).json(&body);
 
@@ -46,7 +74,8 @@ impl CohereClient {
 impl_client_trait!(
     CohereClient,
     chat_completions,
-    chat_completions_streaming
+    chat_completions_streaming,
+    embeddings
 );
 
 async fn chat_completions(builder: RequestBuilder) -> Result<ChatCompletionsOutput> {
@@ -98,6 +127,24 @@ async fn chat_completions_streaming(
         json_stream(res.bytes_stream(), handle).await?;
     }
     Ok(())
+}
+
+async fn embeddings(
+    builder: RequestBuilder,
+) -> Result<EmbeddingsOutput> {
+    let res = builder.send().await?;
+    let status = res.status();
+    let data: Value = res.json().await?;
+    if !status.is_success() {
+        catch_error(&data, status.as_u16())?;
+    }
+    let res_body: EmbeddingsResBody = serde_json::from_value(data).context("Invalid request data")?;
+    Ok(res_body.embeddings)
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBody {
+    embeddings: Vec<Vec<f32>>,
 }
 
 fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Result<Value> {

--- a/src/client/cohere.rs
+++ b/src/client/cohere.rs
@@ -1,8 +1,4 @@
-use super::{
-    catch_error, extract_system_message, json_stream, message::*, ChatCompletionsData,
-    ChatCompletionsOutput, Client, CohereClient, ExtraConfig, Model, ModelData, ModelPatches,
-    PromptAction, PromptKind, SseHandler, ToolCall,
-};
+use super::*;
 
 use anyhow::{bail, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
@@ -35,7 +31,7 @@ impl CohereClient {
         let api_key = self.get_api_key()?;
 
         let mut body = build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         let url = API_URL;
 
@@ -47,7 +43,11 @@ impl CohereClient {
     }
 }
 
-impl_client_trait!(CohereClient, chat_completions, chat_completions_streaming);
+impl_client_trait!(
+    CohereClient,
+    chat_completions,
+    chat_completions_streaming
+);
 
 async fn chat_completions(builder: RequestBuilder) -> Result<ChatCompletionsOutput> {
     let res = builder.send().await?;

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -463,6 +463,12 @@ pub struct EmbeddingsData {
     pub query: bool,
 }
 
+impl EmbeddingsData {
+    pub fn new(texts: Vec<String>, query: bool) -> Self {
+        Self { texts, query }
+    }
+}
+
 pub type EmbeddingsOutput = Vec<Vec<f32>>;
 
 pub type PromptAction<'a> = (&'a str, &'a str, bool, PromptKind);

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,10 +1,13 @@
-use super::{openai::OpenAIConfig, BuiltinModels, ClientConfig, Message, Model, SseHandler};
+use super::*;
 
 use crate::{
     config::{GlobalConfig, Input},
     function::{eval_tool_calls, FunctionDeclaration, ToolCall, ToolCallResult},
     render::{render_error, render_stream},
-    utils::{prompt_input_integer, prompt_input_string, tokenize, AbortSignal, PromptKind},
+    utils::{
+        prompt_input_integer, prompt_input_string, tokenize, watch_abort_signal, AbortSignal,
+        PromptKind,
+    },
 };
 
 use anyhow::{bail, Context, Result};
@@ -16,13 +19,12 @@ use reqwest::{Client as ReqwestClient, ClientBuilder, Proxy, RequestBuilder};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{env, future::Future, time::Duration};
-use tokio::{sync::mpsc::unbounded_channel, time::sleep};
+use tokio::sync::mpsc::unbounded_channel;
 
 const MODELS_YAML: &str = include_str!("../../models.yaml");
 
 lazy_static! {
-    pub static ref ALL_CLIENT_MODELS: Vec<BuiltinModels> =
-        serde_yaml::from_str(MODELS_YAML).unwrap();
+    pub static ref ALL_MODELS: Vec<BuiltinModels> = serde_yaml::from_str(MODELS_YAML).unwrap();
     static ref ESCAPE_SLASH_RE: Regex = Regex::new(r"(?<!\\)/").unwrap();
 }
 
@@ -92,10 +94,10 @@ macro_rules! register_client {
                 pub fn list_models(local_config: &$config) -> Vec<Model> {
                     let client_name = Self::name(local_config);
                     if local_config.models.is_empty() {
-                        if let Some(client_models) = $crate::client::ALL_CLIENT_MODELS.iter().find(|v| {
+                        if let Some(models) = $crate::client::ALL_MODELS.iter().find(|v| {
                             v.platform == $name || ($name == "openai-compatible" && local_config.name.as_deref() == Some(&v.platform))
                         }) {
-                            return Model::from_config(client_name, &client_models.models);
+                            return Model::from_config(client_name, &models.models);
                         }
                         vec![]
                     } else {
@@ -137,10 +139,10 @@ macro_rules! register_client {
             anyhow::bail!("Unknown client '{}'", client)
         }
 
-        static mut ALL_CLIENTS: Option<Vec<$crate::client::Model>> = None;
+        static mut ALL_CLIENT_MODELS: Option<Vec<$crate::client::Model>> = None;
 
-        pub fn list_models(config: &$crate::config::Config) -> Vec<&$crate::client::Model> {
-            if unsafe { ALL_CLIENTS.is_none() } {
+        pub fn list_models(config: &$crate::config::Config) -> Vec<&'static $crate::client::Model> {
+            if unsafe { ALL_CLIENT_MODELS.is_none() } {
                 let models: Vec<_> = config
                     .clients
                     .iter()
@@ -149,9 +151,17 @@ macro_rules! register_client {
                         ClientConfig::Unknown => vec![],
                     })
                     .collect();
-                unsafe { ALL_CLIENTS = Some(models) };
+                unsafe { ALL_CLIENT_MODELS = Some(models) };
             }
-            unsafe { ALL_CLIENTS.as_ref().unwrap().iter().collect() }
+            unsafe { ALL_CLIENT_MODELS.as_ref().unwrap().iter().collect() }
+        }
+
+        pub fn list_chat_models(config: &$crate::config::Config) -> Vec<&'static $crate::client::Model> {
+            list_models(config).into_iter().filter(|v| v.mode() == "chat").collect()
+        }
+
+        pub fn list_embedding_models(config: &$crate::config::Config) -> Vec<&'static $crate::client::Model> {
+            list_models(config).into_iter().filter(|v| v.mode() == "embedding").collect()
         }
     };
 }
@@ -217,6 +227,40 @@ macro_rules! impl_client_trait {
             ) -> Result<()> {
                 let builder = self.chat_completions_builder(client, data)?;
                 $chat_completions_streaming(builder, handler).await
+            }
+        }
+    };
+    ($client:ident, $chat_completions:path, $chat_completions_streaming:path, $embeddings:path) => {
+        #[async_trait::async_trait]
+        impl $crate::client::Client for $crate::client::$client {
+            client_common_fns!();
+
+            async fn chat_completions_inner(
+                &self,
+                client: &reqwest::Client,
+                data: $crate::client::ChatCompletionsData,
+            ) -> anyhow::Result<$crate::client::ChatCompletionsOutput> {
+                let builder = self.chat_completions_builder(client, data)?;
+                $chat_completions(builder).await
+            }
+
+            async fn chat_completions_streaming_inner(
+                &self,
+                client: &reqwest::Client,
+                handler: &mut $crate::client::SseHandler,
+                data: $crate::client::ChatCompletionsData,
+            ) -> Result<()> {
+                let builder = self.chat_completions_builder(client, data)?;
+                $chat_completions_streaming(builder, handler).await
+            }
+
+            async fn embeddings_inner(
+                &self,
+                client: &ReqwestClient,
+                data: EmbeddingsData,
+            ) -> Result<Vec<Vec<f32>>> {
+                let builder = self.embeddings_builder(client, data)?;
+                $embeddings(builder).await
             }
         }
     };
@@ -288,11 +332,10 @@ pub trait Client: Sync + Send {
             return Ok(ChatCompletionsOutput::new(&content));
         }
         let client = self.build_client()?;
-
         let data = input.prepare_completion_data(self.model(), false)?;
         self.chat_completions_inner(&client, data)
             .await
-            .with_context(|| "Failed to get answer")
+            .with_context(|| "Failed to get chat completions")
     }
 
     async fn chat_completions_streaming(
@@ -300,15 +343,7 @@ pub trait Client: Sync + Send {
         input: &Input,
         handler: &mut SseHandler,
     ) -> Result<()> {
-        async fn watch_abort(abort: AbortSignal) {
-            loop {
-                if abort.aborted() {
-                    break;
-                }
-                sleep(Duration::from_millis(100)).await;
-            }
-        }
-        let abort = handler.get_abort();
+        let abort_signal = handler.get_abort();
         let input = input.clone();
         tokio::select! {
             ret = async {
@@ -326,20 +361,27 @@ pub trait Client: Sync + Send {
                 self.chat_completions_streaming_inner(&client, handler, data).await
             } => {
                 handler.done()?;
-                ret.with_context(|| "Failed to get answer")
+                ret.with_context(|| "Failed to get chat completions")
             }
-            _ = watch_abort(abort.clone()) => {
+            _ = watch_abort_signal(abort_signal) => {
                 handler.done()?;
                 Ok(())
             },
         }
     }
 
-    fn patch_request_body(&self, body: &mut Value) {
+    async fn embeddings(&self, data: EmbeddingsData) -> Result<Vec<Vec<f32>>> {
+        let client = self.build_client()?;
+        self.embeddings_inner(&client, data)
+            .await
+            .with_context(|| "Failed to get embeddings")
+    }
+
+    fn patch_chat_completions_body(&self, body: &mut Value) {
         let model_name = self.model().name();
         if let Some(patch_data) = select_model_patch(self.patches_config(), model_name) {
-            if body.is_object() && patch_data.request_body.is_object() {
-                json_patch::merge(body, &patch_data.request_body)
+            if body.is_object() && patch_data.chat_completions_body.is_object() {
+                json_patch::merge(body, &patch_data.chat_completions_body)
             }
         }
     }
@@ -356,6 +398,14 @@ pub trait Client: Sync + Send {
         handler: &mut SseHandler,
         data: ChatCompletionsData,
     ) -> Result<()>;
+
+    async fn embeddings_inner(
+        &self,
+        _client: &ReqwestClient,
+        _data: EmbeddingsData,
+    ) -> Result<Vec<Vec<f32>>> {
+        bail!("No embeddings api")
+    }
 }
 
 impl Default for ClientConfig {
@@ -375,7 +425,7 @@ pub type ModelPatches = IndexMap<String, ModelPatch>;
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelPatch {
     #[serde(default)]
-    pub request_body: Value,
+    pub chat_completions_body: Value,
 }
 
 pub fn select_model_patch<'a>(
@@ -421,6 +471,14 @@ impl ChatCompletionsOutput {
     }
 }
 
+#[derive(Debug)]
+pub struct EmbeddingsData {
+    pub texts: Vec<String>,
+    pub search: bool,
+}
+
+pub type EmbeddingsOutput = Vec<Vec<f32>>;
+
 pub type PromptAction<'a> = (&'a str, &'a str, bool, PromptKind);
 
 pub fn create_config(prompts: &[PromptAction], client: &str) -> Result<(String, Value)> {
@@ -445,7 +503,7 @@ pub fn create_openai_compatible_client_config(client: &str) -> Result<Option<(St
                 "name": name,
                 "api_base": api_base,
             });
-            let prompts = if ALL_CLIENT_MODELS.iter().any(|v| &v.platform == name) {
+            let prompts = if ALL_MODELS.iter().any(|v| &v.platform == name) {
                 vec![("api_key", "API Key:", false, PromptKind::String)]
             } else {
                 vec![

--- a/src/client/ernie.rs
+++ b/src/client/ernie.rs
@@ -1,8 +1,5 @@
-use super::{
-    access_token::*, maybe_catch_error, patch_system_message, sse_stream, ChatCompletionsData,
-    ChatCompletionsOutput, Client, ErnieClient, ExtraConfig, Model, ModelData, ModelPatches,
-    PromptAction, PromptKind, SseHandler, SseMmessage,
-};
+use super::*;
+use super::access_token::*;
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -37,7 +34,7 @@ impl ErnieClient {
         data: ChatCompletionsData,
     ) -> Result<RequestBuilder> {
         let mut body = build_chat_completions_body(data, &self.model);
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         let access_token = get_access_token(self.name())?;
 

--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -1,7 +1,5 @@
-use super::{
-    vertexai::*, ChatCompletionsData, Client, ExtraConfig, GeminiClient, Model, ModelData,
-    ModelPatches, PromptAction, PromptKind,
-};
+use super::*;
+use super::vertexai::*;
 
 use anyhow::Result;
 use reqwest::{Client as ReqwestClient, RequestBuilder};
@@ -38,7 +36,7 @@ impl GeminiClient {
         };
 
         let mut body = gemini_build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         let model = &self.model.name();
 
@@ -54,6 +52,6 @@ impl GeminiClient {
 
 impl_client_trait!(
     GeminiClient,
-    crate::client::vertexai::gemini_chat_completions,
-    crate::client::vertexai::gemini_chat_completions_streaming
+    gemini_chat_completions,
+    gemini_chat_completions_streaming
 );

--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -1,9 +1,10 @@
-use super::*;
 use super::vertexai::*;
+use super::*;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
 use serde::Deserialize;
+use serde_json::{json, Value};
 
 const API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta/models/";
 
@@ -38,11 +39,39 @@ impl GeminiClient {
         let mut body = gemini_build_chat_completions_body(data, &self.model)?;
         self.patch_chat_completions_body(&mut body);
 
-        let model = &self.model.name();
+        let url = format!("{API_BASE}{}:{}?key={}", &self.model.name(), func, api_key);
 
-        let url = format!("{API_BASE}{}:{}?key={}", model, func, api_key);
+        debug!("Gemini Chat Completions Request: {url} {body}");
 
-        debug!("Gemini Request: {url} {body}");
+        let builder = client.post(url).json(&body);
+
+        Ok(builder)
+    }
+
+    fn embeddings_builder(
+        &self,
+        client: &ReqwestClient,
+        data: EmbeddingsData,
+    ) -> Result<RequestBuilder> {
+        let api_key = self.get_api_key()?;
+
+        let body = json!({
+            "content": {
+                "parts": [
+                    {
+                        "text": data.texts[0],
+                    }
+                ]
+            }
+        });
+
+        let url = format!(
+            "{API_BASE}{}:embedContent?key={}",
+            &self.model.name(),
+            api_key
+        );
+
+        debug!("Gemini Embeddings Request: {url} {body}");
 
         let builder = client.post(url).json(&body);
 
@@ -53,5 +82,29 @@ impl GeminiClient {
 impl_client_trait!(
     GeminiClient,
     gemini_chat_completions,
-    gemini_chat_completions_streaming
+    gemini_chat_completions_streaming,
+    gemini_embeddings
 );
+
+async fn gemini_embeddings(builder: RequestBuilder) -> Result<EmbeddingsOutput> {
+    let res = builder.send().await?;
+    let status = res.status();
+    let data: Value = res.json().await?;
+    if !status.is_success() {
+        catch_error(&data, status.as_u16())?;
+    }
+    let res_body: EmbeddingsResBody =
+        serde_json::from_value(data).context("Invalid request data")?;
+    let output = vec![res_body.embedding.values];
+    Ok(output)
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBody {
+    embedding: EmbeddingsResBodyEmbedding,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBodyEmbedding {
+    values: Vec<f32>,
+}

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -1,4 +1,7 @@
-use super::message::{Message, MessageContent};
+use super::{
+    message::{Message, MessageContent},
+    EmbeddingsData,
+};
 
 use crate::utils::{estimate_token_length, format_option_value};
 
@@ -141,6 +144,14 @@ impl Model {
         self.data.supports_function_calling
     }
 
+    pub fn max_chunk_size(&self) -> usize {
+        self.data.max_chunk_size.unwrap_or(1000)
+    }
+
+    pub fn max_concurrent_chunks(&self) -> usize {
+        self.data.max_concurrent_chunks.unwrap_or(1)
+    }
+
     pub fn max_tokens_param(&self) -> Option<isize> {
         if self.data.pass_max_tokens {
             self.data.max_output_tokens
@@ -186,12 +197,19 @@ impl Model {
         }
     }
 
-    pub fn max_input_tokens_limit(&self, messages: &[Message]) -> Result<()> {
+    pub fn guard_max_input_tokens(&self, messages: &[Message]) -> Result<()> {
         let total_tokens = self.total_tokens(messages) + BASIS_TOKENS;
         if let Some(max_input_tokens) = self.data.max_input_tokens {
             if total_tokens >= max_input_tokens {
-                bail!("Exceed max input tokens limit")
+                bail!("Exceed max_input_tokens limit")
             }
+        }
+        Ok(())
+    }
+
+    pub fn guard_max_concurrent_chunks(&self, data: &EmbeddingsData) -> Result<()> {
+        if data.texts.len() > self.max_concurrent_chunks() {
+            bail!("Exceed max_concurrent_chunks limit");
         }
         Ok(())
     }
@@ -202,17 +220,22 @@ pub struct ModelData {
     pub name: String,
     #[serde(default = "default_model_mode")]
     pub mode: String,
+    pub input_price: Option<f64>,
+    pub output_price: Option<f64>,
+
+    // chat-only properties
     pub max_input_tokens: Option<usize>,
     pub max_output_tokens: Option<isize>,
     #[serde(default)]
     pub pass_max_tokens: bool,
-    pub input_price: Option<f64>,
-    pub output_price: Option<f64>,
-    pub dimension: Option<usize>,
     #[serde(default)]
     pub supports_vision: bool,
     #[serde(default)]
     pub supports_function_calling: bool,
+
+    // embedding-only properties
+    pub max_chunk_size: Option<usize>,
+    pub max_concurrent_chunks: Option<usize>,
 }
 
 impl ModelData {

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -144,8 +144,8 @@ impl Model {
         self.data.supports_function_calling
     }
 
-    pub fn max_chunk_size(&self) -> usize {
-        self.data.max_chunk_size.unwrap_or(1000)
+    pub fn default_chunk_size(&self) -> usize {
+        self.data.default_chunk_size.unwrap_or(1000)
     }
 
     pub fn max_concurrent_chunks(&self) -> usize {
@@ -220,11 +220,11 @@ pub struct ModelData {
     pub name: String,
     #[serde(default = "default_model_mode")]
     pub mode: String,
+    pub max_input_tokens: Option<usize>,
     pub input_price: Option<f64>,
     pub output_price: Option<f64>,
 
     // chat-only properties
-    pub max_input_tokens: Option<usize>,
     pub max_output_tokens: Option<isize>,
     #[serde(default)]
     pub pass_max_tokens: bool,
@@ -234,7 +234,7 @@ pub struct ModelData {
     pub supports_function_calling: bool,
 
     // embedding-only properties
-    pub max_chunk_size: Option<usize>,
+    pub default_chunk_size: Option<usize>,
     pub max_concurrent_chunks: Option<usize>,
 }
 

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -81,6 +81,10 @@ impl Model {
         &self.data.name
     }
 
+    pub fn mode(&self) -> &str {
+        &self.data.mode
+    }
+
     pub fn data(&self) -> &ModelData {
         &self.data
     }
@@ -196,12 +200,15 @@ impl Model {
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ModelData {
     pub name: String,
+    #[serde(default = "default_model_mode")]
+    pub mode: String,
     pub max_input_tokens: Option<usize>,
     pub max_output_tokens: Option<isize>,
     #[serde(default)]
     pub pass_max_tokens: bool,
     pub input_price: Option<f64>,
     pub output_price: Option<f64>,
+    pub dimension: Option<usize>,
     #[serde(default)]
     pub supports_vision: bool,
     #[serde(default)]
@@ -221,4 +228,8 @@ impl ModelData {
 pub struct BuiltinModels {
     pub platform: String,
     pub models: Vec<ModelData>,
+}
+
+fn default_model_mode() -> String {
+    "chat".into()
 }

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -10,7 +10,6 @@ pub struct OllamaConfig {
     pub name: Option<String>,
     pub api_base: Option<String>,
     pub api_auth: Option<String>,
-    pub chat_endpoint: Option<String>,
     #[serde(default)]
     pub models: Vec<ModelData>,
     pub patches: Option<ModelPatches>,
@@ -44,11 +43,34 @@ impl OllamaClient {
         let mut body = build_chat_completions_body(data, &self.model)?;
         self.patch_chat_completions_body(&mut body);
 
-        let chat_endpoint = self.config.chat_endpoint.as_deref().unwrap_or("/api/chat");
+        let url = format!("{api_base}/api/chat");
 
-        let url = format!("{api_base}{chat_endpoint}");
+        debug!("Ollama Chat Completions Request: {url} {body}");
 
-        debug!("Ollama Request: {url} {body}");
+        let mut builder = client.post(url).json(&body);
+        if let Some(api_auth) = api_auth {
+            builder = builder.header("Authorization", api_auth)
+        }
+
+        Ok(builder)
+    }
+
+    fn embeddings_builder(
+        &self,
+        client: &ReqwestClient,
+        data: EmbeddingsData,
+    ) -> Result<RequestBuilder> {
+        let api_base = self.get_api_base()?;
+        let api_auth = self.get_api_auth().ok();
+
+        let body = json!({
+            "model": self.model.name(),
+            "prompt": data.texts[0],
+        });
+
+        let url = format!("{api_base}/api/embeddings");
+
+        debug!("Ollama Embeddings Request: {url} {body}");
 
         let mut builder = client.post(url).json(&body);
         if let Some(api_auth) = api_auth {
@@ -62,7 +84,8 @@ impl OllamaClient {
 impl_client_trait!(
     OllamaClient,
     chat_completions,
-    chat_completions_streaming
+    chat_completions_streaming,
+    embeddings
 );
 
 async fn chat_completions(builder: RequestBuilder) -> Result<ChatCompletionsOutput> {
@@ -108,6 +131,25 @@ async fn chat_completions_streaming(
     }
 
     Ok(())
+}
+
+async fn embeddings(
+    builder: RequestBuilder,
+) -> Result<EmbeddingsOutput> {
+    let res = builder.send().await?;
+    let status = res.status();
+    let data = res.json().await?;
+    if !status.is_success() {
+        catch_error(&data, status.as_u16())?;
+    }
+    let res_body: EmbeddingsResBody = serde_json::from_value(data).context("Invalid request data")?;
+    let output = vec![res_body.embedding];
+    Ok(output)
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBody {
+    embedding: Vec<f32>,
 }
 
 fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Result<Value> {

--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -1,8 +1,4 @@
-use super::{
-    catch_error, json_stream, message::*, ChatCompletionsData, ChatCompletionsOutput, Client,
-    ExtraConfig, Model, ModelData, ModelPatches, OllamaClient, PromptAction, PromptKind,
-    SseHandler,
-};
+use super::*;
 
 use anyhow::{anyhow, bail, Result};
 use reqwest::{Client as ReqwestClient, RequestBuilder};
@@ -15,6 +11,7 @@ pub struct OllamaConfig {
     pub api_base: Option<String>,
     pub api_auth: Option<String>,
     pub chat_endpoint: Option<String>,
+    #[serde(default)]
     pub models: Vec<ModelData>,
     pub patches: Option<ModelPatches>,
     pub extra: Option<ExtraConfig>,
@@ -45,7 +42,7 @@ impl OllamaClient {
         let api_auth = self.get_api_auth().ok();
 
         let mut body = build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         let chat_endpoint = self.config.chat_endpoint.as_deref().unwrap_or("/api/chat");
 
@@ -62,7 +59,11 @@ impl OllamaClient {
     }
 }
 
-impl_client_trait!(OllamaClient, chat_completions, chat_completions_streaming);
+impl_client_trait!(
+    OllamaClient,
+    chat_completions,
+    chat_completions_streaming
+);
 
 async fn chat_completions(builder: RequestBuilder) -> Result<ChatCompletionsOutput> {
     let res = builder.send().await?;

--- a/src/client/openai_compatible.rs
+++ b/src/client/openai_compatible.rs
@@ -53,7 +53,7 @@ impl OpenAICompatibleClient {
 
         let url = format!("{api_base}{chat_endpoint}");
 
-        debug!("OpenAICompatible Request: {url} {body}");
+        debug!("OpenAICompatible Chat Completions Request: {url} {body}");
 
         let mut builder = client.post(url).json(&body);
         if let Some(api_key) = api_key {
@@ -74,6 +74,8 @@ impl OpenAICompatibleClient {
         let body = openai_build_embeddings_body(data, &self.model);
 
         let url = format!("{api_base}/embeddings");
+
+        debug!("OpenAICompatible Embeddings Request: {url} {body}");
 
         let builder = client.post(url).bearer_auth(api_key).json(&body);
 

--- a/src/client/qianwen.rs
+++ b/src/client/qianwen.rs
@@ -1,8 +1,4 @@
-use super::{
-    maybe_catch_error, message::*, sse_stream, ChatCompletionsData, ChatCompletionsOutput, Client,
-    ExtraConfig, Model, ModelData, ModelPatches, PromptAction, PromptKind, QianwenClient,
-    SseHandler, SseMmessage,
-};
+use super::*;
 
 use crate::utils::{base64_decode, sha256};
 
@@ -52,7 +48,7 @@ impl QianwenClient {
             false => API_URL,
         };
         let (mut body, has_upload) = build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         debug!("Qianwen Request: {url} {body}");
 

--- a/src/client/qianwen.rs
+++ b/src/client/qianwen.rs
@@ -12,11 +12,14 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::borrow::BorrowMut;
 
-const API_URL: &str =
+const CHAT_COMPLETIONS_API_URL: &str =
     "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation";
 
-const API_URL_VL: &str =
+const CHAT_COMPLETIONS_API_URL_VL: &str =
     "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation";
+
+const EMBEDDINGS_API_URL: &str = 
+    "https://dashscope.aliyuncs.com/api/v1/services/embeddings/text-embedding/text-embedding";
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct QianwenConfig {
@@ -44,13 +47,13 @@ impl QianwenClient {
         let stream = data.stream;
 
         let url = match self.model.supports_vision() {
-            true => API_URL_VL,
-            false => API_URL,
+            true => CHAT_COMPLETIONS_API_URL_VL,
+            false => CHAT_COMPLETIONS_API_URL,
         };
         let (mut body, has_upload) = build_chat_completions_body(data, &self.model)?;
         self.patch_chat_completions_body(&mut body);
 
-        debug!("Qianwen Request: {url} {body}");
+        debug!("Qianwen Chat Completions Request: {url} {body}");
 
         let mut builder = client.post(url).bearer_auth(api_key).json(&body);
         if stream {
@@ -59,6 +62,37 @@ impl QianwenClient {
         if has_upload {
             builder = builder.header("X-DashScope-OssResourceResolve", "enable");
         }
+
+        Ok(builder)
+    }
+
+    fn embeddings_builder(
+        &self,
+        client: &ReqwestClient,
+        data: EmbeddingsData,
+    ) -> Result<RequestBuilder> {
+        let api_key = self.get_api_key()?;
+
+        let text_type = match data.query {
+            true => "query",
+            false => "document",
+        };
+
+        let body = json!({
+            "model": self.model.name(),
+            "input": {
+                "texts": data.texts,
+            },
+            "parameters": {
+                "text_type": text_type,
+            }
+        });
+
+        let url = EMBEDDINGS_API_URL;
+
+        debug!("Qianwen Embeddings Request: {url} {body}");
+
+        let builder = client.post(url).bearer_auth(api_key).json(&body);
 
         Ok(builder)
     }
@@ -89,6 +123,15 @@ impl Client for QianwenClient {
         patch_messages(self.model.name(), &api_key, &mut data.messages).await?;
         let builder = self.chat_completions_builder(client, data)?;
         chat_completions_streaming(builder, handler, &self.model).await
+    }
+
+    async fn embeddings_inner(
+        &self,
+        client: &ReqwestClient,
+        data: EmbeddingsData,
+    ) -> Result<Vec<Vec<f32>>> {
+        let builder = self.embeddings_builder(client, data)?;
+        embeddings(builder).await
     }
 }
 
@@ -204,6 +247,31 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
     });
 
     Ok((body, has_upload))
+}
+
+async fn embeddings(
+    builder: RequestBuilder,
+) -> Result<EmbeddingsOutput> {
+    let data: Value = builder.send().await?.json().await?;
+    maybe_catch_error(&data)?;
+    let res_body: EmbeddingsResBody = serde_json::from_value(data).context("Invalid request data")?;
+    let output = res_body.output.embeddings.into_iter().map(|v| v.embedding).collect();
+    Ok(output)
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBody {
+    output: EmbeddingsResBodyOutput,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBodyOutput {
+    embeddings: Vec<EmbeddingsResBodyOutputEmbedding>,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBodyOutputEmbedding {
+    embedding: Vec<f32>,
 }
 
 fn extract_chat_completions_text(data: &Value, model: &Model) -> Result<ChatCompletionsOutput> {

--- a/src/client/replicate.rs
+++ b/src/client/replicate.rs
@@ -1,8 +1,5 @@
-use super::{
-    catch_error, prompt_format::*, sse_stream, ChatCompletionsData, ChatCompletionsOutput, Client,
-    ExtraConfig, Model, ModelData, ModelPatches, PromptAction, PromptKind, ReplicateClient,
-    SseHandler, SseMmessage,
-};
+use super::*;
+use super::prompt_format::*;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -36,7 +33,7 @@ impl ReplicateClient {
         api_key: &str,
     ) -> Result<RequestBuilder> {
         let mut body = build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         let url = format!("{API_BASE}/models/{}/predictions", self.model.name());
 

--- a/src/client/vertexai.rs
+++ b/src/client/vertexai.rs
@@ -50,7 +50,35 @@ impl VertexAIClient {
         let mut body = gemini_build_chat_completions_body(data, &self.model)?;
         self.patch_chat_completions_body(&mut body);
 
-        debug!("VertexAI Request: {url} {body}");
+        debug!("VertexAI Chat Completions Request: {url} {body}");
+
+        let builder = client.post(url).bearer_auth(access_token).json(&body);
+
+        Ok(builder)
+    }
+
+    fn embeddings_builder(
+        &self,
+        client: &ReqwestClient,
+        data: EmbeddingsData,
+    ) -> Result<RequestBuilder> {
+        let project_id = self.get_project_id()?;
+        let location = self.get_location()?;
+        let access_token = get_access_token(self.name())?;
+
+        let base_url = format!("https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/publishers");
+        let url = format!("{base_url}/google/models/{}:predict", self.model.name());
+
+        let task_type = match data.query {
+            true => "RETRIEVAL_DOCUMENT",
+            false => "QUESTION_ANSWERING",
+        };
+        let instances: Vec<_> = data.texts.into_iter().map(|v| json!({"task_type": task_type, "content": v})).collect();
+        let body = json!({
+            "instances": instances,
+        });
+
+        debug!("VertexAI Embeddings Request: {url} {body}");
 
         let builder = client.post(url).bearer_auth(access_token).json(&body);
 
@@ -81,6 +109,16 @@ impl Client for VertexAIClient {
         prepare_gcloud_access_token(client, self.name(), &self.config.adc_file).await?;
         let builder = self.chat_completions_builder(client, data)?;
         gemini_chat_completions_streaming(builder, handler).await
+    }
+
+    async fn embeddings_inner(
+        &self,
+        client: &ReqwestClient,
+        data: EmbeddingsData,
+    ) -> Result<Vec<Vec<f32>>> {
+        prepare_gcloud_access_token(client, self.name(), &self.config.adc_file).await?;
+        let builder = self.embeddings_builder(client, data)?;
+        embeddings(builder).await
     }
 }
 
@@ -135,6 +173,34 @@ pub async fn gemini_chat_completions_streaming(
     Ok(())
 }
 
+async fn embeddings(builder: RequestBuilder) -> Result<EmbeddingsOutput> {
+    let res = builder.send().await?;
+    let status = res.status();
+    let data: Value = res.json().await?;
+    if !status.is_success() {
+        catch_error(&data, status.as_u16())?;
+    }
+    let res_body: EmbeddingsResBody =
+        serde_json::from_value(data).context("Invalid request data")?;
+    let output = res_body.predictions.into_iter().map(|v| v.embeddings.values).collect();
+    Ok(output)
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBody {
+    predictions: Vec<EmbeddingsResBodyPrediction>,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBodyPrediction {
+    embeddings: EmbeddingsResBodyPredictionEmbeddings,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingsResBodyPredictionEmbeddings {
+    values: Vec<f32>
+}
+
 fn gemini_extract_chat_completions_text(data: &Value) -> Result<ChatCompletionsOutput> {
     let text = data["candidates"][0]["content"]["parts"][0]["text"]
         .as_str()
@@ -176,7 +242,7 @@ fn gemini_extract_chat_completions_text(data: &Value) -> Result<ChatCompletionsO
     Ok(output)
 }
 
-pub(crate) fn gemini_build_chat_completions_body(
+pub fn gemini_build_chat_completions_body(
     data: ChatCompletionsData,
     model: &Model,
 ) -> Result<Value> {

--- a/src/client/vertexai.rs
+++ b/src/client/vertexai.rs
@@ -1,8 +1,5 @@
-use super::{
-    access_token::*, catch_error, json_stream, message::*, patch_system_message,
-    ChatCompletionsData, ChatCompletionsOutput, Client, ExtraConfig, Model, ModelData,
-    ModelPatches, PromptAction, PromptKind, SseHandler, ToolCall, VertexAIClient,
-};
+use super::*;
+use super::access_token::*;
 
 use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
@@ -51,7 +48,7 @@ impl VertexAIClient {
         let url = format!("{base_url}/google/models/{}:{func}", self.model.name());
 
         let mut body = gemini_build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
 
         debug!("VertexAI Request: {url} {body}");
 

--- a/src/client/vertexai_claude.rs
+++ b/src/client/vertexai_claude.rs
@@ -1,8 +1,7 @@
-use super::{
-    access_token::*, claude::*, vertexai::*, ChatCompletionsData, ChatCompletionsOutput, Client,
-    ExtraConfig, Model, ModelData, ModelPatches, PromptAction, PromptKind, SseHandler,
-    VertexAIClaudeClient,
-};
+use super::*;
+use super::access_token::*;
+use super::claude::*;
+use super::vertexai::*;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -46,7 +45,7 @@ impl VertexAIClaudeClient {
         );
 
         let mut body = claude_build_chat_completions_body(data, &self.model)?;
-        self.patch_request_body(&mut body);
+        self.patch_chat_completions_body(&mut body);
         if let Some(body_obj) = body.as_object_mut() {
             body_obj.remove("model");
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1218,7 +1218,7 @@ fn create_config_file(config_path: &Path) -> Result<()> {
         std::fs::set_permissions(config_path, perms)?;
     }
 
-    println!("✨ Saved config file to '{}'", config_path.display());
+    println!("✨ Saved config file to '{}'\n", config_path.display());
 
     Ok(())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,14 +7,15 @@ pub use self::role::{Role, CODE_ROLE, EXPLAIN_SHELL_ROLE, SHELL_ROLE};
 use self::session::{Session, TEMP_SESSION_NAME};
 
 use crate::client::{
-    create_client_config, list_client_types, list_models, ClientConfig, Model,
+    create_client_config, list_chat_models, list_client_types, ClientConfig, Model,
     OPENAI_COMPATIBLE_PLATFORMS,
 };
 use crate::function::{Function, ToolCallResult};
+use crate::rag::{Rag, TEMP_RAG_NAME};
 use crate::render::{MarkdownRender, RenderOptions};
 use crate::utils::{
     format_option_value, fuzzy_match, get_env_name, light_theme_from_colorfgbg, now, render_prompt,
-    set_text,
+    set_text, AbortSignal,
 };
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -42,6 +43,7 @@ const CONFIG_FILE_NAME: &str = "config.yaml";
 const ROLES_FILE_NAME: &str = "roles.yaml";
 const MESSAGES_FILE_NAME: &str = "messages.md";
 const SESSIONS_DIR_NAME: &str = "sessions";
+const RAGS_DIR_NAME: &str = "rags";
 const FUNCTIONS_DIR_NAME: &str = "functions";
 
 const CLIENTS_FIELD: &str = "clients";
@@ -49,7 +51,16 @@ const CLIENTS_FIELD: &str = "clients";
 const SUMMARIZE_PROMPT: &str =
     "Summarize the discussion briefly in 200 words or less to use as a prompt for future context.";
 const SUMMARY_PROMPT: &str = "This is a summary of the chat history as a recap: ";
-const LEFT_PROMPT: &str = "{color.green}{?session {session}{?role /}}{role}{color.cyan}{?session )}{!session >}{color.reset} ";
+
+const RAG_PROMPT: &str = r#"Use the following context as your learned knowledge to answer the question
+<context>
+__CONTEXT__
+</context>
+
+__INPUT__
+"#;
+
+const LEFT_PROMPT: &str = "{color.green}{?session {session}{?role /}}{role}{?rag #{rag}}{color.cyan}{?session )}{!session >}{color.reset} ";
 const RIGHT_PROMPT: &str = "{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{color.reset}";
 
 #[derive(Debug, Clone, Deserialize)]
@@ -71,6 +82,8 @@ pub struct Config {
     pub keybindings: Keybindings,
     pub prelude: Option<String>,
     pub buffer_editor: Option<String>,
+    pub embedding_model: Option<String>,
+    pub rag_prompt: Option<String>,
     pub function_calling: bool,
     pub compress_threshold: usize,
     pub summarize_prompt: Option<String>,
@@ -84,6 +97,8 @@ pub struct Config {
     pub role: Option<Role>,
     #[serde(skip)]
     pub session: Option<Session>,
+    #[serde(skip)]
+    pub rag: Option<Arc<Rag>>,
     #[serde(skip)]
     pub model: Model,
     #[serde(skip)]
@@ -111,6 +126,8 @@ impl Default for Config {
             keybindings: Default::default(),
             prelude: None,
             buffer_editor: None,
+            embedding_model: None,
+            rag_prompt: None,
             function_calling: false,
             compress_threshold: 4000,
             summarize_prompt: None,
@@ -121,6 +138,7 @@ impl Default for Config {
             roles: vec![],
             role: None,
             session: None,
+            rag: None,
             model: Default::default(),
             function: Default::default(),
             working_mode: WorkingMode::Command,
@@ -170,12 +188,12 @@ impl Config {
         match prelude.split_once(':') {
             Some(("role", name)) => {
                 if self.role.is_none() && self.session.is_none() {
-                    self.set_role(name).with_context(err_msg)?;
+                    self.use_role(name).with_context(err_msg)?;
                 }
             }
             Some(("session", name)) => {
                 if self.session.is_none() {
-                    self.start_session(Some(name)).with_context(err_msg)?;
+                    self.use_session(Some(name)).with_context(err_msg)?;
                 }
             }
             _ => {
@@ -289,6 +307,10 @@ impl Config {
         Self::local_path(SESSIONS_DIR_NAME)
     }
 
+    pub fn rags_dir() -> Result<PathBuf> {
+        Self::local_path(RAGS_DIR_NAME)
+    }
+
     pub fn functions_dir() -> Result<PathBuf> {
         Self::local_path(FUNCTIONS_DIR_NAME)
     }
@@ -299,17 +321,23 @@ impl Config {
         Ok(path)
     }
 
-    pub fn set_prompt(&mut self, prompt: &str) -> Result<()> {
+    pub fn rag_file(name: &str) -> Result<PathBuf> {
+        let mut path = Self::rags_dir()?;
+        path.push(&format!("{name}.bin"));
+        Ok(path)
+    }
+
+    pub fn use_prompt(&mut self, prompt: &str) -> Result<()> {
         let role = Role::temp(prompt);
-        self.set_role_obj(role)
+        self.use_role_obj(role)
     }
 
-    pub fn set_role(&mut self, name: &str) -> Result<()> {
+    pub fn use_role(&mut self, name: &str) -> Result<()> {
         let role = self.retrieve_role(name)?;
-        self.set_role_obj(role)
+        self.use_role_obj(role)
     }
 
-    pub fn set_role_obj(&mut self, role: Role) -> Result<()> {
+    pub fn use_role_obj(&mut self, role: Role) -> Result<()> {
         if let Some(session) = self.session.as_mut() {
             session.guard_empty()?;
             session.set_role_properties(&role);
@@ -321,7 +349,7 @@ impl Config {
         Ok(())
     }
 
-    pub fn clear_role(&mut self) -> Result<()> {
+    pub fn exit_role(&mut self) -> Result<()> {
         self.role = None;
         self.restore_model()?;
         Ok(())
@@ -337,7 +365,10 @@ impl Config {
             }
         }
         if self.role.is_some() {
-            flags |= StateFlags::ROLE
+            flags |= StateFlags::ROLE;
+        }
+        if self.rag.is_some() {
+            flags |= StateFlags::RAG;
         }
         flags
     }
@@ -393,7 +424,7 @@ impl Config {
     }
 
     pub fn set_model(&mut self, value: &str) -> Result<()> {
-        let models = list_models(self);
+        let models = list_chat_models(self);
         let model = Model::find(&models, value);
         match model {
             None => bail!("No model '{}'", value),
@@ -458,6 +489,7 @@ impl Config {
             ("roles_file", display_path(&Self::roles_file()?)),
             ("messages_file", display_path(&Self::messages_file()?)),
             ("sessions_dir", display_path(&Self::sessions_dir()?)),
+            ("rags_dir", display_path(&Self::rags_dir()?)),
             ("functions_dir", display_path(&Self::functions_dir()?)),
         ];
         let output = items
@@ -486,11 +518,21 @@ impl Config {
         }
     }
 
+    pub fn rag_info(&self) -> Result<String> {
+        if let Some(rag) = &self.rag {
+            rag.export()
+        } else {
+            bail!("No rag")
+        }
+    }
+
     pub fn info(&self) -> Result<String> {
         if let Some(session) = &self.session {
             session.export()
         } else if let Some(role) = &self.role {
             role.export()
+        } else if let Some(rag) = &self.rag {
+            rag.export()
         } else {
             self.system_info()
         }
@@ -511,12 +553,17 @@ impl Config {
                     .iter()
                     .map(|v| (v.name.clone(), String::new()))
                     .collect(),
-                ".model" => list_models(self)
+                ".model" => list_chat_models(self)
                     .into_iter()
                     .map(|v| (v.id(), v.description()))
                     .collect(),
                 ".session" => self
                     .list_sessions()
+                    .into_iter()
+                    .map(|v| (v.clone(), String::new()))
+                    .collect(),
+                ".rag" => self
+                    .list_rags()
                     .into_iter()
                     .map(|v| (v.clone(), String::new()))
                     .collect(),
@@ -625,7 +672,7 @@ impl Config {
         Ok(())
     }
 
-    pub fn start_session(&mut self, session: Option<&str>) -> Result<()> {
+    pub fn use_session(&mut self, session: Option<&str>) -> Result<()> {
         if self.session.is_some() {
             bail!(
                 "Already in a session, please run '.exit session' first to exit the current session."
@@ -671,7 +718,7 @@ impl Config {
         Ok(())
     }
 
-    pub fn end_session(&mut self) -> Result<()> {
+    pub fn exit_session(&mut self) -> Result<()> {
         if let Some(mut session) = self.session.take() {
             self.last_message = None;
             let save_session = session.save_session();
@@ -767,6 +814,74 @@ impl Config {
         }
     }
 
+    pub async fn use_rag(
+        config: &GlobalConfig,
+        rag: Option<&str>,
+        abort_signal: AbortSignal,
+    ) -> Result<()> {
+        if config.read().rag.is_some() {
+            bail!("Already in a rag, please run '.exit rag' first to exit the current rag.");
+        }
+        let rag = match rag {
+            None => {
+                let rag_path = Self::rag_file(TEMP_RAG_NAME)?;
+                if rag_path.exists() {
+                    remove_file(&rag_path).with_context(|| {
+                        format!("Failed to cleanup previous '{TEMP_RAG_NAME}' rag")
+                    })?;
+                }
+                Rag::init(config, TEMP_RAG_NAME, &rag_path, abort_signal).await?
+            }
+            Some(name) => {
+                let rag_path = Self::rag_file(name)?;
+                if !rag_path.exists() {
+                    Rag::init(config, name, &rag_path, abort_signal).await?
+                } else {
+                    Rag::load(config, name, &rag_path)?
+                }
+            }
+        };
+        config.write().rag = Some(Arc::new(rag));
+        Ok(())
+    }
+
+    pub fn exit_rag(&mut self) -> Result<()> {
+        self.rag.take();
+        Ok(())
+    }
+
+    pub fn list_rags(&self) -> Vec<String> {
+        let rags_dir = match Self::rags_dir() {
+            Ok(dir) => dir,
+            Err(_) => return vec![],
+        };
+        match read_dir(rags_dir) {
+            Ok(rd) => {
+                let mut names = vec![];
+                for entry in rd.flatten() {
+                    let name = entry.file_name();
+                    if let Some(name) = name.to_string_lossy().strip_suffix(".bin") {
+                        names.push(name.to_string());
+                    }
+                }
+                names.sort_unstable();
+                names
+            }
+            Err(_) => vec![],
+        }
+    }
+
+    pub fn rag_prompt(&self, embeddings: &str, text: &str) -> String {
+        if embeddings.is_empty() {
+            return text.to_string();
+        }
+        self.rag_prompt
+            .as_deref()
+            .unwrap_or(RAG_PROMPT)
+            .replace("__CONTEXT__", embeddings)
+            .replace("__INPUT__", text)
+    }
+
     pub fn get_render_options(&self) -> Result<RenderOptions> {
         let theme = if self.highlight {
             let theme_mode = if self.light_theme { "light" } else { "dark" };
@@ -857,6 +972,9 @@ impl Config {
             output.insert("consume_tokens", tokens.to_string());
             output.insert("consume_percent", percent.to_string());
             output.insert("user_messages_len", session.user_messages_len().to_string());
+        }
+        if let Some(rag) = &self.rag {
+            output.insert("rag", rag.name().to_string());
         }
 
         if self.highlight {
@@ -974,7 +1092,7 @@ impl Config {
 
     fn setup_model(&mut self) -> Result<()> {
         let model_id = if self.model_id.is_empty() {
-            let models = list_models(self);
+            let models = list_chat_models(self);
             if models.is_empty() {
                 bail!("No available model");
             }
@@ -1049,6 +1167,7 @@ bitflags::bitflags! {
         const ROLE = 1 << 0;
         const SESSION_EMPTY = 1 << 1;
         const SESSION = 1 << 2;
+        const RAG = 1 << 3;
     }
 }
 
@@ -1090,12 +1209,12 @@ fn create_config_file(config_path: &Path) -> Result<()> {
         std::fs::set_permissions(config_path, perms)?;
     }
 
-    println!("✨ Saved config file to {}\n", config_path.display());
+    println!("✨ Saved config file to '{}'", config_path.display());
 
     Ok(())
 }
 
-fn ensure_parent_exists(path: &Path) -> Result<()> {
+pub(crate) fn ensure_parent_exists(path: &Path) -> Result<()> {
     if path.exists() {
         return Ok(());
     }

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -160,7 +160,7 @@ impl Session {
         data["messages"] = json!(self.messages);
 
         let output = serde_yaml::to_string(&data)
-            .with_context(|| format!("Unable to show info about session {}", &self.name))?;
+            .with_context(|| format!("Unable to show info about session '{}'", &self.name))?;
         Ok(output)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ async fn main() -> Result<()> {
 #[async_recursion]
 async fn start_directive(
     config: &GlobalConfig,
-    input: Input,
+    mut input: Input,
     no_stream: bool,
     code_mode: bool,
 ) -> Result<()> {
@@ -175,7 +175,7 @@ async fn start_directive(
     };
     config
         .write()
-        .save_message(&input, &output, &tool_call_results)?;
+        .save_message(&mut input, &output, &tool_call_results)?;
     config.write().exit_session()?;
     if need_send_call_results(&tool_call_results) {
         start_directive(
@@ -211,7 +211,7 @@ async fn shell_execute(config: &GlobalConfig, shell: &Shell, mut input: Input) -
     if let Ok(true) = CODE_BLOCK_RE.is_match(&eval_str) {
         eval_str = extract_block(&eval_str);
     }
-    config.write().save_message(&input, &eval_str, &[])?;
+    config.write().save_message(&mut input, &eval_str, &[])?;
     config.read().maybe_copy(&eval_str);
     let render_options = config.read().get_render_options()?;
     let mut markdown_render = MarkdownRender::init(render_options)?;

--- a/src/rag/loader.rs
+++ b/src/rag/loader.rs
@@ -1,0 +1,106 @@
+use super::RagDocument;
+
+use anyhow::{bail, Result};
+use async_recursion::async_recursion;
+use std::path::Path;
+use tokio::fs;
+
+pub async fn load_text(path: &str) -> Result<Vec<RagDocument>> {
+    let contents = fs::read_to_string(path).await?;
+    let document = RagDocument::new(contents);
+    Ok(vec![document])
+}
+
+pub fn parse_glob(path_str: &str) -> Result<(String, Vec<String>)> {
+    if let Some(start) = path_str.find("/**/*.").or_else(|| path_str.find(r"\**\*.")) {
+        let base_path = path_str[..start].to_string();
+        if let Some(curly_brace_end) = path_str[start..].find('}') {
+            let end = start + curly_brace_end;
+            let extensions_str = &path_str[start + 6..end + 1];
+            let extensions = if extensions_str.starts_with('{') && extensions_str.ends_with('}') {
+                extensions_str[1..extensions_str.len() - 1]
+                    .split(',')
+                    .map(|s| s.to_string())
+                    .collect::<Vec<String>>()
+            } else {
+                bail!("Invalid path '{path_str}'");
+            };
+            Ok((base_path, extensions))
+        } else {
+            let extensions_str = &path_str[start + 6..];
+            let extensions = vec![extensions_str.to_string()];
+            Ok((base_path, extensions))
+        }
+    } else {
+        Ok((path_str.to_string(), vec![]))
+    }
+}
+
+#[async_recursion]
+pub async fn list_files(
+    files: &mut Vec<String>,
+    entry_path: &Path,
+    suffixes: Option<&Vec<String>>,
+) -> Result<()> {
+    if entry_path.is_file() {
+        add_file(files, suffixes, entry_path);
+        return Ok(());
+    }
+    if !entry_path.is_dir() {
+        bail!("Path is not a directory: {:?}", entry_path);
+    }
+    let mut reader = fs::read_dir(entry_path).await?;
+    while let Some(entry) = reader.next_entry().await? {
+        let path = entry.path();
+        if path.is_file() {
+            add_file(files, suffixes, &path);
+        } else if path.is_dir() {
+            list_files(files, &path, suffixes).await?;
+        }
+    }
+    Ok(())
+}
+
+fn add_file(files: &mut Vec<String>, suffixes: Option<&Vec<String>>, path: &Path) {
+    if is_valid_extension(suffixes, path) {
+        files.push(path.display().to_string());
+    }
+}
+
+fn is_valid_extension(suffixes: Option<&Vec<String>>, path: &Path) -> bool {
+    if let Some(suffixes) = suffixes {
+        if !suffixes.is_empty() {
+            if let Some(extension) = path.extension().map(|v| v.to_string_lossy().to_string()) {
+                return suffixes.contains(&extension);
+            }
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_glob() {
+        assert_eq!(parse_glob("dir").unwrap(), ("dir".into(), vec![]));
+        assert_eq!(
+            parse_glob("dir/file.md").unwrap(),
+            ("dir/file.md".into(), vec![])
+        );
+        assert_eq!(
+            parse_glob("dir/**/*.md").unwrap(),
+            ("dir".into(), vec!["md".into()])
+        );
+        assert_eq!(
+            parse_glob("dir/**/*.{md,txt}").unwrap(),
+            ("dir".into(), vec!["md".into(), "txt".into()])
+        );
+        assert_eq!(
+            parse_glob("C:\\dir\\**\\*.{md,txt}").unwrap(),
+            ("C:\\dir".into(), vec!["md".into(), "txt".into()])
+        );
+    }
+}

--- a/src/rag/loader.rs
+++ b/src/rag/loader.rs
@@ -42,12 +42,15 @@ pub async fn list_files(
     entry_path: &Path,
     suffixes: Option<&Vec<String>>,
 ) -> Result<()> {
+    if !entry_path.exists() {
+        bail!("Not found: {:?}", entry_path);
+    }
     if entry_path.is_file() {
         add_file(files, suffixes, entry_path);
         return Ok(());
     }
     if !entry_path.is_dir() {
-        bail!("Path is not a directory: {:?}", entry_path);
+        bail!("Not a directory: {:?}", entry_path);
     }
     let mut reader = fs::read_dir(entry_path).await?;
     while let Some(entry) = reader.next_entry().await? {

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -53,7 +53,7 @@ impl Rag {
     ) -> Result<Self> {
         debug!("init rag: {name}");
         let model = select_embedding_model(config)?;
-        let chunk_size = model.max_chunk_size();
+        let chunk_size = model.default_chunk_size();
         let chunk_size = set_chunk_size(chunk_size)?;
         let data = RagData::new(&model.id(), chunk_size);
         let mut rag = Self::create(config, name, path, data)?;
@@ -400,15 +400,7 @@ fn set_chunk_size(chunk_size: usize) -> Result<usize> {
         .with_default(&chunk_size.to_string())
         .with_validator(move |text: &str| {
             let out = match text.parse::<usize>() {
-                Ok(value) => {
-                    if value > chunk_size {
-                        Validation::Invalid(
-                            format!("Must be less than or equal to {chunk_size}").into(),
-                        )
-                    } else {
-                        Validation::Valid
-                    }
-                }
+                Ok(_) => Validation::Valid,
                 Err(_) => Validation::Invalid("Must be a integer".into()),
             };
             Ok(out)
@@ -418,7 +410,7 @@ fn set_chunk_size(chunk_size: usize) -> Result<usize> {
 }
 
 fn add_document_paths() -> Result<Vec<String>> {
-    let text = Text::new("Add doc paths:")
+    let text = Text::new("Add document paths:")
         .with_validator(required!("This field is required"))
         .with_help_message("e.g. file1;dir2/;dir3/**/*.md")
         .prompt()?;

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -1,0 +1,350 @@
+use self::loader::*;
+use self::splitter::*;
+
+use crate::client::*;
+use crate::config::*;
+use crate::utils::*;
+
+mod loader;
+mod splitter;
+
+use anyhow::bail;
+use anyhow::{anyhow, Context, Result};
+use hnsw_rs::prelude::*;
+use indexmap::IndexMap;
+use inquire::{required, Select, Text};
+use path_absolutize::Absolutize;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::fmt::Debug;
+use std::{io::BufReader, path::Path};
+use tokio::sync::oneshot;
+
+pub const TEMP_RAG_NAME: &str = "temp";
+pub const CHUNK_SIZE: usize = 1500;
+pub const CHUNK_OVERLAP: usize = 100;
+pub const NUM_RESULTS: usize = 5;
+
+pub struct Rag {
+    client: Box<dyn Client>,
+    name: String,
+    path: String,
+    model: Model,
+    hnsw: Hnsw<'static, f32, DistCosine>,
+    data: RagData,
+}
+
+impl Debug for Rag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Rag")
+            .field("name", &self.name)
+            .field("path", &self.path)
+            .field("model", &self.model)
+            .field("data", &self.data)
+            .finish()
+    }
+}
+
+impl Rag {
+    pub async fn init(
+        config: &GlobalConfig,
+        name: &str,
+        path: &Path,
+        abort_signal: AbortSignal,
+    ) -> Result<Self> {
+        debug!("init rag: {name}");
+        let model = Self::select_embedding_model(config)?;
+        let data = RagData::new(&model.id());
+        let mut rag = Self::create(config, name, path, data)?;
+
+        let paths: Vec<String> = {
+            let text = Text::new("Add paths:")
+                .with_validator(required!("This field is required"))
+                .with_help_message("e.g. file1;dir2/;dir3/**/*.md")
+                .prompt()?;
+            text.split(';').map(|v| v.to_string()).collect()
+        };
+        debug!("rag paths: {paths:?}");
+        tokio::select! {
+            ret = rag.add_paths(&paths) => {
+                ret?;
+            }
+            _ = watch_abort_signal(abort_signal) => {
+                bail!("Aborted!")
+            },
+        };
+        if !rag.is_temp() {
+            rag.save(path)?;
+        }
+        Ok(rag)
+    }
+
+    pub fn load(config: &GlobalConfig, name: &str, path: &Path) -> Result<Self> {
+        let err = || format!("Failed to load rag '{name}'");
+        let file = std::fs::File::open(path).with_context(err)?;
+        let reader = BufReader::new(file);
+        let data: RagData = bincode::deserialize_from(reader).with_context(err)?;
+        Self::create(config, name, path, data)
+    }
+
+    pub fn create(config: &GlobalConfig, name: &str, path: &Path, data: RagData) -> Result<Self> {
+        let hnsw = data.build_hnsw();
+        let model = retrive_embedding_model(&config.read(), &data.model)?;
+        let client = init_client(config, Some(model.clone()))?;
+        let rag = Rag {
+            client,
+            name: name.to_string(),
+            path: path.display().to_string(),
+            data,
+            model,
+            hnsw,
+        };
+        Ok(rag)
+    }
+
+    pub fn select_embedding_model(config: &GlobalConfig) -> Result<Model> {
+        let config = config.read();
+        let model = match config.embedding_model.clone() {
+            Some(model_id) => retrive_embedding_model(&config, &model_id)?,
+            None => {
+                let models = list_embedding_models(&config);
+                if models.is_empty() {
+                    bail!("No embedding model");
+                }
+                let model_ids: Vec<_> = models.iter().map(|v| v.id()).collect();
+                let model_id = Select::new("Select embedding model:", model_ids).prompt()?;
+                retrive_embedding_model(&config, &model_id)?
+            }
+        };
+        Ok(model)
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        ensure_parent_exists(path)?;
+        let mut file = std::fs::File::create(path)?;
+        bincode::serialize_into(&mut file, &self.data)
+            .with_context(|| format!("Failed to save rag '{}'", self.name))?;
+        Ok(())
+    }
+
+    pub fn export(&self) -> Result<String> {
+        let files: Vec<_> = self.data.files.iter().map(|v| &v.path).collect();
+        let data = json!({
+            "path": self.path,
+            "model": self.model.id(),
+            "files": files,
+        });
+        let output = serde_yaml::to_string(&data)
+            .with_context(|| format!("Unable to show info about rag '{}'", self.name))?;
+        Ok(output)
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn is_temp(&self) -> bool {
+        self.name == TEMP_RAG_NAME
+    }
+
+    pub async fn search(&self, text: &str, abort_signal: AbortSignal) -> Result<String> {
+        let (spinner_tx, spinner_rx) = oneshot::channel();
+        tokio::spawn(run_spinner(" Embedding", spinner_rx));
+        let ret = tokio::select! {
+            ret = self.search_inner(text) => {
+                ret
+            }
+            _ = watch_abort_signal(abort_signal) => {
+                bail!("Aborted!")
+            },
+        };
+        let _ = spinner_tx.send(());
+        let output = ret?.join("\n\n");
+        Ok(output)
+    }
+
+    pub async fn add_paths<T: AsRef<Path>>(&mut self, paths: &[T]) -> Result<()> {
+        // List files
+        let mut file_paths = vec![];
+        for path in paths {
+            let path = path
+                .as_ref()
+                .absolutize()
+                .with_context(|| anyhow!("Invalid path '{}'", path.as_ref().display()))?;
+            let path_str = path.display().to_string();
+            if self.data.files.iter().any(|v| v.path == path_str) {
+                continue;
+            }
+            let (path_str, suffixes) = parse_glob(&path_str)?;
+            let suffixes = if suffixes.is_empty() {
+                None
+            } else {
+                Some(&suffixes)
+            };
+            list_files(&mut file_paths, Path::new(&path_str), suffixes).await?;
+        }
+
+        // Load files
+        let mut rag_files = vec![];
+        for path in file_paths {
+            let extension = Path::new(&path)
+                .extension()
+                .map(|v| v.to_string_lossy())
+                .unwrap_or_default();
+            let separater = autodetect_separater(&extension);
+            let splitter = Splitter::new(CHUNK_SIZE, CHUNK_OVERLAP, separater);
+            let documents = load_text(&path)
+                .await
+                .with_context(|| format!("Failed to load text at '{path}'"))?;
+            let documents =
+                splitter.split_documents(&documents, &SplitterChunkHeaderOptions::default());
+            rag_files.push(RagFile { path, documents });
+        }
+        if rag_files.is_empty() {
+            return Ok(());
+        }
+
+        // Convert vectors
+        let mut vector_ids = vec![];
+        let mut texts = vec![];
+        for (file_index, file) in rag_files.iter().enumerate() {
+            for (document_index, doc) in file.documents.iter().enumerate() {
+                vector_ids.push(combine_vector_id(file_index, document_index));
+                texts.push(doc.page_content.clone())
+            }
+        }
+        let embeddings_data = self.build_embeddings_data(texts, false);
+        let embeddings = self.create_embeddings(embeddings_data).await?;
+
+        self.data.add(rag_files, vector_ids, embeddings);
+        self.hnsw = self.data.build_hnsw();
+
+        Ok(())
+    }
+
+    async fn search_inner(&self, text: &str) -> Result<Vec<String>> {
+        let splitter = Splitter::new(CHUNK_SIZE, CHUNK_OVERLAP, &DEFAULT_SEPARATERS);
+        let texts = splitter.split_text(text);
+        let embeddings_data = self.build_embeddings_data(texts, true);
+        let embeddings = self.create_embeddings(embeddings_data).await?;
+        let output = self
+            .hnsw
+            .parallel_search(&embeddings, NUM_RESULTS, 30)
+            .into_iter()
+            .flat_map(|list| {
+                list.into_iter()
+                    .map(|v| {
+                        let (file_index, document_index) = split_vector_id(v.d_id);
+                        self.data.files[file_index].documents[document_index]
+                            .page_content
+                            .clone()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        Ok(output)
+    }
+
+    fn build_embeddings_data(&self, texts: Vec<String>, search: bool) -> EmbeddingsData {
+        EmbeddingsData { texts, search }
+    }
+
+    async fn create_embeddings(&self, data: EmbeddingsData) -> Result<EmbeddingsOutput> {
+        self.client
+            .embeddings(data)
+            .await
+            .context("Failed to create embedding")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RagData {
+    pub model: String,
+    pub files: Vec<RagFile>,
+    pub vectors: IndexMap<VectorID, Vec<f32>>,
+}
+
+impl RagData {
+    pub fn new(model: &str) -> Self {
+        Self {
+            model: model.to_string(),
+            files: Default::default(),
+            vectors: Default::default(),
+        }
+    }
+
+    pub fn add(
+        &mut self,
+        files: Vec<RagFile>,
+        vector_ids: Vec<VectorID>,
+        embeddings: EmbeddingsOutput,
+    ) {
+        self.files.extend(files);
+        self.vectors.extend(vector_ids.into_iter().zip(embeddings));
+    }
+
+    pub fn build_hnsw(&self) -> Hnsw<'static, f32, DistCosine> {
+        let hnsw = Hnsw::new(16, 100, 16, 200, DistCosine {});
+        let datas: Vec<_> = self.vectors.iter().map(|(k, v)| (v, *k)).collect();
+        hnsw.parallel_insert(&datas);
+        hnsw
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RagFile {
+    path: String,
+    documents: Vec<RagDocument>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RagDocument {
+    pub page_content: String,
+    pub metadata: RagMetadata,
+}
+
+pub type RagMetadata = IndexMap<String, String>;
+
+impl RagDocument {
+    pub fn new<S: Into<String>>(page_content: S) -> Self {
+        RagDocument {
+            page_content: page_content.into(),
+            metadata: IndexMap::new(),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn with_metadata(mut self, metadata: RagMetadata) -> Self {
+        self.metadata = metadata;
+        self
+    }
+}
+
+impl Default for RagDocument {
+    fn default() -> Self {
+        RagDocument {
+            page_content: "".to_string(),
+            metadata: IndexMap::new(),
+        }
+    }
+}
+
+pub type VectorID = usize;
+
+pub fn combine_vector_id(file_index: usize, document_index: usize) -> VectorID {
+    file_index << (usize::BITS / 2) | document_index
+}
+
+pub fn split_vector_id(value: VectorID) -> (usize, usize) {
+    let low_mask = (1 << (usize::BITS / 2)) - 1;
+    let low = value & low_mask;
+    let high = value >> (usize::BITS / 2);
+    (high, low)
+}
+
+fn retrive_embedding_model(config: &Config, model_id: &str) -> Result<Model> {
+    let models = list_embedding_models(config);
+    let model =
+        Model::find(&models, model_id).ok_or_else(|| anyhow!("No embedding model '{model_id}'"))?;
+    Ok(model)
+}

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -182,11 +182,11 @@ impl Rag {
         for path in file_paths {
             let extension = Path::new(&path)
                 .extension()
-                .map(|v| v.to_string_lossy())
+                .map(|v| v.to_string_lossy().to_lowercase())
                 .unwrap_or_default();
             let separator = autodetect_separator(&extension);
             let splitter = Splitter::new(self.data.chunk_size, CHUNK_OVERLAP, separator);
-            let documents = load_text(&path)
+            let documents = load(&path, &extension)
                 .await
                 .with_context(|| format!("Failed to load text at '{path}'"))?;
             let documents =

--- a/src/rag/splitter.rs
+++ b/src/rag/splitter.rs
@@ -34,11 +34,37 @@ pub const MARKDOWN_SEPARATES: [&str; 13] = [
     " ",
     "",
 ];
+pub const LATEX_SEPARATES: [&str; 19] = [
+    // First, try to split along Latex sections
+    "\n\\chapter{",
+    "\n\\section{",
+    "\n\\subsection{",
+    "\n\\subsubsection{",
+    // Now split by environments
+    "\n\\begin{enumerate}",
+    "\n\\begin{itemize}",
+    "\n\\begin{description}",
+    "\n\\begin{list}",
+    "\n\\begin{quote}",
+    "\n\\begin{quotation}",
+    "\n\\begin{verse}",
+    "\n\\begin{verbatim}",
+    // Now split by math environments
+    "\n\\begin{align}",
+    "$$",
+    "$",
+    // Now split by the normal type of lines
+    "\n\n",
+    "\n",
+    " ",
+    "",
+];
 
 pub fn autodetect_separator(extension: &str) -> &[&'static str] {
     match extension {
-        "md" => &MARKDOWN_SEPARATES,
+        "md" | "mkd" => &MARKDOWN_SEPARATES,
         "htm" | "html" => &HTML_SEPARATES,
+        "tex" => &LATEX_SEPARATES,
         _ => &DEFAULT_SEPARATES,
     }
 }

--- a/src/rag/splitter.rs
+++ b/src/rag/splitter.rs
@@ -1,0 +1,536 @@
+use super::{RagDocument, RagMetadata};
+
+use std::cmp::Ordering;
+
+pub const DEFAULT_SEPARATERS: [&str; 4] = ["\n\n", "\n", " ", ""];
+pub const HTML_SEPARATERS: [&str; 28] = [
+    // First, try to split along HTML tags
+    "<body>", "<div>", "<p>", "<br>", "<li>", "<h1>", "<h2>", "<h3>", "<h4>", "<h5>", "<h6>",
+    "<span>", "<table>", "<tr>", "<td>", "<th>", "<ul>", "<ol>", "<header>", "<footer>", "<nav>",
+    // Head
+    "<head>", "<style>", "<script>", "<meta>", "<title>", // Normal type of lines
+    " ", "",
+];
+pub const MARKDOWN_SEPARATERS: [&str; 13] = [
+    // First, try to split along Markdown headings (starting with level 2)
+    "\n## ",
+    "\n### ",
+    "\n#### ",
+    "\n##### ",
+    "\n###### ",
+    // Note the alternative syntax for headings (below) is not handled here
+    // Heading level 2
+    // ---------------
+    // End of code block
+    "```\n\n",
+    // Horizontal lines
+    "\n\n***\n\n",
+    "\n\n---\n\n",
+    "\n\n___\n\n",
+    // Note that this splitter doesn't handle horizontal lines defined
+    // by *three or more* of ***, ---, or ___, but this is not handled
+    "\n\n",
+    "\n",
+    " ",
+    "",
+];
+
+pub fn autodetect_separater(extension: &str) -> &[&'static str] {
+    match extension {
+        "md" => &MARKDOWN_SEPARATERS,
+        "htm" | "html" => &HTML_SEPARATERS,
+        _ => &DEFAULT_SEPARATERS,
+    }
+}
+
+pub struct Splitter {
+    pub chunk_size: usize,
+    pub chunk_overlap: usize,
+    pub separators: Vec<String>,
+    pub length_function: Box<dyn Fn(&str) -> usize + Send + Sync>,
+}
+
+impl Default for Splitter {
+    fn default() -> Self {
+        Self {
+            chunk_size: 1000,
+            chunk_overlap: 20,
+            separators: DEFAULT_SEPARATERS.iter().map(|v| v.to_string()).collect(),
+            length_function: Box::new(|text| text.len()),
+        }
+    }
+}
+
+// Builder pattern for Options struct
+impl Splitter {
+    pub fn new(chunk_size: usize, chunk_overlap: usize, separators: &[&str]) -> Self {
+        Self::default()
+            .with_chunk_size(chunk_size)
+            .with_chunk_overlap(chunk_overlap)
+            .with_separators(separators)
+    }
+
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = chunk_size;
+        self
+    }
+
+    pub fn with_chunk_overlap(mut self, chunk_overlap: usize) -> Self {
+        self.chunk_overlap = chunk_overlap;
+        self
+    }
+
+    pub fn with_separators(mut self, separators: &[&str]) -> Self {
+        self.separators = separators.iter().map(|v| v.to_string()).collect();
+        self
+    }
+
+    #[allow(unused)]
+    pub fn with_length_function<F>(mut self, length_function: F) -> Self
+    where
+        F: Fn(&str) -> usize + Send + Sync + 'static,
+    {
+        self.length_function = Box::new(length_function);
+        self
+    }
+
+    pub fn split_documents(
+        &self,
+        documents: &[RagDocument],
+        chunk_header_options: &SplitterChunkHeaderOptions,
+    ) -> Vec<RagDocument> {
+        let mut texts: Vec<String> = Vec::new();
+        let mut metadatas: Vec<RagMetadata> = Vec::new();
+        documents.iter().for_each(|d| {
+            if !d.page_content.is_empty() {
+                texts.push(d.page_content.clone());
+                metadatas.push(d.metadata.clone());
+            }
+        });
+
+        self.create_documents(&texts, &metadatas, chunk_header_options)
+    }
+
+    pub fn create_documents(
+        &self,
+        texts: &[String],
+        metadatas: &[RagMetadata],
+        chunk_header_options: &SplitterChunkHeaderOptions,
+    ) -> Vec<RagDocument> {
+        let SplitterChunkHeaderOptions {
+            chunk_header,
+            chunk_overlap_header,
+            append_chunk_overlap_header,
+        } = chunk_header_options;
+
+        let mut documents = Vec::new();
+        for (i, text) in texts.iter().enumerate() {
+            let mut line_counter_index = 1;
+            let mut prev_chunk = None;
+            let mut index_prev_chunk = None;
+
+            for chunk in self.split_text(text) {
+                let mut page_content = chunk_header.clone();
+
+                let index_chunk = {
+                    let idx = match index_prev_chunk {
+                        Some(v) => v + 1,
+                        None => 0,
+                    };
+                    text[idx..].find(&chunk).map(|i| i + idx).unwrap_or(0)
+                };
+                if prev_chunk.is_none() {
+                    line_counter_index += self.number_of_newlines(text, 0, index_chunk);
+                } else {
+                    let index_end_prev_chunk: usize = index_prev_chunk.unwrap_or_default()
+                        + (self.length_function)(prev_chunk.as_deref().unwrap_or_default());
+
+                    match index_end_prev_chunk.cmp(&index_chunk) {
+                        Ordering::Less => {
+                            line_counter_index +=
+                                self.number_of_newlines(text, index_end_prev_chunk, index_chunk);
+                        }
+                        Ordering::Greater => {
+                            let number =
+                                self.number_of_newlines(text, index_chunk, index_end_prev_chunk);
+                            line_counter_index = line_counter_index.saturating_sub(number);
+                        }
+                        Ordering::Equal => {}
+                    }
+
+                    if *append_chunk_overlap_header {
+                        page_content += chunk_overlap_header;
+                    }
+                }
+
+                let newlines_count = self.number_of_newlines(&chunk, 0, chunk.len());
+
+                let mut metadata = metadatas[i].clone();
+                metadata.insert("loc_from_line".into(), line_counter_index.to_string());
+                metadata.insert(
+                    "loc_to_line".into(),
+                    (line_counter_index + newlines_count).to_string(),
+                );
+                page_content += &chunk;
+                documents.push(RagDocument {
+                    page_content,
+                    metadata,
+                });
+
+                line_counter_index += newlines_count;
+                prev_chunk = Some(chunk);
+                index_prev_chunk = Some(index_chunk);
+            }
+        }
+
+        documents
+    }
+
+    fn number_of_newlines(&self, text: &str, start: usize, end: usize) -> usize {
+        text[start..end].matches('\n').count()
+    }
+
+    pub fn split_text(&self, text: &str) -> Vec<String> {
+        let keep_separator = self
+            .separators
+            .iter()
+            .any(|v| v.chars().any(|v| !v.is_whitespace()));
+        self.split_text_impl(text, &self.separators, keep_separator)
+    }
+
+    fn split_text_impl(
+        &self,
+        text: &str,
+        separators: &[String],
+        keep_separator: bool,
+    ) -> Vec<String> {
+        let mut final_chunks = Vec::new();
+
+        let mut separator: String = separators.last().cloned().unwrap_or_default();
+        let mut new_separators: Vec<String> = vec![];
+        for (i, s) in separators.iter().enumerate() {
+            if s.is_empty() {
+                separator.clone_from(s);
+                break;
+            }
+            if text.contains(s) {
+                separator.clone_from(s);
+                new_separators = separators[i + 1..].to_vec();
+                break;
+            }
+        }
+
+        // Now that we have the separator, split the text
+        let splits = split_on_separator(text, &separator, keep_separator);
+
+        // Now go merging things, recursively splitting longer texts.
+        let mut good_splits = Vec::new();
+        let _separator = if keep_separator { "" } else { &separator };
+        for s in splits {
+            if (self.length_function)(s) < self.chunk_size {
+                good_splits.push(s.to_string());
+            } else {
+                if !good_splits.is_empty() {
+                    let merged_text = self.merge_splits(&good_splits, _separator);
+                    final_chunks.extend(merged_text);
+                    good_splits.clear();
+                }
+                if new_separators.is_empty() {
+                    final_chunks.push(s.to_string());
+                } else {
+                    let other_info = self.split_text_impl(s, &new_separators, keep_separator);
+                    final_chunks.extend(other_info);
+                }
+            }
+        }
+        if !good_splits.is_empty() {
+            let merged_text = self.merge_splits(&good_splits, _separator);
+            final_chunks.extend(merged_text);
+        }
+        final_chunks
+    }
+
+    fn merge_splits(&self, splits: &[String], separator: &str) -> Vec<String> {
+        let mut docs = Vec::new();
+        let mut current_doc = Vec::new();
+        let mut total = 0;
+        for d in splits {
+            let _len = (self.length_function)(d);
+            if total + _len + current_doc.len() * separator.len() > self.chunk_size {
+                if total > self.chunk_size {
+                    // warn!("Warning: Created a chunk of size {}, which is longer than the specified {}", total, self.chunk_size);
+                }
+                if !current_doc.is_empty() {
+                    let doc = self.join_docs(&current_doc, separator);
+                    if let Some(doc) = doc {
+                        docs.push(doc);
+                    }
+                    // Keep on popping if:
+                    // - we have a larger chunk than in the chunk overlap
+                    // - or if we still have any chunks and the length is long
+                    while total > self.chunk_overlap
+                        || (total + _len + current_doc.len() * separator.len() > self.chunk_size
+                            && total > 0)
+                    {
+                        total -= (self.length_function)(&current_doc[0]);
+                        current_doc.remove(0);
+                    }
+                }
+            }
+            current_doc.push(d.to_string());
+            total += _len;
+        }
+        let doc = self.join_docs(&current_doc, separator);
+        if let Some(doc) = doc {
+            docs.push(doc);
+        }
+        docs
+    }
+
+    fn join_docs(&self, docs: &[String], separator: &str) -> Option<String> {
+        let text = docs.join(separator).trim().to_string();
+        if text.is_empty() {
+            None
+        } else {
+            Some(text)
+        }
+    }
+}
+
+pub struct SplitterChunkHeaderOptions {
+    pub chunk_header: String,
+    pub chunk_overlap_header: String,
+    pub append_chunk_overlap_header: bool,
+}
+
+impl Default for SplitterChunkHeaderOptions {
+    fn default() -> Self {
+        Self {
+            chunk_header: "".into(),
+            chunk_overlap_header: "(cont'd) ".into(),
+            append_chunk_overlap_header: false,
+        }
+    }
+}
+
+impl SplitterChunkHeaderOptions {
+    // Set the value of chunk_header
+    #[allow(unused)]
+    pub fn with_chunk_header(mut self, header: &str) -> Self {
+        self.chunk_header = header.to_string();
+        self
+    }
+
+    // Set the value of chunk_overlap_header
+    #[allow(unused)]
+    pub fn with_chunk_overlap_header(mut self, overlap_header: &str) -> Self {
+        self.chunk_overlap_header = overlap_header.to_string();
+        self
+    }
+
+    // Set the value of append_chunk_overlap_header
+    #[allow(unused)]
+    pub fn with_append_chunk_overlap_header(mut self, value: bool) -> Self {
+        self.append_chunk_overlap_header = value;
+        self
+    }
+}
+
+fn split_on_separator<'a>(text: &'a str, separator: &str, keep_separator: bool) -> Vec<&'a str> {
+    let splits: Vec<&str> = if !separator.is_empty() {
+        if keep_separator {
+            let mut splits = Vec::new();
+            let mut prev_idx = 0;
+            let sep_len = separator.len();
+
+            while let Some(idx) = text[prev_idx..].find(separator) {
+                splits.push(&text[prev_idx.saturating_sub(sep_len)..prev_idx + idx]);
+                prev_idx += idx + sep_len;
+            }
+
+            if prev_idx < text.len() {
+                splits.push(&text[prev_idx.saturating_sub(sep_len)..]);
+            }
+
+            splits
+        } else {
+            text.split(separator).collect()
+        }
+    } else {
+        text.split("").collect()
+    };
+    splits.into_iter().filter(|s| !s.is_empty()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+    use pretty_assertions::assert_eq;
+    use serde_json::{json, Value};
+
+    fn build_metadata(source: &str, loc_from_line: &str, loc_to_line: &str) -> Value {
+        json!({
+            "source": source,
+            "loc_from_line": loc_from_line,
+            "loc_to_line": loc_to_line,
+        })
+    }
+    #[test]
+    fn test_split_text() {
+        let splitter = Splitter {
+            chunk_size: 7,
+            chunk_overlap: 3,
+            separators: vec![" ".into()],
+            ..Default::default()
+        };
+        let output = splitter.split_text("foo bar baz 123");
+        assert_eq!(output, vec!["foo bar", "bar baz", "baz 123"]);
+    }
+
+    #[test]
+    fn test_create_document() {
+        let splitter = Splitter::new(3, 0, &[" "]);
+        let chunk_header_options = SplitterChunkHeaderOptions::default();
+        let mut metadata1 = IndexMap::new();
+        metadata1.insert("source".into(), "1".into());
+        let mut metadata2 = IndexMap::new();
+        metadata2.insert("source".into(), "2".into());
+        let output = splitter.create_documents(
+            &["foo bar".into(), "baz".into()],
+            &[metadata1, metadata2],
+            &chunk_header_options,
+        );
+        let output = json!(output);
+        assert_eq!(
+            output,
+            json!([
+                {
+                    "page_content": "foo",
+                    "metadata": build_metadata("1", "1", "1"),
+                },
+                {
+                    "page_content": "bar",
+                    "metadata": build_metadata("1", "1", "1"),
+                },
+                {
+                    "page_content": "baz",
+                    "metadata": build_metadata("2", "1", "1"),
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn test_chunk_header() {
+        let splitter = Splitter::new(3, 0, &[" "]);
+        let chunk_header_options = SplitterChunkHeaderOptions::default()
+            .with_chunk_header("SOURCE NAME: testing\n-----\n")
+            .with_append_chunk_overlap_header(true);
+        let mut metadata1 = IndexMap::new();
+        metadata1.insert("source".into(), "1".into());
+        let mut metadata2 = IndexMap::new();
+        metadata2.insert("source".into(), "2".into());
+        let output = splitter.create_documents(
+            &["foo bar".into(), "baz".into()],
+            &[metadata1, metadata2],
+            &chunk_header_options,
+        );
+        let output = json!(output);
+        assert_eq!(
+            output,
+            json!([
+                {
+                    "page_content": "SOURCE NAME: testing\n-----\nfoo",
+                    "metadata": build_metadata("1", "1", "1"),
+                },
+                {
+                    "page_content": "SOURCE NAME: testing\n-----\n(cont'd) bar",
+                    "metadata": build_metadata("1", "1", "1"),
+                },
+                {
+                    "page_content": "SOURCE NAME: testing\n-----\nbaz",
+                    "metadata": build_metadata("2", "1", "1"),
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn test_markdown_splitter() {
+        let text = r#"# 🦜️🔗 LangChain
+
+⚡ Building applications with LLMs through composability ⚡
+
+## Quick Install
+
+```bash
+# Hopefully this code block isn't split
+pip install langchain
+```
+
+As an open source project in a rapidly developing field, we are extremely open to contributions."#;
+        let splitter = Splitter::new(100, 0, &MARKDOWN_SEPARATERS);
+        let output = splitter.split_text(text);
+        let expected_output = vec![
+            "# 🦜️🔗 LangChain\n\n⚡ Building applications with LLMs through composability ⚡",
+            "## Quick Install\n\n```bash\n# Hopefully this code block isn't split\npip install langchain",
+            "```",
+            "As an open source project in a rapidly developing field, we are extremely open to contributions.",
+        ];
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn test_html_splitter() {
+        let text = r#"<!DOCTYPE html>
+<html>
+  <head>
+    <title>🦜️🔗 LangChain</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+      }
+      h1 {
+        color: darkblue;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>🦜️🔗 LangChain</h1>
+      <p>⚡ Building applications with LLMs through composability ⚡</p>
+    </div>
+    <div>
+      As an open source project in a rapidly developing field, we are extremely open to contributions.
+    </div>
+  </body>
+</html>"#;
+        let splitter = Splitter::new(175, 20, &HTML_SEPARATERS);
+        let output = splitter.split_text(text);
+        let expected_output = vec![
+            "<!DOCTYPE html>\n<html>",
+            "<head>\n    <title>🦜️🔗 LangChain</title>",
+            r#"<style>
+      body {
+        font-family: Arial, sans-serif;
+      }
+      h1 {
+        color: darkblue;
+      }
+    </style>
+  </head>"#,
+            r#"<body>
+    <div>
+      <h1>🦜️🔗 LangChain</h1>
+      <p>⚡ Building applications with LLMs through composability ⚡</p>
+    </div>"#,
+            r#"<div>
+      As an open source project in a rapidly developing field, we are extremely open to contributions.
+    </div>
+  </body>
+</html>"#,
+        ];
+        assert_eq!(output, expected_output);
+    }
+}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -7,7 +7,7 @@ use self::highlighter::ReplHighlighter;
 use self::prompt::ReplPrompt;
 
 use crate::client::send_stream;
-use crate::config::{AssertState, GlobalConfig, Input, InputContext, StateFlags};
+use crate::config::{AssertState, Config, GlobalConfig, Input, InputContext, StateFlags};
 use crate::function::need_send_call_results;
 use crate::render::render_error;
 use crate::utils::{create_abort_signal, set_text, AbortSignal};
@@ -33,7 +33,7 @@ lazy_static! {
 const MENU_NAME: &str = "completion_menu";
 
 lazy_static! {
-    static ref REPL_COMMANDS: [ReplCommand; 16] = [
+    static ref REPL_COMMANDS: [ReplCommand; 19] = [
         ReplCommand::new(".help", "Show this help message", AssertState::any()),
         ReplCommand::new(".info", "View system info", AssertState::any()),
         ReplCommand::new(".model", "Change the current LLM", AssertState::any()),
@@ -83,6 +83,21 @@ lazy_static! {
             AssertState::True(StateFlags::SESSION_EMPTY | StateFlags::SESSION)
         ),
         ReplCommand::new(
+            ".rag",
+            "Init or use a rag",
+            AssertState::False(StateFlags::SESSION_EMPTY | StateFlags::SESSION),
+        ),
+        ReplCommand::new(
+            ".info rag",
+            "View rag info",
+            AssertState::True(StateFlags::RAG),
+        ),
+        ReplCommand::new(
+            ".exit rag",
+            "Leave the rag",
+            AssertState::True(StateFlags::RAG)
+        ),
+        ReplCommand::new(
             ".file",
             "Include files with the message",
             AssertState::any()
@@ -99,7 +114,7 @@ pub struct Repl {
     config: GlobalConfig,
     editor: Reedline,
     prompt: ReplPrompt,
-    abort: AbortSignal,
+    abort_signal: AbortSignal,
 }
 
 impl Repl {
@@ -114,7 +129,7 @@ impl Repl {
             config: config.clone(),
             editor,
             prompt,
-            abort,
+            abort_signal: abort,
         })
     }
 
@@ -122,13 +137,13 @@ impl Repl {
         self.banner();
 
         loop {
-            if self.abort.aborted_ctrld() {
+            if self.abort_signal.aborted_ctrld() {
                 break;
             }
             let sig = self.editor.read_line(&self.prompt);
             match sig {
                 Ok(Signal::Success(line)) => {
-                    self.abort.reset();
+                    self.abort_signal.reset();
                     match self.handle(&line).await {
                         Ok(exit) => {
                             if exit {
@@ -142,11 +157,11 @@ impl Repl {
                     }
                 }
                 Ok(Signal::CtrlC) => {
-                    self.abort.set_ctrlc();
+                    self.abort_signal.set_ctrlc();
                     println!("(To exit, press Ctrl+D or enter \".exit\")\n");
                 }
                 Ok(Signal::CtrlD) => {
-                    self.abort.set_ctrld();
+                    self.abort_signal.set_ctrld();
                     break;
                 }
                 _ => {}
@@ -176,6 +191,10 @@ impl Repl {
                         let info = self.config.read().session_info()?;
                         println!("{}", info);
                     }
+                    Some("rag") => {
+                        let info = self.config.read().rag_info()?;
+                        println!("{}", info);
+                    }
                     Some(_) => unknown_command()?,
                     None => {
                         let output = self.config.read().system_info()?;
@@ -193,7 +212,7 @@ impl Repl {
                 },
                 ".prompt" => match args {
                     Some(text) => {
-                        self.config.write().set_prompt(text)?;
+                        self.config.write().use_prompt(text)?;
                     }
                     None => println!("Usage: .prompt <text>..."),
                 },
@@ -206,16 +225,19 @@ impl Repl {
                                 text.trim(),
                                 Some(InputContext::role(role)),
                             );
-                            ask(&self.config, self.abort.clone(), input).await?;
+                            ask(&self.config, self.abort_signal.clone(), input).await?;
                         }
                         None => {
-                            self.config.write().set_role(args)?;
+                            self.config.write().use_role(args)?;
                         }
                     },
                     None => println!(r#"Usage: .role <name> [text]..."#),
                 },
                 ".session" => {
-                    self.config.write().start_session(args)?;
+                    self.config.write().use_session(args)?;
+                }
+                ".rag" => {
+                    Config::use_rag(&self.config, args, self.abort_signal.clone()).await?;
                 }
                 ".save" => {
                     match args.map(|v| match v.split_once(' ') {
@@ -248,16 +270,19 @@ impl Repl {
                         let (files, text) = split_files_text(args);
                         let files = shell_words::split(files).with_context(|| "Invalid args")?;
                         let input = Input::new(&self.config, text, files, None)?;
-                        ask(&self.config, self.abort.clone(), input).await?;
+                        ask(&self.config, self.abort_signal.clone(), input).await?;
                     }
                     None => println!("Usage: .file <files>... [-- <text>...]"),
                 },
                 ".exit" => match args {
                     Some("role") => {
-                        self.config.write().clear_role()?;
+                        self.config.write().exit_role()?;
                     }
                     Some("session") => {
-                        self.config.write().end_session()?;
+                        self.config.write().exit_session()?;
+                    }
+                    Some("rag") => {
+                        self.config.write().exit_rag()?;
                     }
                     Some(_) => unknown_command()?,
                     None => {
@@ -273,8 +298,9 @@ impl Repl {
                 _ => unknown_command()?,
             },
             None => {
-                let input = Input::from_str(&self.config, line, None);
-                ask(&self.config, self.abort.clone(), input).await?;
+                let mut input = Input::from_str(&self.config, line, None);
+                input.rag(self.abort_signal.clone()).await?;
+                ask(&self.config, self.abort_signal.clone(), input).await?;
             }
         }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,11 +1,4 @@
-use crate::{
-    client::{
-        init_client, list_models, ChatCompletionsData, ChatCompletionsOutput, ClientConfig,
-        Message, Model, ModelData, SseEvent, SseHandler,
-    },
-    config::{Config, GlobalConfig, Role},
-    utils::create_abort_signal,
-};
+use crate::{client::*, config::*, utils::*};
 
 use anyhow::{anyhow, bail, Result};
 use bytes::Bytes;
@@ -76,7 +69,7 @@ impl Server {
         let clients = config.clients.clone();
         let model = config.model.clone();
         let roles = config.roles.clone();
-        let mut models = list_models(&config);
+        let mut models = list_chat_models(&config);
         let mut default_model = model.clone();
         default_model.data_mut().name = DEFAULT_MODEL_NAME.into();
         models.insert(0, &default_model);

--- a/src/utils/abort_signal.rs
+++ b/src/utils/abort_signal.rs
@@ -53,3 +53,12 @@ impl AbortSignalInner {
         self.ctrld.store(true, Ordering::SeqCst);
     }
 }
+
+pub async fn watch_abort_signal(abort: AbortSignal) {
+    loop {
+        if abort.aborted() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,7 +6,7 @@ mod prompt_input;
 mod render_prompt;
 mod spinner;
 
-pub use self::abort_signal::{create_abort_signal, AbortSignal};
+pub use self::abort_signal::*;
 pub use self::clipboard::set_text;
 pub use self::command::*;
 pub use self::crypto::*;


### PR DESCRIPTION
## Screenshot

![image](https://github.com/sigoden/aichat/assets/4012553/96e6632c-3c29-45d5-bfd9-395869ad926c)

## REPL

```
.rag <name>             Init a rag
.info rag               View rag info
.exit rag               Leave the rag 
```

## TODO

- [x] Process numerous document chunks with multiple calls to the embeddings API
- [x] Support more embedding models (openai, cohere, mistral, ollama, vertexai, qianwen)
- [x] Show the progress of adding paths
- [x] Support non-text formats like pdf, docx, epub, ipynb

