### PR TITLE
feat: export agent variable as `LLM_AGENT_VAR_*`

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -342,7 +342,7 @@ impl Config {
     }
 
     pub fn agent_config_dir(name: &str) -> Result<PathBuf> {
-        match env::var(format!("{}_CONFIG_DIR", convert_env_prefix(name))) {
+        match env::var(format!("{}_CONFIG_DIR", normalize_env_name(name))) {
             Ok(value) => Ok(PathBuf::from(value)),
             Err(_) => Ok(Self::agents_config_dir()?.join(name)),
         }
@@ -365,7 +365,7 @@ impl Config {
     }
 
     pub fn agent_functions_dir(name: &str) -> Result<PathBuf> {
-        match env::var(format!("{}_FUNCTIONS_DIR", convert_env_prefix(name))) {
+        match env::var(format!("{}_FUNCTIONS_DIR", normalize_env_name(name))) {
             Ok(value) => Ok(PathBuf::from(value)),
             Err(_) => Ok(Self::agents_functions_dir()?.join(name)),
         }
@@ -1903,8 +1903,4 @@ fn complete_option_bool(value: Option<bool>) -> Vec<String> {
         Some(false) => vec!["true".to_string(), "null".to_string()],
         None => vec!["true".to_string(), "false".to_string()],
     }
-}
-
-fn convert_env_prefix(value: &str) -> String {
-    value.replace('-', "_").to_ascii_uppercase()
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -38,6 +38,10 @@ pub fn get_env_name(key: &str) -> String {
     format!("{}_{key}", env!("CARGO_CRATE_NAME"),).to_ascii_uppercase()
 }
 
+pub fn normalize_env_name(value: &str) -> String {
+    value.replace('-', "_").to_ascii_uppercase()
+}
+
 pub fn estimate_token_length(text: &str) -> usize {
     let words: Vec<&str> = text.unicode_words().collect();
     let mut output: f32 = 0.0;


### PR DESCRIPTION
The agent have variables
```yaml
# index.yaml
variables:
  - name: username
    description: Your user name
```
The agent tools script can access these variables through environment variables
```
LLM_AGENT_VAR_USERNAME
```