### PR TITLE
fix: max_output_tokens param ignored in config

### DIFF
--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -166,10 +166,9 @@ impl Model {
     }
 
     pub fn max_tokens_param(&self) -> Option<isize> {
-        if self.data.require_max_tokens {
-            self.data.max_output_tokens
-        } else {
-            None
+        match self.data.max_output_tokens {
+            Some(v) => self.data.require_max_tokens.then_some(v),
+            None => None,
         }
     }
 


### PR DESCRIPTION
Hi there, I was using AiChat with local KoboldCPP instance and noticed that `max_output_tokens` param is ignored and not inserted into the request body, causing koboldcpp api to only generate 100 tokens of output. Looks like the issue is related to the variable ownership due to passing option to another object, repacking it into a new option fixed the issue for me.

My config:

```yaml
model: koboldcpp:kobold
function_calling: true
wrap_code: false
temperature: 0.5

clients:
- type: openai-compatible
  name: koboldcpp
  api_base: http://DESKTOP-IC823FN.local:5001/v1
  api_key: 'kobold'
  models:
  - name: kobold
    require_max_tokens: true
    max_output_tokens: 1024
```

Without fix:

```
Input: {"model": "kobold", "messages": [{"role": "user", "content": "write sample python class"}], "temperature": 0.5, "stream": true}

Processing Prompt (9 / 9 tokens)
Generating (100 / 100 tokens)
CtxLimit: 117/2048, Process:1.00s (111.7ms/T = 8.96T/s), Generate:15.87s (158.7ms/T = 6.30T/s), Total:16.88s (5.92T/s)
Output: Here's a simple example of a Python class that represents a book.
```

```python
class Book:
    def __init__(self, title, author, pages):
        self.title = title
        self.author = author
        self.pages = pages

    def display_info(self):
        print(f"Title: {self.title}")
        print(f"Author: {self.author}")
        print(f
```

With fix:

```md
Input: {"model": "kobold", "messages": [{"role": "user", "content": "write sample python class"}], "max_tokens": 1024, "temperature": 0.5, "stream": true}

Processing Prompt (1 / 1 tokens)
Generating (321 / 1024 tokens)
(EOS token triggered!)
CtxLimit: 338/2048, Process:0.39s (390.0ms/T = 2.56T/s), Generate:49.98s (155.7ms/T = 6.42T/s), Total:50.37s (6.37T/s)
Output: Sure, here's a simple example of a Python class that represents a basic "Car" object:
```

```python
class Car:
    def __init__(self, make, model, year):
        self.make = make
        self.model = model
        self.year = year
        self.odometer_reading = 0

    def get_descriptive_name(self):
        long_name = f"{self.year} {self.make} {self.model}"
        return long_name.title()

    def read_odometer(self):
        print(f"This car has {self.odometer_reading} miles on it.")

    def update_odometer(self, mileage):
        if mileage >= self.odometer_reading:
            self.odometer_reading = mileage
        else:
            print("You can't roll back an odometer!")

    def increment_odometer(self, miles):
        self.odometer_reading += miles
```

Thanks for the great tool, keep it up!