### PR TITLE
fix: gemini with functions that have empty parameters

### DIFF
--- a/src/client/vertexai.rs
+++ b/src/client/vertexai.rs
@@ -353,7 +353,18 @@ pub fn gemini_build_chat_completions_body(
     }
 
     if let Some(functions) = functions {
-        body["tools"] = json!([{ "functionDeclarations": *functions }]);
+        // Gemini doesn't support functions with parameters that have empty properties, so we need to patch it.
+        let function_declarations: Vec<_> = functions.into_iter().map(|function| {
+            if function.parameters.is_empty_properties() {
+                json!({
+                    "name": function.name,
+                    "description": function.description,
+                })
+            } else {
+                json!(function)
+            }
+        }).collect();
+        body["tools"] = json!([{ "functionDeclarations": function_declarations }]);
     }
 
     Ok(body)

--- a/src/function.rs
+++ b/src/function.rs
@@ -125,6 +125,15 @@ pub struct JsonSchema {
     pub required: Option<Vec<String>>,
 }
 
+impl JsonSchema {
+    pub fn is_empty_properties(&self) -> bool {
+        match &self.properties {
+            Some(v) => v.is_empty(),
+            None => true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct ToolCall {
     pub name: String,


### PR DESCRIPTION
When we call a function without parameters in Gemini (not Vertex AI)， It throws error:
```
Failed to call chat-completions api

Caused by:
    Request contains an invalid argument. (status: INVALID_ARGUMENT)
```
```
  {
    "name": "get_current_time",
    "description": "Get the current time.",
    "parameters": {
      "type": "object",
      "properties": {},
      "required": []
    }
  },
```