### PR TITLE
feat: add `config.stream` and `.set stream` repl command

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,6 +4,7 @@ temperature: null                # Set default temperature parameter
 top_p: null                      # Set default top-p parameter, range (0, 1)
 
 # ---- behavior ----
+stream: true                     # Use stream style by default
 save: true                       # Indicates whether to persist the message
 keybindings: emacs               # Choose keybinding style (emacs, vi)
 buffer_editor: null              # Command used to edit the current input with ctrl+o, env: EDITOR

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,7 +16,7 @@ pub use self::path::*;
 pub use self::prompt_input::*;
 pub use self::render_prompt::render_prompt;
 pub use self::request::*;
-pub use self::spinner::{create_spinner, Spinner};
+pub use self::spinner::*;
 
 use anyhow::{Context, Result};
 use fancy_regex::Regex;


### PR DESCRIPTION
Motivation: many LLMs do not support streaming tools, we can set `stream=false` to using them in non-streaming.

Resolve #91