### PR TITLE
fix: config for stream false

### DIFF
--- a/src/client/claude.rs
+++ b/src/client/claude.rs
@@ -253,7 +253,7 @@ pub fn claude_build_chat_completions_body(
         body["top_p"] = v.into();
     }
     if stream {
-        body["stream"] = true.into();
+        body["stream"] = stream.into();
     }
     if let Some(functions) = functions {
         body["tools"] = functions

--- a/src/client/cloudflare.rs
+++ b/src/client/cloudflare.rs
@@ -160,7 +160,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
         body["top_p"] = v.into();
     }
     if stream {
-        body["stream"] = true.into();
+        body["stream"] = stream.into();
     }
 
     Ok(body)

--- a/src/client/cohere.rs
+++ b/src/client/cohere.rs
@@ -237,7 +237,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
         body["p"] = v.into();
     }
     if stream {
-        body["stream"] = true.into();
+        body["stream"] = stream.into();
     }
 
     if let Some(tool_results) = tool_results {

--- a/src/client/ernie.rs
+++ b/src/client/ernie.rs
@@ -266,7 +266,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Valu
     }
 
     if stream {
-        body["stream"] = true.into();
+        body["stream"] = stream.into();
     }
 
     if let Some(functions) = functions {

--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -240,7 +240,7 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
         body["top_p"] = v.into();
     }
     if stream {
-        body["stream"] = true.into();
+        body["stream"] = stream.into();
     }
     if let Some(functions) = functions {
         body["tools"] = functions

--- a/src/client/replicate.rs
+++ b/src/client/replicate.rs
@@ -165,7 +165,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
     });
 
     if stream {
-        body["stream"] = true.into();
+        body["stream"] = stream.into();
     }
 
     Ok(body)


### PR DESCRIPTION
Some huggingface models are offered over the openai-compatible interface, but don't support streaming. When I tested them, I realized that `stream: false` in the config yaml didn't control streaming. This matters because I tried using the non-streaming interface, and they weren't getting called.

The following config lets a user call hugging face models for free:

```yaml
model: huggingface:meta-llama/Meta-Llama-3-8B-Instruct
stream: false
clients:
- type: openai-compatible
  name: huggingface
  api_base: https://api-inference.huggingface.co/v1
  chat_endpoint: /chat/completions
  api_key: hf_SECRET_KEY_HERE
  models:
    - name: HuggingFaceTB/SmolLM-1.7B
    - name: google/gemma-2-2b-it
    - name: meta-llama/Meta-Llama-3.1-8B-Instruct # hugging face pro only
    - name: arcee-ai/arcee-lite
    - name: meta-llama/Meta-Llama-3-8B-Instruct
```
(I want to implement huggingface like the other openai-compatible platforms, but figured this fix should come first)

I tested this fix with replicate, openai, and hugging face so far; they all support `stream: false`