### PR TITLE
add option to disable spinner

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,6 +19,7 @@ use crate::utils::*;
 
 use anyhow::{anyhow, bail, Context, Result};
 use fancy_regex::Regex;
+use input::Regenerate;
 use inquire::{Confirm, Select};
 use parking_lot::RwLock;
 use serde::Deserialize;
@@ -119,6 +120,7 @@ pub struct Config {
 
     pub highlight: bool,
     pub light_theme: bool,
+    pub repl_spinner: bool,
     pub left_prompt: Option<String>,
     pub right_prompt: Option<String>,
 
@@ -184,6 +186,7 @@ impl Default for Config {
 
             highlight: true,
             light_theme: false,
+            repl_spinner: true,
             left_prompt: None,
             right_prompt: None,
 
@@ -1271,12 +1274,16 @@ impl Config {
         output: &str,
         tool_results: &[ToolResult],
     ) -> Result<()> {
+        let mut output = output.to_string();
         if self.dry_run || output.is_empty() || !tool_results.is_empty() {
             self.last_message = None;
             return Ok(());
         }
+        if let Some(Regenerate::Edit(prefix)) = input.regenerate() {
+            output = format!("{}{}", prefix, output);
+        }
         self.last_message = Some((input.clone(), output.to_string()));
-        self.save_message(input, output)?;
+        self.save_message(input, &output)?;
         Ok(())
     }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -17,8 +17,9 @@ pub async fn render_stream(
 ) -> Result<()> {
     if *IS_STDOUT_TERMINAL {
         let render_options = config.read().render_options()?;
+        let spin = config.read().repl_spinner;
         let mut render = MarkdownRender::init(render_options)?;
-        markdown_stream(rx, &mut render, &abort).await
+        markdown_stream(rx, &mut render, &abort, spin).await
     } else {
         raw_stream(rx, &abort).await
     }


### PR DESCRIPTION
- The spinner uses a log of resources on some terminals such asAlacritty
such as waiting for the LLM reponse takes up to 20% CPU usagejust to
render the spinner.

