### PR TITLE
fix: invalid model error while switching roles if the model_id is same to current

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -749,6 +749,8 @@ impl Config {
                 if self.model.id() != model_id {
                     let model = Model::retrieve_chat(self, model_id)?;
                     role.set_model(&model);
+                } else {
+                    role.set_model(&self.model);
                 }
             }
             None => role.set_model(&self.model),


### PR DESCRIPTION
For example, if the current model_id is `openai:gpt-4o-mini` and we switch to a role that has the model_id `openai:gpt-4o-mini`.

AIChat will throw error when chatting
```
Invalid model ''
```
