### PR TITLE
feat: add config `repl_prelude` and `bot_prelude`

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,7 +9,9 @@ wrap: no                         # Controls text wrapping (no, auto, <max-width>
 wrap_code: false                 # Enables or disables wrapping of code blocks
 auto_copy: false                 # Enables or disables automatic copying the last LLM response to the clipboard 
 keybindings: emacs               # Choose keybinding style (emacs, vi)
-prelude: null                    # Set a default role or session to start with (role:<name>, session:<name>)
+
+prelude: null                    # Set a default role or session to start with (e.g. role:<name>, session:<name>)
+repl_prelude: null               # This overrides 'prelude' when using REPL
 
 # Command that will be used to edit the current line buffer with ctrl+o
 # if unset fallback to $EDITOR and $VISUAL
@@ -22,6 +24,15 @@ function_calling: false
 # User confirmation is required when executing these functions. 
 # e.g. 'execute_command|execute_js_code' 'execute_.*'
 dangerously_functions: null
+
+bot_prelude: null               # Set a session to use when starting a bot.  (e.g. temp, default)
+
+bots:
+  - name: todo-sh
+    model: null
+    temperature: null
+    top_p: null
+    dangerously_functions: null
 
 # Specifies the embedding model to use
 embedding_model: null
@@ -253,10 +264,3 @@ clients:
     name: together
     api_base: https://api.together.xyz/v1
     api_key: xxx                                      # ENV: {client}_API_KEY
-
-bots:
-  - name: todo-sh
-    model: null
-    temperature: null
-    top_p: null
-    dangerously_functions: null


### PR DESCRIPTION
```
repl_prelude: null              # This overrides 'prelude' when using REPL
bot_prelude: null               # Set a session to use when starting a bot.  (e.g. temp, default)
```