### PR TITLE
refactor: update models.yaml to fix Bedrock Sonnet 3.5 max_output_tokens (4096)

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -413,7 +413,7 @@
   models:
     - name: anthropic.claude-3-5-sonnet-20240620-v1:0
       max_input_tokens: 200000
-      max_output_tokens: 8192
+      max_output_tokens: 4096
       require_max_tokens: true
       input_price: 3
       output_price: 15


### PR DESCRIPTION
Fixed Bedrock Sonnet 3.5 max_output_tokens  to be 4096, not sure why it had been changed to 8k, but I confirm 4096 is the maximum, otherwise the following error occurs:

```
Failed to call chat-completions api

Caused by:
    The maximum tokens you requested exceeds the model limit of 4096. Try again with a maximum tokens value that is lower than 4096.
```
