### PR TITLE
Ollama: adding support for num_ctx parameter based on max_input_tokens

### DIFF
--- a/src/client/ollama.rs
+++ b/src/client/ollama.rs
@@ -236,6 +236,9 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
     if let Some(v) = model.max_tokens_param() {
         body["options"]["num_predict"] = v.into();
     }
+    if let Some(v) = model.max_input_tokens() {
+        body["options"]["num_ctx"] = v.into();
+    }
     if let Some(v) = temperature {
         body["options"]["temperature"] = v.into();
     }


### PR DESCRIPTION
It does what it says on the tin.

Ollama uses the `num_ctx` option to specify the maximum context length for a request. If absent, ollama (v 0.3.6) defaults to 2048 tokens, regardless of what an aichat user specifies as `max_input_tokens` in their local configuration.