### PR TITLE
feat: Add autofocus to chat-input textarea in playground and arena html.

### DIFF
--- a/assets/arena.html
+++ b/assets/arena.html
@@ -495,7 +495,7 @@
     <div class="input-panel">
       <div class="input-panel-inner">
         <textarea id="chat-input" x-model="input" x-ref="input" @keydown.enter="handleEnterKeydown"
-          placeholder="Ask Anything"></textarea>
+          placeholder="Ask Anything" autofocus></textarea>
         <div class="input-image-bar" x-show="images.length > 0">
           <template x-for="(image, index) in images">
             <div class="input-image-item">

--- a/assets/playground.html
+++ b/assets/playground.html
@@ -640,7 +640,7 @@
       <div class="input-panel">
         <div class="input-panel-inner">
           <textarea id="chat-input" x-model="input" x-ref="input" @keydown.enter="handleEnterKeydown"
-            placeholder="Ask Anything"></textarea>
+            placeholder="Ask Anything" autofocus></textarea>
           <div class="input-image-bar" x-show="images.length > 0">
             <template x-for="(image, index) in images">
               <div class="input-image-item">


### PR DESCRIPTION
This MR adds the `autofocus` attribute to the `chat-input` textarea in both the playground and arena HTML files. This enhancement ensures that the chat prompt is automatically focused when the page loads, improving the user experience by allowing users to start typing immediately.