### PR TITLE
fix: incorrect function call handling with session in non-REPL

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -198,8 +198,6 @@ async fn start_directive(
         .write()
         .after_chat_completion(&input, &output, &tool_results)?;
 
-    config.write().exit_session()?;
-
     if need_send_tool_results(&tool_results) {
         start_directive(
             config,
@@ -207,10 +205,11 @@ async fn start_directive(
             code_mode,
             abort_signal,
         )
-        .await
-    } else {
-        Ok(())
+        .await?;
     }
+
+    config.write().exit_session()?;
+    Ok(())
 }
 
 async fn start_interactive(config: &GlobalConfig) -> Result<()> {


### PR DESCRIPTION
Hello, this is quite a fascinating project you've got here!
I have this niche use-case where I'm trying to use it on commandline by manually setting the session ID with the -s and --save-session argument, but found that the model's response does not get saved if it used a function call.

I believe this is due to you calling `exit_session` before processing the tool results here:
https://github.com/sigoden/aichat/blob/514a3689e8588921e0148059967dcf2aa7282747/src/main.rs#L201-L213

Moving the `start_directive` recursion before the `exit_session` call seems to fix session handling and the save flag gets applied properly.

I am 99% sure this doesn't break any other functionality, but I'm not very familiar with the codebase -- Please double-check this before considering a merge. Cheers.