### PR TITLE
feat: add agent-scoped `agent_prelude` config

### DIFF
--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -139,6 +139,10 @@ impl Agent {
         self.definition.interpolated_instructions()
     }
 
+    pub fn agent_prelude(&self) -> Option<&str> {
+        self.config.agent_prelude.as_deref()
+    }
+
     pub fn variables(&self) -> &[AgentVariable] {
         &self.definition.variables
     }
@@ -211,7 +215,9 @@ pub struct AgentConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    use_tools: Option<String>,
+    pub use_tools: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_prelude: Option<String>,
 }
 
 impl AgentConfig {


### PR DESCRIPTION
The `agent_prelude` config field in config.yaml provides global control over the agent prelude. However, each agent has its own config.yaml file, which can also contain an `agent_prelude` field for agent-specific control.

```yaml
# <aichat-config-dir>/config.yaml
agent_prelude: 'temp'

# <aichat-config-dir>/agents/demo/config.yaml
agent_prelude: ''
```
When starting in `demo` agent, it will not use the `temp` session automaticlly.