### PR TITLE
feat: support patching request url, headers and body

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -96,11 +96,15 @@ clients:
   #       type: reranker 
   #       max_input_tokens: 2048
   #   patch:                                          # Patch api request
-  #     chat_completions_body:                        
+  #     chat_completions:                             # Api types, one of chat_completions, embeddings, and rerank
   #       <regex>:                                    # The regex to match model names, e.g. '.*' 'gpt-4o' 'gpt-4o|gpt-4-.*'
-  #         <json>                                    # The JSON to be merged with the chat completions request body.
+  #         url:  ''                                  # Patch request url
+  #         body:                                     # Patch request body
+  #           <json>
+  #         headers:                                  # Patch request headers
+  #           <key>: <value>
   #   extra:
-  #     proxy: socks5://127.0.0.1:1080                # Set https/socks5 proxy. ENV: HTTPS_PROXY/https_proxy/ALL_PROXY/all_proxy
+  #     proxy: socks5://127.0.0.1:1080                # Set https/socks5 proxy. ENV: HTTPS_PROXY/ALL_PROXY
   #     connect_timeout: 10                           # Set timeout in seconds for connect to api
 
   # See https://platform.openai.com/docs/quickstart
@@ -123,17 +127,18 @@ clients:
   - type: gemini
     api_key: xxx                                      # ENV: {client}_API_KEY
     patch:
-      chat_completions_body:
-        '.*':                                           
-          safetySettings:
-            - category: HARM_CATEGORY_HARASSMENT
-              threshold: BLOCK_NONE
-            - category: HARM_CATEGORY_HATE_SPEECH
-              threshold: BLOCK_NONE
-            - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
-              threshold: BLOCK_NONE
-            - category: HARM_CATEGORY_DANGEROUS_CONTENT
-              threshold: BLOCK_NONE
+      chat_completions:
+        '.*':
+          body:
+            safetySettings:
+              - category: HARM_CATEGORY_HARASSMENT
+                threshold: BLOCK_NONE
+              - category: HARM_CATEGORY_HATE_SPEECH
+                threshold: BLOCK_NONE
+              - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
+                threshold: BLOCK_NONE
+              - category: HARM_CATEGORY_DANGEROUS_CONTENT
+                threshold: BLOCK_NONE
 
   # See https://docs.anthropic.com/claude/reference/getting-started-with-the-api
   - type: claude
@@ -189,17 +194,18 @@ clients:
     # see https://cloud.google.com/docs/authentication/external/set-up-adc
     adc_file: <path-to/gcloud/application_default_credentials.json> 
     patch:
-      chat_completions_body:
+      chat_completions:
         'gemini-.*':
-          safetySettings:
-            - category: HARM_CATEGORY_HARASSMENT
-              threshold: BLOCK_ONLY_HIGH
-            - category: HARM_CATEGORY_HATE_SPEECH
-              threshold: BLOCK_ONLY_HIGH
-            - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
-              threshold: BLOCK_ONLY_HIGH
-            - category: HARM_CATEGORY_DANGEROUS_CONTENT
-              threshold: BLOCK_ONLY_HIGH
+          body:
+            safetySettings:
+              - category: HARM_CATEGORY_HARASSMENT
+                threshold: BLOCK_ONLY_HIGH
+              - category: HARM_CATEGORY_HATE_SPEECH
+                threshold: BLOCK_ONLY_HIGH
+              - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
+                threshold: BLOCK_ONLY_HIGH
+              - category: HARM_CATEGORY_DANGEROUS_CONTENT
+                threshold: BLOCK_ONLY_HIGH
 
   # See https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
   - type: vertexai-claude

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -31,7 +31,7 @@ pub trait Client: Sync + Send {
 
     fn extra_config(&self) -> Option<&ExtraConfig>;
 
-    fn patch_config(&self) -> Option<&ModelPatch>;
+    fn patch_config(&self) -> Option<&RequestPatch>;
 
     fn name(&self) -> &str;
 
@@ -110,13 +110,40 @@ pub trait Client: Sync + Send {
             .context("Failed to call rerank api")
     }
 
-    fn patch_chat_completions_body(&self, body: &mut Value) {
-        if let Some(patch) = extract_chat_completions_body_patch(
-            self.patch_config().map(|v| v.chat_completions_body.clone()),
-            self.model(),
-        ) {
-            if body.is_object() && patch.is_object() {
-                json_patch::merge(body, &patch)
+    fn request_builder(
+        &self,
+        client: &reqwest::Client,
+        mut request_data: RequestData,
+        api_type: ApiType,
+    ) -> RequestBuilder {
+        self.patch_request_data(&mut request_data, api_type);
+        request_data.into_builder(client)
+    }
+
+    fn patch_request_data(&self, request_data: &mut RequestData, api_type: ApiType) {
+        let map = std::env::var(get_env_name(&format!(
+            "{}_{}_patch",
+            self.model().client_name(),
+            api_type.name(),
+        )))
+        .ok()
+        .and_then(|v| serde_json::from_str(&v).ok())
+        .or_else(|| {
+            self.patch_config()
+                .and_then(|v| api_type.extract_patch(v))
+                .cloned()
+        });
+        let map = match map {
+            Some(v) => v,
+            _ => return,
+        };
+        for (key, patch) in map {
+            let key = ESCAPE_SLASH_RE.replace_all(&key, r"\/");
+            if let Ok(regex) = Regex::new(&format!("^({key})$")) {
+                if let Ok(true) = regex.is_match(self.model().name()) {
+                    request_data.apply_patch(patch);
+                    return;
+                }
             }
         }
     }
@@ -164,32 +191,99 @@ pub struct ExtraConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
-pub struct ModelPatch {
-    pub chat_completions_body: ChatCompletionsBodyPatch,
+pub struct RequestPatch {
+    pub chat_completions: Option<ApiPatch>,
+    pub embeddings: Option<ApiPatch>,
+    pub rerank: Option<ApiPatch>,
 }
 
-pub type ChatCompletionsBodyPatch = IndexMap<String, Value>;
+pub type ApiPatch = IndexMap<String, Value>;
 
-pub fn extract_chat_completions_body_patch(
-    patch: Option<ChatCompletionsBodyPatch>,
-    model: &Model,
-) -> Option<Value> {
-    let patch = std::env::var(get_env_name(&format!(
-        "{}_chat_completions_body_patch",
-        model.client_name()
-    )))
-    .ok()
-    .and_then(|v| serde_json::from_str(&v).ok())
-    .or(patch)?;
-    for (key, patch_data) in patch {
-        let key = ESCAPE_SLASH_RE.replace_all(&key, r"\/");
-        if let Ok(regex) = Regex::new(&format!("^({key})$")) {
-            if let Ok(true) = regex.is_match(model.name()) {
-                return Some(patch_data);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiType {
+    ChatCompletions,
+    Embeddings,
+    Rerank,
+}
+
+impl ApiType {
+    pub fn name(&self) -> &str {
+        match self {
+            ApiType::ChatCompletions => "chat_completions",
+            ApiType::Embeddings => "embeddings",
+            ApiType::Rerank => "rerank",
+        }
+    }
+    pub fn extract_patch<'a>(&self, patch: &'a RequestPatch) -> Option<&'a ApiPatch> {
+        match self {
+            ApiType::ChatCompletions => patch.chat_completions.as_ref(),
+            ApiType::Embeddings => patch.embeddings.as_ref(),
+            ApiType::Rerank => patch.rerank.as_ref(),
+        }
+    }
+}
+
+pub struct RequestData {
+    pub url: String,
+    pub headers: IndexMap<String, String>,
+    pub body: Value,
+}
+
+impl RequestData {
+    pub fn new<T>(url: T, body: Value) -> Self
+    where
+        T: std::fmt::Display,
+    {
+        Self {
+            url: url.to_string(),
+            headers: Default::default(),
+            body,
+        }
+    }
+
+    pub fn bearer_auth<T>(&mut self, auth: T)
+    where
+        T: std::fmt::Display,
+    {
+        self.headers
+            .insert("authorization".into(), format!("Bearer {auth}"));
+    }
+
+    pub fn header<K, V>(&mut self, key: K, value: V)
+    where
+        K: std::fmt::Display,
+        V: std::fmt::Display,
+    {
+        self.headers.insert(key.to_string(), value.to_string());
+    }
+
+    pub fn into_builder(self, client: &ReqwestClient) -> RequestBuilder {
+        let RequestData { url, headers, body } = self;
+        debug!("Request {url} {body}");
+
+        let mut builder = client.post(url);
+        for (key, value) in headers {
+            builder = builder.header(key, value);
+        }
+        builder = builder.json(&body);
+        builder
+    }
+
+    pub fn apply_patch(&mut self, patch: Value) {
+        if let Some(patch_url) = patch["url"].as_str() {
+            self.url = patch_url.into();
+        }
+        if let Some(patch_body) = patch.get("body") {
+            json_patch::merge(&mut self.body, patch_body)
+        }
+        if let Some(patch_headers) = patch["headers"].as_object() {
+            for (key, value) in patch_headers {
+                if let Some(value) = value.as_str() {
+                    self.header(key, value)
+                }
             }
         }
     }
-    None
 }
 
 #[derive(Debug)]
@@ -445,24 +539,24 @@ fn set_client_config(
 fn set_client_config_value(client_config: &mut Value, path: &str, kind: &PromptKind, value: &str) {
     let segs: Vec<&str> = path.split('.').collect();
     match segs.as_slice() {
-        [name] => client_config[name] = to_json(kind, value),
+        [name] => client_config[name] = prompt_value_to_json(kind, value),
         [scope, name] => match scope.split_once('[') {
             None => {
                 if client_config.get(scope).is_none() {
                     let mut obj = json!({});
-                    obj[name] = to_json(kind, value);
+                    obj[name] = prompt_value_to_json(kind, value);
                     client_config[scope] = obj;
                 } else {
-                    client_config[scope][name] = to_json(kind, value);
+                    client_config[scope][name] = prompt_value_to_json(kind, value);
                 }
             }
             Some((scope, _)) => {
                 if client_config.get(scope).is_none() {
                     let mut obj = json!({});
-                    obj[name] = to_json(kind, value);
+                    obj[name] = prompt_value_to_json(kind, value);
                     client_config[scope] = json!([obj]);
                 } else {
-                    client_config[scope][0][name] = to_json(kind, value);
+                    client_config[scope][0][name] = prompt_value_to_json(kind, value);
                 }
             }
         },
@@ -470,7 +564,7 @@ fn set_client_config_value(client_config: &mut Value, path: &str, kind: &PromptK
     }
 }
 
-fn to_json(kind: &PromptKind, value: &str) -> Value {
+fn prompt_value_to_json(kind: &PromptKind, value: &str) -> Value {
     if value.is_empty() {
         return Value::Null;
     }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -122,7 +122,7 @@ pub trait Client: Sync + Send {
 
     fn patch_request_data(&self, request_data: &mut RequestData, api_type: ApiType) {
         let map = std::env::var(get_env_name(&format!(
-            "{}_{}_patch",
+            "patch_{}_{}",
             self.model().client_name(),
             api_type.name(),
         )))

--- a/src/client/macros.rs
+++ b/src/client/macros.rs
@@ -141,7 +141,7 @@ macro_rules! client_common_fns {
             self.config.extra.as_ref()
         }
 
-        fn patch_config(&self) -> Option<&$crate::client::ModelPatch> {
+        fn patch_config(&self) -> Option<&$crate::client::RequestPatch> {
             self.config.patch.as_ref()
         }
 
@@ -171,7 +171,8 @@ macro_rules! impl_client_trait {
                 client: &reqwest::Client,
                 data: $crate::client::ChatCompletionsData,
             ) -> anyhow::Result<$crate::client::ChatCompletionsOutput> {
-                let builder = self.chat_completions_builder(client, data)?;
+                let request_data = self.prepare_chat_completions(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::ChatCompletions);
                 $chat_completions(builder).await
             }
 
@@ -181,7 +182,8 @@ macro_rules! impl_client_trait {
                 handler: &mut $crate::client::SseHandler,
                 data: $crate::client::ChatCompletionsData,
             ) -> Result<()> {
-                let builder = self.chat_completions_builder(client, data)?;
+                let request_data = self.prepare_chat_completions(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::ChatCompletions);
                 $chat_completions_streaming(builder, handler).await
             }
         }
@@ -196,7 +198,8 @@ macro_rules! impl_client_trait {
                 client: &reqwest::Client,
                 data: $crate::client::ChatCompletionsData,
             ) -> anyhow::Result<$crate::client::ChatCompletionsOutput> {
-                let builder = self.chat_completions_builder(client, data)?;
+                let request_data = self.prepare_chat_completions(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::ChatCompletions);
                 $chat_completions(builder).await
             }
 
@@ -206,7 +209,8 @@ macro_rules! impl_client_trait {
                 handler: &mut $crate::client::SseHandler,
                 data: $crate::client::ChatCompletionsData,
             ) -> Result<()> {
-                let builder = self.chat_completions_builder(client, data)?;
+                let request_data = self.prepare_chat_completions(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::ChatCompletions);
                 $chat_completions_streaming(builder, handler).await
             }
 
@@ -215,7 +219,8 @@ macro_rules! impl_client_trait {
                 client: &reqwest::Client,
                 data: $crate::client::EmbeddingsData,
             ) -> Result<$crate::client::EmbeddingsOutput> {
-                let builder = self.embeddings_builder(client, data)?;
+                let request_data = self.prepare_embeddings(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::Embeddings);
                 $embeddings(builder).await
             }
         }
@@ -230,7 +235,8 @@ macro_rules! impl_client_trait {
                 client: &reqwest::Client,
                 data: $crate::client::ChatCompletionsData,
             ) -> anyhow::Result<$crate::client::ChatCompletionsOutput> {
-                let builder = self.chat_completions_builder(client, data)?;
+                let request_data = self.prepare_chat_completions(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::ChatCompletions);
                 $chat_completions(builder).await
             }
 
@@ -240,7 +246,8 @@ macro_rules! impl_client_trait {
                 handler: &mut $crate::client::SseHandler,
                 data: $crate::client::ChatCompletionsData,
             ) -> Result<()> {
-                let builder = self.chat_completions_builder(client, data)?;
+                let request_data = self.prepare_chat_completions(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::ChatCompletions);
                 $chat_completions_streaming(builder, handler).await
             }
 
@@ -249,7 +256,8 @@ macro_rules! impl_client_trait {
                 client: &reqwest::Client,
                 data: $crate::client::EmbeddingsData,
             ) -> Result<$crate::client::EmbeddingsOutput> {
-                let builder = self.embeddings_builder(client, data)?;
+                let request_data = self.prepare_embeddings(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::Embeddings);
                 $embeddings(builder).await
             }
 
@@ -258,7 +266,8 @@ macro_rules! impl_client_trait {
                 client: &reqwest::Client,
                 data: $crate::client::RerankData,
             ) -> Result<$crate::client::RerankOutput> {
-                let builder = self.rerank_builder(client, data)?;
+                let request_data = self.prepare_rerank(data)?;
+                let builder = self.request_builder(client, request_data, ApiType::Rerank);
                 $rerank(builder).await
             }
         }

--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use anyhow::{bail, Context, Result};
-use reqwest::{Client as ReqwestClient, RequestBuilder};
+use reqwest::RequestBuilder;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
@@ -15,7 +15,7 @@ pub struct OpenAIConfig {
     pub organization_id: Option<String>,
     #[serde(default)]
     pub models: Vec<ModelData>,
-    pub patch: Option<ModelPatch>,
+    pub patch: Option<RequestPatch>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -26,47 +26,40 @@ impl OpenAIClient {
     pub const PROMPTS: [PromptAction<'static>; 1] =
         [("api_key", "API Key:", true, PromptKind::String)];
 
-    fn chat_completions_builder(
-        &self,
-        client: &ReqwestClient,
-        data: ChatCompletionsData,
-    ) -> Result<RequestBuilder> {
+    fn prepare_chat_completions(&self, data: ChatCompletionsData) -> Result<RequestData> {
         let api_key = self.get_api_key()?;
         let api_base = self.get_api_base().unwrap_or_else(|_| API_BASE.to_string());
-
-        let mut body = openai_build_chat_completions_body(data, &self.model);
-        self.patch_chat_completions_body(&mut body);
 
         let url = format!("{api_base}/chat/completions");
 
-        debug!("OpenAI Chat Completions Request: {url} {body}");
+        let body = openai_build_chat_completions_body(data, &self.model);
 
-        let mut builder = client.post(url).bearer_auth(api_key).json(&body);
+        let mut request_data = RequestData::new(url, body);
 
+        request_data.bearer_auth(api_key);
         if let Some(organization_id) = &self.config.organization_id {
-            builder = builder.header("OpenAI-Organization", organization_id);
+            request_data.header("OpenAI-Organization", organization_id);
         }
 
-        Ok(builder)
+        Ok(request_data)
     }
 
-    fn embeddings_builder(
-        &self,
-        client: &ReqwestClient,
-        data: EmbeddingsData,
-    ) -> Result<RequestBuilder> {
+    fn prepare_embeddings(&self, data: EmbeddingsData) -> Result<RequestData> {
         let api_key = self.get_api_key()?;
         let api_base = self.get_api_base().unwrap_or_else(|_| API_BASE.to_string());
 
-        let body = openai_build_embeddings_body(data, &self.model);
-
         let url = format!("{api_base}/embeddings");
 
-        debug!("OpenAI Embeddings Request: {url} {body}");
+        let body = openai_build_embeddings_body(data, &self.model);
 
-        let builder = client.post(url).bearer_auth(api_key).json(&body);
+        let mut request_data = RequestData::new(url, body);
 
-        Ok(builder)
+        request_data.bearer_auth(api_key);
+        if let Some(organization_id) = &self.config.organization_id {
+            request_data.header("OpenAI-Organization", organization_id);
+        }
+
+        Ok(request_data)
     }
 }
 

--- a/src/client/openai_compatible.rs
+++ b/src/client/openai_compatible.rs
@@ -3,7 +3,6 @@ use super::rag_dedicated::*;
 use super::*;
 
 use anyhow::Result;
-use reqwest::{Client as ReqwestClient, RequestBuilder};
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -14,7 +13,7 @@ pub struct OpenAICompatibleConfig {
     pub chat_endpoint: Option<String>,
     #[serde(default)]
     pub models: Vec<ModelData>,
-    pub patch: Option<ModelPatch>,
+    pub patch: Option<RequestPatch>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -35,16 +34,9 @@ impl OpenAICompatibleClient {
         ),
     ];
 
-    fn chat_completions_builder(
-        &self,
-        client: &ReqwestClient,
-        data: ChatCompletionsData,
-    ) -> Result<RequestBuilder> {
+    fn prepare_chat_completions(&self, data: ChatCompletionsData) -> Result<RequestData> {
         let api_key = self.get_api_key().ok();
         let api_base = self.get_api_base_ext()?;
-
-        let mut body = openai_build_chat_completions_body(data, &self.model);
-        self.patch_chat_completions_body(&mut body);
 
         let chat_endpoint = self
             .config
@@ -54,54 +46,49 @@ impl OpenAICompatibleClient {
 
         let url = format!("{api_base}{chat_endpoint}");
 
-        debug!("OpenAICompatible Chat Completions Request: {url} {body}");
+        let body = openai_build_chat_completions_body(data, &self.model);
 
-        let mut builder = client.post(url).json(&body);
+        let mut request_data = RequestData::new(url, body);
+
         if let Some(api_key) = api_key {
-            builder = builder.bearer_auth(api_key);
+            request_data.bearer_auth(api_key);
         }
 
-        Ok(builder)
+        Ok(request_data)
     }
 
-    fn embeddings_builder(
-        &self,
-        client: &ReqwestClient,
-        data: EmbeddingsData,
-    ) -> Result<RequestBuilder> {
+    fn prepare_embeddings(&self, data: EmbeddingsData) -> Result<RequestData> {
         let api_key = self.get_api_key().ok();
         let api_base = self.get_api_base_ext()?;
-
-        let body = openai_build_embeddings_body(data, &self.model);
 
         let url = format!("{api_base}/embeddings");
 
-        debug!("OpenAICompatible Embeddings Request: {url} {body}");
+        let body = openai_build_embeddings_body(data, &self.model);
 
-        let mut builder = client.post(url).json(&body);
+        let mut request_data = RequestData::new(url, body);
+
         if let Some(api_key) = api_key {
-            builder = builder.bearer_auth(api_key);
+            request_data.bearer_auth(api_key);
         }
 
-        Ok(builder)
+        Ok(request_data)
     }
 
-    fn rerank_builder(&self, client: &ReqwestClient, data: RerankData) -> Result<RequestBuilder> {
+    fn prepare_rerank(&self, data: RerankData) -> Result<RequestData> {
         let api_key = self.get_api_key().ok();
         let api_base = self.get_api_base_ext()?;
 
-        let body = rag_dedicated_build_rerank_body(data, &self.model);
-
         let url = format!("{api_base}/rerank");
 
-        debug!("OpenAICompatible Rerank Request: {url} {body}");
+        let body = rag_dedicated_build_rerank_body(data, &self.model);
 
-        let mut builder = client.post(url).json(&body);
+        let mut request_data = RequestData::new(url, body);
+
         if let Some(api_key) = api_key {
-            builder = builder.bearer_auth(api_key);
+            request_data.bearer_auth(api_key);
         }
 
-        Ok(builder)
+        Ok(request_data)
     }
 
     fn get_api_base_ext(&self) -> Result<String> {

--- a/src/client/replicate.rs
+++ b/src/client/replicate.rs
@@ -16,7 +16,7 @@ pub struct ReplicateConfig {
     pub api_key: Option<String>,
     #[serde(default)]
     pub models: Vec<ModelData>,
-    pub patch: Option<ModelPatch>,
+    pub patch: Option<RequestPatch>,
     pub extra: Option<ExtraConfig>,
 }
 
@@ -26,22 +26,20 @@ impl ReplicateClient {
     pub const PROMPTS: [PromptAction<'static>; 1] =
         [("api_key", "API Key:", true, PromptKind::String)];
 
-    fn chat_completions_builder(
+    fn prepare_chat_completions(
         &self,
-        client: &ReqwestClient,
         data: ChatCompletionsData,
         api_key: &str,
-    ) -> Result<RequestBuilder> {
-        let mut body = build_chat_completions_body(data, &self.model)?;
-        self.patch_chat_completions_body(&mut body);
-
+    ) -> Result<RequestData> {
         let url = format!("{API_BASE}/models/{}/predictions", self.model.name());
 
-        debug!("Replicate Request: {url} {body}");
+        let body = build_chat_completions_body(data, &self.model)?;
 
-        let builder = client.post(url).bearer_auth(api_key).json(&body);
+        let mut request_data = RequestData::new(url, body);
 
-        Ok(builder)
+        request_data.bearer_auth(api_key);
+
+        Ok(request_data)
     }
 }
 
@@ -55,7 +53,8 @@ impl Client for ReplicateClient {
         data: ChatCompletionsData,
     ) -> Result<ChatCompletionsOutput> {
         let api_key = self.get_api_key()?;
-        let builder = self.chat_completions_builder(client, data, &api_key)?;
+        let request_data = self.prepare_chat_completions(data, &api_key)?;
+        let builder = self.request_builder(client, request_data, ApiType::ChatCompletions);
         chat_completions(client, builder, &api_key).await
     }
 
@@ -66,7 +65,8 @@ impl Client for ReplicateClient {
         data: ChatCompletionsData,
     ) -> Result<()> {
         let api_key = self.get_api_key()?;
-        let builder = self.chat_completions_builder(client, data, &api_key)?;
+        let request_data = self.prepare_chat_completions(data, &api_key)?;
+        let builder = self.request_builder(client, request_data, ApiType::ChatCompletions);
         chat_completions_streaming(client, builder, handler).await
     }
 }


### PR DESCRIPTION
Now we can patch request headers

```yaml
  - type: claude
    patch:
      chat_completions:
        'claude-3-5-sonnet-20240620':
          headers:
            anthropic-beta: max-tokens-3-5-sonnet-2024-07-15
          body:
            max_tokens: 8192
```

