### PR TITLE
refactor: smart `function_calling` config value

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -62,7 +62,7 @@ impl Functions {
         let declarations: Vec<FunctionDeclaration> = if declarations_path.exists() {
             let ctx = || {
                 format!(
-                    "Failed to load function declarations at {}",
+                    "Failed to load functions at {}",
                     declarations_path.display()
                 )
             };


### PR DESCRIPTION
If LLM functions are installed, the default value of `function_calling` will be true. Otherwise, the default value will be false.