### PR TITLE
feat: load env vars from file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,8 @@ extern crate log;
 use crate::cli::Cli;
 use crate::client::{chat_completion_streaming, list_chat_models, ChatCompletionsOutput};
 use crate::config::{
-    list_agents, Config, GlobalConfig, Input, WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE,
-    SHELL_ROLE, TEMP_SESSION_NAME,
+    list_agents, load_env_file, Config, GlobalConfig, Input, WorkingMode, CODE_ROLE,
+    EXPLAIN_SHELL_ROLE, SHELL_ROLE, TEMP_SESSION_NAME,
 };
 use crate::function::{eval_tool_calls, need_send_tool_results};
 use crate::render::{render_error, MarkdownRender};
@@ -39,6 +39,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    load_env_file()?;
     let cli = Cli::parse();
     let text = cli.text();
     let text = aggregate_text(text)?;


### PR DESCRIPTION
The PR enables users to use environment variables stored in separate env file.

To find the default env file path, run `aichat --info | grep -w env_file`.
Users can override the path with the `AICHAT_ENV_FILE` environment variable.

The environment variables can be used in tools, agents, and document loader scripts.

close #678