### PR TITLE
feat: add config `dangerously_functions`

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,11 @@ buffer_editor: null
 # Controls the function calling feature. For setup instructions, visit https://github.com/sigoden/llm-functions
 function_calling: false
 
+# Regex for seletecting dangerous functions.
+# User confirmation is required when executing these functions. 
+# e.g. 'execute_command|execute_js_code' 'execute_.*'
+dangerously_functions: null
+
 # Specifies the embedding model to use
 embedding_model: null
 
@@ -254,3 +259,4 @@ bots:
     model: null
     temperature: null
     top_p: null
+    dangerously_functions: null

--- a/src/config/bot.rs
+++ b/src/config/bot.rs
@@ -105,6 +105,10 @@ impl Bot {
         &self.name
     }
 
+    pub fn config(&self) -> &BotConfig {
+        &self.config
+    }
+
     pub fn functions(&self) -> &Functions {
         &self.functions
     }
@@ -170,6 +174,8 @@ pub struct BotConfig {
     pub temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dangerously_functions: Option<FunctionsFilter>,
 }
 
 impl BotConfig {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -151,14 +151,6 @@ pub fn dimmed_text(input: &str) -> String {
     nu_ansi_term::Style::new().dimmed().paint(input).to_string()
 }
 
-pub fn indent_text(text: &str, spaces: usize) -> String {
-    let indent_size = " ".repeat(spaces);
-    text.lines()
-        .map(|line| format!("{}{}", indent_size, line))
-        .collect::<Vec<String>>()
-        .join("\n")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Previous we treats function name that starts with `may_` as excute type (dangerously). This method requires modifying function names, which is inflexible.

This PR makes it configurable. In `config.yaml`, you can now define which functions are considered dangerous and require user confirmation. 

```yaml
dangerously_functions: 'execute_.*'


bots:
  - name: todo-sh
    model: openai:gpt-4o
    dangerously_functions: clear_todos
```

