### PR TITLE
feat: custom rag document loaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "urlencoding",
- "which",
 ]
 
 [[package]]
@@ -3182,18 +3181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
-dependencies = [
- "either",
- "home",
- "rustix",
- "winsafe",
-]
-
-[[package]]
 name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,12 +3412,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wl-clipboard-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ json-patch = { version = "2.0.0", default-features = false }
 bitflags = "2.5.0"
 path-absolutize = "3.1.1"
 hnsw_rs = "0.3.0"
-which = "6.0.1"
 rayon = "1.10.0"
 
 [dependencies.reqwest]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -41,14 +41,21 @@ agents:
     dangerously_functions_filter: null
 
 # ---- RAG ----
-rag_embedding_model: null         # Specifies the embedding model to use
-rag_reranker_model: null            # Specifies the rerank model to use
-rag_top_k: 4                      # Specifies the number of documents to retrieve
-rag_chunk_size: null              # Specifies the chunk size
-rag_chunk_overlap: null           # Specifies the chunk overlap
-rag_min_score_vector_search: 0    # Specifies the minimum relevance score for vector-based searching
-rag_min_score_keyword_search: 0   # Specifies the minimum relevance score for keyword-based searching
-rag_min_score_rerank: 0           # Specifies the minimum relevance score for reranking
+rag_embedding_model: null                   # Specifies the embedding model to use
+rag_reranker_model: null                    # Specifies the rerank model to use
+rag_top_k: 4                                # Specifies the number of documents to retrieve
+rag_chunk_size: null                        # Specifies the chunk size
+rag_chunk_overlap: null                     # Specifies the chunk overlap
+rag_min_score_vector_search: 0              # Specifies the minimum relevance score for vector-based searching
+rag_min_score_keyword_search: 0             # Specifies the minimum relevance score for keyword-based searching
+rag_min_score_rerank: 0                     # Specifies the minimum relevance score for reranking
+# Defines document loaders
+rag_document_loaders:
+  # You can add more loaders, here is the syntax:
+  # <file-extension>: <command-to-load-the-file>
+  pdf: 'pdftotext $1 -'                     # Load .pdf file 
+  docx: 'pandoc --to plain $1'              # Load .docx file
+
 # Defines the query structure using variables like __CONTEXT__ and __INPUT__ to tailor searches to specific needs
 rag_template: |
   Use the following context as your learned knowledge, inside <context></context> XML tags.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -115,6 +115,8 @@ pub struct Config {
     pub rag_min_score_vector_search: f32,
     pub rag_min_score_keyword_search: f32,
     pub rag_min_score_rerank: f32,
+    #[serde(default)]
+    pub rag_document_loaders: HashMap<String, String>,
     pub rag_template: Option<String>,
 
     pub highlight: bool,
@@ -174,6 +176,7 @@ impl Default for Config {
             rag_min_score_vector_search: 0.0,
             rag_min_score_keyword_search: 0.0,
             rag_min_score_rerank: 0.0,
+            rag_document_loaders: Default::default(),
             rag_template: None,
 
             save_session: None,
@@ -229,6 +232,7 @@ impl Config {
         config.setup_model()?;
         config.setup_highlight();
         config.setup_light_theme()?;
+        config.setup_rag_document_loaders();
 
         Ok(config)
     }
@@ -1439,6 +1443,19 @@ impl Config {
             }
         };
         Ok(())
+    }
+
+    fn setup_rag_document_loaders(&mut self) {
+        [
+            ("pdf", "pdftotext $1 -"),
+            ("docx", "pandoc --to plain $1"),
+            ("url", "curl -fsSL $1"),
+        ]
+        .into_iter()
+        .for_each(|(k, v)| {
+            let (k, v) = (k.to_string(), v.to_string());
+            self.rag_document_loaders.entry(k).or_insert(v);
+        });
     }
 }
 


### PR DESCRIPTION
```yaml
# Defines document loaders
rag_document_loaders:
  # You can add more loaders, here is the syntax:
  # <file-extension>: <command-to-load-the-file>
  pdf: 'pdftotext $1 -'                     # Load .pdf file 
  docx: 'pandoc --to plain $1'              # Load .docx file
```