### PR TITLE
add .devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/rust:latest"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /tmp
 *.log
+config.yaml

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ AIChat supports custom dark and light themes, which highlight response text and 
 - [Environment Variables](https://github.com/sigoden/aichat/wiki/Environment-Variables)
 - [Custom Theme](https://github.com/sigoden/aichat/wiki/Custom-Theme)
 - [Custom REPL Prompt](https://github.com/sigoden/aichat/wiki/Custom-REPL-Prompt)
+- [Contributing](https://github.com/sigoden/aichat/wiki/Contributing)
 
 ## License
 


### PR DESCRIPTION
https://containers.dev/

> A development container (or dev container for short) allows you to use a container as a full-featured development environment.

for example for GitHub codespaces

could also involve adding a wiki page for contributing