### PR TITLE
refactor: rename bot to agent

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -24,9 +24,9 @@ function_calling: false
 # e.g. 'execute_command|execute_js_code' 'execute_.*'
 dangerously_functions_filter: null
 
-bot_prelude: null               # Set a session to use when starting a bot.  (e.g. temp, default)
+agent_prelude: null               # Set a session to use when starting a agent.  (e.g. temp, default)
 
-bots:
+agents:
   - name: todo-sh
     model: null
     temperature: null
@@ -74,7 +74,7 @@ summarize_prompt: 'Summarize the discussion briefly in 200 words or less to use 
 summary_prompt: 'This is a summary of the chat history as a recap: '
 
 # Custom REPL prompt, see https://github.com/sigoden/aichat/wiki/Custom-REPL-Prompt
-left_prompt: '{color.green}{?session {?bot {bot}#}{session}{?role /}}{!session {?bot {bot}}}{role}{?rag @{rag}}{color.cyan}{?session )}{!session >}{color.reset} '
+left_prompt: '{color.green}{?session {?agent {agent}#}{session}{?role /}}{!session {?agent {agent}}}{role}{?rag @{rag}}{color.cyan}{?session )}{!session >}{color.reset} '
 right_prompt: '{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{color.reset}'
 
 clients:

--- a/scripts/completions/aichat.bash
+++ b/scripts/completions/aichat.bash
@@ -19,7 +19,7 @@ _aichat() {
 
     case "${cmd}" in
         aichat)
-            opts="-m -r -s -b -e -c -f -H -S -w -h -V --model --prompt --role --session --save-session --bot --rag --serve --execute --code --file --no-highlight --no-stream --wrap --light-theme --dry-run --info --list-models --list-roles --list-sessions --list-bots --list-rags --help --version"
+            opts="-m -r -s -b -e -c -f -H -S -w -h -V --model --prompt --role --session --save-session --agent --rag --serve --execute --code --file --no-highlight --no-stream --wrap --light-theme --dry-run --info --list-models --list-roles --list-sessions --list-agents --list-rags --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -61,8 +61,8 @@ _aichat() {
                     COMPREPLY=($(compgen -W "$("$1" --list-sessions)" -- "${cur}"))
                     return 0
                     ;;
-                -b|--bot)
-                    COMPREPLY=($(compgen -W "$("$1" --list-bots)" -- "${cur}"))
+                -b|--agent)
+                    COMPREPLY=($(compgen -W "$("$1" --list-agents)" -- "${cur}"))
                     return 0
                     ;;
                 --rag)

--- a/scripts/completions/aichat.fish
+++ b/scripts/completions/aichat.fish
@@ -3,7 +3,7 @@ complete -c aichat -l prompt -d 'Use the system prompt'
 complete -c aichat -s r -l role -x -a "(aichat --list-roles)" -d 'Select a role' -r
 complete -c aichat -s s -l session -x  -a"(aichat --list-sessions)" -d 'Start or join a session' -r
 complete -c aichat -l save-session -d 'Forces the session to be saved'
-complete -c aichat -s b -l bot -x  -a"(aichat --list-bots)" -d 'Start a bot' -r
+complete -c aichat -s b -l agent -x  -a"(aichat --list-agents)" -d 'Start a agent' -r
 complete -c aichat -l rag -x  -a"(aichat --list-rags)" -d 'Start a RAG' -r
 complete -c aichat -s f -l file -d 'Include files with the message' -r -F
 complete -c aichat -s w -l wrap -d 'Control text wrapping (no, auto, <max-width>)'
@@ -18,7 +18,7 @@ complete -c aichat -l info -d 'Display information'
 complete -c aichat -l list-models -d 'List all available chat models'
 complete -c aichat -l list-roles -d 'List all roles'
 complete -c aichat -l list-sessions -d 'List all sessions'
-complete -c aichat -l list-bots -d 'List all bots'
+complete -c aichat -l list-agents -d 'List all agents'
 complete -c aichat -l list-rags -d 'List all RAGs'
 complete -c aichat -s h -l help -d 'Print help'
 complete -c aichat -s V -l version -d 'Print version'

--- a/scripts/completions/aichat.nu
+++ b/scripts/completions/aichat.nu
@@ -22,8 +22,8 @@ module completions {
     | parse "{value}" 
   }
 
-  def "nu-complete aichat bot" [] {
-    ^aichat --list-bots |
+  def "nu-complete aichat agent" [] {
+    ^aichat --list-agents |
     | lines 
     | parse "{value}" 
   }
@@ -41,7 +41,7 @@ module completions {
     --role(-r): string@"nu-complete aichat role"      # Select a role
     --session(-s): string@"nu-complete aichat role"   # Start or join a session
     --save-session                                    # Forces the session to be saved
-    --bot(-b): string@"nu-complete aichat bot"        # Start a bot
+    --agent(-b): string@"nu-complete aichat agent"        # Start a agent
     --rag: string@"nu-complete aichat rag"            # Start a RAG
     --serve                                           # Serve the LLM API and WebAPP
     --execute(-e)                                     # Execute commands in natural language
@@ -56,7 +56,7 @@ module completions {
     --list-models                                     # List all available chat models
     --list-roles                                      # List all roles
     --list-sessions                                   # List all sessions
-    --list-bots                                       # List all bots
+    --list-agents                                       # List all agents
     --list-rags                                       # List all RAGs
     ...text: string                                   # Input text
     --help(-h)                                        # Print help

--- a/scripts/completions/aichat.ps1
+++ b/scripts/completions/aichat.ps1
@@ -28,8 +28,8 @@ Register-ArgumentCompleter -Native -CommandName 'aichat' -ScriptBlock {
             [CompletionResult]::new('-s', '-s', [CompletionResultType]::ParameterName, 'Start or join a session')
             [CompletionResult]::new('--session', '--session', [CompletionResultType]::ParameterName, 'Start or join a session')
             [CompletionResult]::new('--save-session', '--save-session', [CompletionResultType]::ParameterName, 'Forces the session to be saved')
-            [CompletionResult]::new('-b', '-b', [CompletionResultType]::ParameterName, 'Start a bot')
-            [CompletionResult]::new('--bot', '--bot', [CompletionResultType]::ParameterName, 'Start a bot')
+            [CompletionResult]::new('-b', '-b', [CompletionResultType]::ParameterName, 'Start a agent')
+            [CompletionResult]::new('--agent', '--agent', [CompletionResultType]::ParameterName, 'Start a agent')
             [CompletionResult]::new('--rag', '--rag', [CompletionResultType]::ParameterName, 'Start a RAG')
             [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, 'Include files with the message')
             [CompletionResult]::new('--file', '--file', [CompletionResultType]::ParameterName, 'Include files with the message')
@@ -50,7 +50,7 @@ Register-ArgumentCompleter -Native -CommandName 'aichat' -ScriptBlock {
             [CompletionResult]::new('--list-models', '--list-models', [CompletionResultType]::ParameterName, 'List all available chat models')
             [CompletionResult]::new('--list-roles', '--list-roles', [CompletionResultType]::ParameterName, 'List all roles')
             [CompletionResult]::new('--list-sessions', '--list-sessions', [CompletionResultType]::ParameterName, 'List all sessions')
-            [CompletionResult]::new('--list-bots', '--list-bots', [CompletionResultType]::ParameterName, 'List all bots')
+            [CompletionResult]::new('--list-agents', '--list-agents', [CompletionResultType]::ParameterName, 'List all agents')
             [CompletionResult]::new('--list-rags', '--list-rags', [CompletionResultType]::ParameterName, 'List all RAGs')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
@@ -76,8 +76,8 @@ Register-ArgumentCompleter -Native -CommandName 'aichat' -ScriptBlock {
             $completions = Get-AichatValues "--list-roles"
         } elseif ($flag -eq "-s" -or $flag -eq "--session") {
             $completions = Get-AichatValues "--list-sessions"
-        } elseif ($flag -eq "-b" -or $flag -eq "--bot") {
-            $completions = Get-AichatValues "--list-bots"
+        } elseif ($flag -eq "-b" -or $flag -eq "--agent") {
+            $completions = Get-AichatValues "--list-agents"
         } elseif ($flag -eq "--rag") {
             $completions = Get-AichatValues "--list-rags"
         } elseif ($flag -eq "-f" -or $flag -eq "--file") {

--- a/scripts/completions/aichat.zsh
+++ b/scripts/completions/aichat.zsh
@@ -23,8 +23,8 @@ _aichat() {
 '-s+[Start or join a session]:SESSION:->sessions' \
 '--session=[Start or join a session]:SESSION:->sessions' \
 '--save-session[Forces the session to be saved]' \
-'-b+[Start a bot]:BOT:->bots' \
-'--bot=[Start a bot]:BOT:->bots' \
+'-b+[Start a agent]:BOT:->agents' \
+'--agent=[Start a agent]:BOT:->agents' \
 '--rag=[Start a RAG]:RAG:->rags' \
 '*-f+[Include files with the message]:FILE:_files' \
 '*--file=[Include files with the message]:FILE:_files' \
@@ -45,7 +45,7 @@ _aichat() {
 '--list-models[List all available chat models]' \
 '--list-roles[List all roles]' \
 '--list-sessions[List all sessions]' \
-'--list-bots[List all bots]' \
+'--list-agents[List all agents]' \
 '--list-rags[List all RAGs]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -58,7 +58,7 @@ _aichat() {
     _arguments "${_arguments_options[@]}" $common \
         && ret=0 
     case $state in
-        models|roles|sessions|bots|rags)
+        models|roles|sessions|agents|rags)
             local -a values expl
             values=( ${(f)"$(_call_program values aichat --list-$state)"} )
             _wanted values expl $state compadd -a values && ret=0

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,9 +18,9 @@ pub struct Cli {
     /// Forces the session to be saved
     #[clap(long)]
     pub save_session: bool,
-    /// Start a bot
+    /// Start a agent
     #[clap(short = 'b', long)]
-    pub bot: Option<String>,
+    pub agent: Option<String>,
     /// Start a RAG
     #[clap(long)]
     pub rag: Option<String>,
@@ -63,9 +63,9 @@ pub struct Cli {
     /// List all sessions
     #[clap(long)]
     pub list_sessions: bool,
-    /// List all bots
+    /// List all agents
     #[clap(long)]
-    pub list_bots: bool,
+    pub list_agents: bool,
     /// List all RAGs
     #[clap(long)]
     pub list_rags: bool,

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -38,12 +38,12 @@ pub struct Input {
     rag_name: Option<String>,
     role: Role,
     with_session: bool,
-    with_bot: bool,
+    with_agent: bool,
 }
 
 impl Input {
     pub fn from_str(config: &GlobalConfig, text: &str, role: Option<Role>) -> Self {
-        let (role, with_session, with_bot) = resolve_role(&config.read(), role);
+        let (role, with_session, with_agent) = resolve_role(&config.read(), role);
         Self {
             config: config.clone(),
             text: text.to_string(),
@@ -56,7 +56,7 @@ impl Input {
             rag_name: None,
             role,
             with_session,
-            with_bot,
+            with_agent,
         }
     }
 
@@ -102,7 +102,7 @@ impl Input {
             }
         }
 
-        let (role, with_session, with_bot) = resolve_role(&config.read(), role);
+        let (role, with_session, with_agent) = resolve_role(&config.read(), role);
         Ok(Self {
             config: config.clone(),
             text: texts.join("\n"),
@@ -115,7 +115,7 @@ impl Input {
             rag_name: None,
             role,
             with_session,
-            with_bot,
+            with_agent,
         })
     }
 
@@ -289,8 +289,8 @@ impl Input {
         }
     }
 
-    pub fn with_bot(&self) -> bool {
-        self.with_bot
+    pub fn with_agent(&self) -> bool {
+        self.with_agent
     }
 
     pub fn summary(&self) -> String {
@@ -361,7 +361,7 @@ fn resolve_role(config: &Config, role: Option<Role>) -> (Role, bool, bool) {
         None => (
             config.extract_role(),
             config.session.is_some(),
-            config.bot.is_some(),
+            config.agent.is_some(),
         ),
     }
 }

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -77,10 +77,10 @@ impl Session {
         session.name = name.to_string();
         session.path = Some(path.display().to_string());
 
-        if let Some(bot) = &config.bot {
+        if let Some(agent) = &config.agent {
             session
                 .role_prompt
-                .clone_from(&bot.definition().instructions);
+                .clone_from(&agent.definition().instructions);
         }
 
         Ok(session)

--- a/src/function.rs
+++ b/src/function.rs
@@ -163,18 +163,18 @@ impl ToolCall {
     pub fn eval(&self, config: &GlobalConfig) -> Result<Value> {
         let function_name = self.name.clone();
         let is_dangerously = config.read().is_dangerously_function(&function_name);
-        let (call_name, cmd_name, mut cmd_args) = match &config.read().bot {
-            Some(bot) => {
-                if !bot.functions().contains(&function_name) {
+        let (call_name, cmd_name, mut cmd_args) = match &config.read().agent {
+            Some(agent) => {
+                if !agent.functions().contains(&function_name) {
                     bail!(
                         "Unexpected call: {} {function_name} {}",
-                        bot.name(),
+                        agent.name(),
                         self.arguments
                     );
                 }
                 (
-                    format!("{}:{}", bot.name(), function_name),
-                    bot.name().to_string(),
+                    format!("{}:{}", agent.name(), function_name),
+                    agent.name().to_string(),
                     vec![function_name],
                 )
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,8 @@ extern crate log;
 use crate::cli::Cli;
 use crate::client::{chat_completion_streaming, list_chat_models, ChatCompletionsOutput};
 use crate::config::{
-    list_bots, Config, GlobalConfig, Input, WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE, SHELL_ROLE,
-    TEMP_SESSION_NAME,
+    list_agents, Config, GlobalConfig, Input, WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE,
+    SHELL_ROLE, TEMP_SESSION_NAME,
 };
 use crate::function::{eval_tool_calls, need_send_tool_results};
 use crate::render::{render_error, MarkdownRender};
@@ -70,9 +70,9 @@ async fn main() -> Result<()> {
             .for_each(|v| println!("{}", v.name()));
         return Ok(());
     }
-    if cli.list_bots {
-        let bots = list_bots().join("\n");
-        println!("{bots}");
+    if cli.list_agents {
+        let agents = list_agents().join("\n");
+        println!("{agents}");
         return Ok(());
     }
     if cli.list_rags {
@@ -90,12 +90,12 @@ async fn main() -> Result<()> {
         config.write().dry_run = true;
     }
 
-    if let Some(bot) = &cli.bot {
+    if let Some(agent) = &cli.agent {
         let session = cli.session.as_ref().map(|v| match v {
             Some(v) => v.as_str(),
             None => TEMP_SESSION_NAME,
         });
-        Config::use_bot(&config, bot, session, abort_signal.clone()).await?
+        Config::use_agent(&config, agent, session, abort_signal.clone()).await?
     } else {
         if let Some(prompt) = &cli.prompt {
             config.write().use_prompt(prompt)?;

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -102,10 +102,10 @@ lazy_static! {
             "Leave the rag",
             AssertState::TrueFalse(StateFlags::RAG, StateFlags::BOT),
         ),
-        ReplCommand::new(".bot", "Use a bot", AssertState::bare()),
+        ReplCommand::new(".agent", "Use a agent", AssertState::bare()),
         ReplCommand::new(
-            ".info bot",
-            "View bot info",
+            ".info agent",
+            "View agent info",
             AssertState::True(StateFlags::BOT),
         ),
         ReplCommand::new(
@@ -114,8 +114,8 @@ lazy_static! {
             AssertState::True(StateFlags::BOT)
         ),
         ReplCommand::new(
-            ".exit bot",
-            "Leave the bot",
+            ".exit agent",
+            "Leave the agent",
             AssertState::True(StateFlags::BOT)
         ),
         ReplCommand::new(
@@ -221,8 +221,8 @@ impl Repl {
                         let info = self.config.read().rag_info()?;
                         println!("{}", info);
                     }
-                    Some("bot") => {
-                        let info = self.config.read().bot_info()?;
+                    Some("agent") => {
+                        let info = self.config.read().agent_info()?;
                         println!("{}", info);
                     }
                     Some(_) => unknown_command()?,
@@ -262,12 +262,12 @@ impl Repl {
                 ".rag" => {
                     Config::use_rag(&self.config, args, self.abort_signal.clone()).await?;
                 }
-                ".bot" => match args {
+                ".agent" => match args {
                     Some(name) => {
-                        Config::use_bot(&self.config, name, None, self.abort_signal.clone())
+                        Config::use_agent(&self.config, name, None, self.abort_signal.clone())
                             .await?;
                     }
-                    None => println!(r#"Usage: .bot <name>"#),
+                    None => println!(r#"Usage: .agent <name>"#),
                 },
                 ".starter" => match args {
                     Some(value) => {
@@ -275,7 +275,7 @@ impl Repl {
                         ask(&self.config, self.abort_signal.clone(), input, true).await?;
                     }
                     None => {
-                        let banner = self.config.read().bot_banner()?;
+                        let banner = self.config.read().agent_banner()?;
                         let output = format!(
                             r#"Usage: .starter <text>...
 
@@ -362,8 +362,8 @@ Tips: use <tab> to autocomplete conversation starter text.
                     Some("rag") => {
                         self.config.write().exit_rag()?;
                     }
-                    Some("bot") => {
-                        self.config.write().exit_bot()?;
+                    Some("agent") => {
+                        self.config.write().exit_agent()?;
                     }
                     Some(_) => unknown_command()?,
                     None => {


### PR DESCRIPTION
`agent` is more commonly used than `bot`.

![aichat-agent](https://github.com/sigoden/aichat/assets/4012553/d544f00d-5303-4393-a9fb-5e3f20f88412)
![aichat-agent2](https://github.com/sigoden/aichat/assets/4012553/509861ea-f77b-49b4-9b6b-5cf9378aa604)

relate to #517 #579