### PR TITLE
add docker config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Rust build artifacts
+/target
+**/*.rs.bk
+
+# Cargo.lock for libraries
+# Uncomment this line if your project is a library
+# Cargo.lock
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.bak
+*.log
+
+# Test coverage
+coverage/
+
+# Documentation
+/doc
+
+# Any local configuration files
+config.local.yaml
+
+# Git directory
+.git/
+.gitignore
+
+# Docker files (optional, depending on your needs)
+# Dockerfile
+# .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Use a more recent version of the official Rust image as a parent image
+FROM rust:1.74 AS builder
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy the current directory contents into the container
+COPY . .
+
+# Build the application
+RUN cargo build --release
+
+# Use a more recent base image for the final image
+FROM debian:bookworm-slim
+
+# Install any needed packages
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Copy the built executable from the builder stage
+COPY --from=builder /usr/src/app/target/release/aichat /usr/local/bin/aichat
+
+# Create directories for aichat configuration and data
+RUN mkdir -p /root/.config/aichat
+
+# Set the working directory
+WORKDIR /root
+
+# Create volume mount points for persistent data
+VOLUME ["/root/.config/aichat"]
+
+# Expose port 8000 for the server
+EXPOSE 8000
+
+# Set the entrypoint to directly call aichat
+ENTRYPOINT ["aichat"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# Use a more recent version of the official Rust image as a parent image
-FROM rust:1.74 AS builder
+# Use Alpine Linux for the builder stage
+FROM rust:1.74-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache musl-dev openssl-dev
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
@@ -10,11 +13,11 @@ COPY . .
 # Build the application
 RUN cargo build --release
 
-# Use a more recent base image for the final image
-FROM debian:bookworm-slim
+# Use Alpine Linux for the final stage
+FROM alpine:3.18
 
-# Install any needed packages
-RUN apt-get update && apt-get install -y libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+# Install runtime dependencies
+RUN apk add --no-cache libgcc openssl ca-certificates
 
 # Copy the built executable from the builder stage
 COPY --from=builder /usr/src/app/target/release/aichat /usr/local/bin/aichat
@@ -32,4 +35,4 @@ VOLUME ["/root/.config/aichat"]
 EXPOSE 8000
 
 # Set the entrypoint to directly call aichat
-ENTRYPOINT ["aichat"]
+ENTRYPOINT ["/usr/local/bin/aichat"]

--- a/README.md
+++ b/README.md
@@ -168,6 +168,72 @@ AIChat supports custom dark and light themes, which highlight response text and 
 
 ![aichat-themes](https://github.com/sigoden/aichat/assets/4012553/29fa8b79-031e-405d-9caa-70d24fa0acf8)
 
+## Docker Usage
+
+To build the Docker image locally:
+
+```bash
+docker build -t aichat:latest .
+```
+
+After you've built the image, you can run AIChat using Docker in various modes:
+
+### One-time Execution
+
+```bash
+docker run --rm -it -e OPENAI_API_KEY=$OPENAI_API_KEY -e AICHAT_PLATFORM=openai aichat:latest -m openai:gpt-4o-mini "Hello, how are you?"
+```
+
+This command:
+- Runs the container interactively and removes it after execution (`--rm -it`)
+- Passes the OpenAI API key and platform from your environment
+- Uses the GPT-4o-mini model (OpenAI's newest)
+- Sends a one-time prompt
+
+Note: Providing both `OPENAI_API_KEY` and `AICHAT_PLATFORM` allows the container to run without a config file. For more information on environment variables, see the [Environment Variables documentation](https://github.com/sigoden/aichat/wiki/Environment-Variables#client-related-envs).
+
+### REPL Mode
+
+```bash
+docker run -it -e OPENROUTER_API_KEY=$OPENROUTER_API_KEY aichat:latest -m openrouter:meta-llama/llama-3.1-8b-instruct:free
+```
+
+This command starts an interactive REPL session using OpenRouter's currently-free Llama 3.1 model.
+
+Note: When first run, the container will prompt to create a config file in Docker's storage location. Subsequent runs of the same container will reuse this config.
+
+### Serve Mode
+
+```bash
+docker run -d -p 8000:8000 -e OPENAI_API_KEY=$OPENAI_API_KEY aichat:latest -m openai:gpt-4o-mini --serve 0.0.0.0
+```
+
+This command:
+- Runs the container in detached mode (`-d`)
+- Maps port 8000 to access the playground and API
+- Starts the AIChat server with the GPT-4o-mini model, listening on all interfaces
+
+Note: The `0.0.0.0` address is necessary to make the server accessible from outside the Docker container.
+
+Access the playground at `http://localhost:8000/playground` and the API at `http://localhost:8000/v1/chat/completions`.
+
+### Persistent Data
+
+To persist configuration and session data:
+
+```bash
+docker run -v $HOME/.config/aichat:/root/.config/aichat -e OPENAI_API_KEY=$OPENAI_API_KEY aichat:latest
+```
+
+This command mounts the user's own configuration location, allowing the container and any local install to share metadata. This ensures that your configuration, sessions, and other data are consistent between the Docker container and a local installation of AIChat.
+
+### Environment Variables
+
+- `AICHAT_PLATFORM`: The AI platform to use (e.g., 'openai', 'openrouter')
+- `AICHAT_<CLIENT>_<CONFIG>`: Client-specific configuration (e.g., `AICHAT_OPENAI_API_KEY`, `AICHAT_OPENROUTER_API_KEY`)
+
+Replace environment variables with your actual API keys and adjust the model and platform as needed.
+
 ## Documentation
 
 - [Configuration Guide](https://github.com/sigoden/aichat/wiki/Configuration-Guide)


### PR DESCRIPTION
Ok I'm going to state right up front that my entire motivation for this work is [this PR](https://github.com/runtipi/runtipi-appstore/pull/4378) in a home server management platform app list.

I also hope you won't be offended by the inclusion of a Stability-generated logo (runtipi requires one).

All of that said, i _do_ think there's genuine value in a dockerized "installation" mechanism. Here's an actual unintended use-case for myself:

- i manage some company servers that are on very old versions of all kinds of stuff. AIChat is unlikely to run well there natively, and my corporate overlords would be very unhappy if i mistakenly sent company data to OpenAI
- I have an internet-exposed AIChat instance running on a GPU-enabled device in my office proxying to an Ollama instance running on the same device (tho really the important use-case would work just as well with an exposed Ollama instance - the AIChat proxy is incidental here)
- I can run this docker image on my ancient server and connect it up to the box in my office et voila i have a "private" LLM I can use from the terminal

I've added a few docs / example, but there's more that could be done there.

If this is of interest, i've got a package associated with my fork that i'm happy to remove. I'd also be happy to work on adding publishing to the Github Container Repo into the release pipeline.