### PR TITLE
feat: add builtin variables for agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "shell-words",
  "simplelog",
  "syntect",
+ "sys-locale",
  "textwrap",
  "time",
  "tokio",
@@ -2725,6 +2726,15 @@ dependencies = [
  "serde_json",
  "thiserror",
  "walkdir",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e801cf239ecd6ccd71f03d270d67dd53d13e90aab208bf4b8fe4ad957ea949b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ hnsw_rs = "0.3.0"
 rayon = "1.10.0"
 uuid = { version = "1.9.1", features = ["v4"] }
 html2text = "0.12.5"
+sys-locale = "0.3.1"
 
 [dependencies.reqwest]
 version = "0.12.0"

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -279,6 +279,9 @@ impl AgentDefinition {
         for variable in &self.variables {
             output = output.replace(&format!("{{{{{}}}}}", variable.name), &variable.value)
         }
+        for (key, value) in builtin_variables() {
+            output = output.replace(&format!("{{{{{}}}}}", key), &value);
+        }
         output
     }
 
@@ -394,4 +397,31 @@ fn save_variables(variables_path: &Path, variables: &[AgentVariable]) -> Result<
     fs::write(variables_path, content)
         .with_context(|| format!("Failed to save variables to '{}'", variables_path.display()))?;
     Ok(())
+}
+
+fn builtin_variables() -> Vec<(&'static str, String)> {
+    vec![
+        ("__os__", env::consts::OS.to_string()),
+        ("__os_family__", env::consts::FAMILY.to_string()),
+        ("__arch__", env::consts::ARCH.to_string()),
+        ("__shell__", detect_shell().name),
+        (
+            "__locale__",
+            sys_locale::get_locale().unwrap_or_else(|| "en-US".into()),
+        ),
+        (
+            "__now__",
+            time::OffsetDateTime::now_utc()
+                .format(simplelog::format_description!(
+                    "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z"
+                ))
+                .unwrap_or_else(|_| "NOW".into()),
+        ),
+        (
+            "__cwd__",
+            env::current_dir()
+                .map(|v| v.display().to_string())
+                .unwrap_or_else(|_| "CWD".into()),
+        ),
+    ]
 }

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -405,23 +405,20 @@ fn builtin_variables() -> Vec<(&'static str, String)> {
         ("__os_family__", env::consts::FAMILY.to_string()),
         ("__arch__", env::consts::ARCH.to_string()),
         ("__shell__", detect_shell().name),
-        (
-            "__locale__",
-            sys_locale::get_locale().unwrap_or_else(|| "en-US".into()),
-        ),
+        ("__locale__", sys_locale::get_locale().unwrap_or_default()),
         (
             "__now__",
             time::OffsetDateTime::now_utc()
                 .format(simplelog::format_description!(
                     "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z"
                 ))
-                .unwrap_or_else(|_| "NOW".into()),
+                .unwrap_or_default(),
         ),
         (
             "__cwd__",
             env::current_dir()
                 .map(|v| v.display().to_string())
-                .unwrap_or_else(|_| "CWD".into()),
+                .unwrap_or_default(),
         ),
     ]
 }


### PR DESCRIPTION

| name          | description                                   | example                  |
| :------------ | :-------------------------------------------- | :----------------------- |
| __os__        | Operating system name                         | linux                    |
| __os_family__ | Operating system family                       | unix                     |
| __arch__      | System architecture                           | x86_64                   |
| __shell__     | Current user's default shell                  | bash                     |
| __locale__    | User's preferred language and region settings | en-US                    |
| __now__       | Current timestamp in ISO 8601 format          | 2024-07-29T08:11:24.367Z |
| __cwd__       | Current working directory                     | /tmp                     |


```yaml
instructions: |
  ...
  
  <system>
  os: {{__os__}}
  os_family: {{__os_family__}}
  arch: {{__arch__}}
  shell: {{__shell__}}
  locale: {{__locale__}}
  now: {{__now__}}
  cwd: {{__cwd__}}
  </system>
```

