### PR TITLE
feat: move agent config to separate file

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -31,12 +31,6 @@ function_calling: true           # Enables or disables function calling (Globall
 mapping_tools:                   # Alias for a tool or toolset
   # fs: 'fs_cat,fs_ls,fs_mkdir,fs_rm,fs_write'
 use_tools: null                  # Which tools to use by default
-# Per-Agent configuration
-agents:
-  - name: todo-sh
-    model: null
-    temperature: null
-    top_p: null
 
 # ---- RAG ----
 rag_embedding_model: null                   # Specifies the embedding model to use


### PR DESCRIPTION
- use `<agent-config-dir>/config.yaml` to agent config
```
model: openai:gpt-4o             # Specify the LLM to use
temperature: null                # Set default temperature parameter
top_p: null                      # Set default top-p parameter, range (0, 1)
```

- allow `<agent>_FUNCTIONS_DIR` to custom the agent functions dir, default to `<aichat-config-dir>/functions/agents/<agent>`
- allow `<agent>_CONFIG_DIR` to custom the agent config dir, default to `<aichat-config-dir>/agents/<agent>`