### PR TITLE
feat: agent instructions support `__TOOLS__` placeholder

### DIFF
--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -11,6 +11,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+pub const TOOLS_PLACEHOLDER: &str = "__TOOLS__";
+
 #[derive(Debug, Clone, Serialize)]
 pub struct Agent {
     name: String,
@@ -45,6 +47,7 @@ impl Agent {
         } else {
             Functions::default()
         };
+        definition.replace_tools_placeholder(&functions);
         let agent_config = config
             .read()
             .agents
@@ -278,6 +281,25 @@ impl AgentDefinition {
             output = output.replace(&format!("{{{{{}}}}}", variable.name), &variable.value)
         }
         output
+    }
+
+    fn replace_tools_placeholder(&mut self, functions: &Functions) {
+        if self.instructions.contains(TOOLS_PLACEHOLDER) {
+            let tools = functions
+                .declarations()
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let description = match v.description.split_once('\n') {
+                        Some((v, _)) => v,
+                        None => &v.description,
+                    };
+                    format!("{}. {}: {description}", i + 1, v.name)
+                })
+                .collect::<Vec<String>>()
+                .join("\n");
+            self.instructions = self.instructions.replace(TOOLS_PLACEHOLDER, &tools);
+        }
     }
 }
 

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -11,7 +11,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-pub const TOOLS_PLACEHOLDER: &str = "__TOOLS__";
+const TOOLS_PLACEHOLDER: &str = "__TOOLS__";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Agent {


### PR DESCRIPTION
The `__TOOLS__` placeholder in the instructions will be replaced with a list of tool names and descriptions.

```yaml
instructions: |
  Users can interact with you using the following tools:
  __TOOLS__
```

```yaml
instructions: |
  Users can interact with you using the following commands:
  1. add_todo: Add a new todo item
  2. del_todo: Delete an existing todo item
  3. list_todos: Display the current todo list in json format.
  4. clear_todos: Delete the entire todo list.
```