### PR TITLE
refactor: agent instructions

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -861,6 +861,9 @@ impl Config {
     pub fn clear_session_messages(&mut self) -> Result<()> {
         if let Some(session) = self.session.as_mut() {
             session.clear_messages();
+            if let Some(prompt) = self.agent.as_ref().map(|v| v.interpolated_instructions()) {
+                session.update_role_prompt(&prompt);
+            }
         } else {
             bail!("No session")
         }

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -249,6 +249,10 @@ impl Session {
         self.dirty = true;
     }
 
+    pub fn update_role_prompt(&mut self, prompt: &str) {
+        self.role_prompt = prompt.to_string();
+    }
+
     pub fn clear_role(&mut self) {
         self.role_name.clear();
         self.role_prompt.clear();


### PR DESCRIPTION
- replace `__TOOLS__` with `{{__tools__}}`
- after `.clear messages`, update system message of agent session
- show interpolated instructions in agent info