### PR TITLE
refactor: openai_compatible client config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -116,8 +116,6 @@ clients:
     name: local
     api_base: http://localhost:8080/v1
     api_key: xxx                                      # Optional
-    chat_endpoint: /chat/completions                  # Optional
-    embeddings_endpoint: /embeddings                  # Optional
     models:
       - name: llama3.1
         max_input_tokens: 128000

--- a/src/client/openai_compatible.rs
+++ b/src/client/openai_compatible.rs
@@ -11,8 +11,6 @@ pub struct OpenAICompatibleConfig {
     pub name: Option<String>,
     pub api_base: Option<String>,
     pub api_key: Option<String>,
-    pub chat_endpoint: Option<String>,
-    pub embeddings_endpoint: Option<String>,
     #[serde(default)]
     pub models: Vec<ModelData>,
     pub patch: Option<RequestPatch>,
@@ -55,18 +53,7 @@ fn prepare_chat_completions(
     let api_key = self_.get_api_key().ok();
     let api_base = get_api_base_ext(self_)?;
 
-    let chat_endpoint = match self_.config.chat_endpoint.clone() {
-        Some(v) => {
-            if v.starts_with('/') {
-                v
-            } else {
-                format!("/{}", v)
-            }
-        }
-        None => "/chat/completions".into(),
-    };
-
-    let url = format!("{api_base}{chat_endpoint}");
+    let url = format!("{api_base}/chat/completions");
 
     let body = openai_build_chat_completions_body(data, &self_.model);
 
@@ -83,18 +70,7 @@ fn prepare_embeddings(self_: &OpenAICompatibleClient, data: EmbeddingsData) -> R
     let api_key = self_.get_api_key().ok();
     let api_base = get_api_base_ext(self_)?;
 
-    let embeddings_endpoint = match self_.config.embeddings_endpoint.clone() {
-        Some(v) => {
-            if v.starts_with('/') {
-                v
-            } else {
-                format!("/{}", v)
-            }
-        }
-        None => "/embeddings".into(),
-    };
-
-    let url = format!("{api_base}{embeddings_endpoint}");
+    let url = format!("{api_base}/embeddings");
 
     let body = openai_build_embeddings_body(data, &self_.model);
 


### PR DESCRIPTION
Remove `chat_endpoint` and `embeddings_endpoint` fields.

The APIs I've seen that are OpenAI-compatible all have consistent endpoints. These two fields are meaningless.

In case of special circumstances, it can also be resolved through the `patch` mechanism.
```
    patch:
      chat_completions:
        '.*':
          url: <endpoint>
```
