### PR TITLE
Update models.yaml with correct batch size limits for voyageai

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -1363,25 +1363,25 @@
       max_input_tokens: 16000
       input_price: 0.12
       default_chunk_size: 2000
-      max_batch_size: 128
+      max_batch_size: 120
     - name: voyage-large-2
       type: embedding
       max_input_tokens: 16000
       input_price: 0.12
       default_chunk_size: 3000
-      max_batch_size: 128
+      max_batch_size: 120
     - name: voyage-multilingual-2
       type: embedding
       max_input_tokens: 32000
       input_price: 0.12
       default_chunk_size: 2000
-      max_batch_size: 128
+      max_batch_size: 120
     - name: voyage-code-2
       type: embedding
       max_input_tokens: 16000
       input_price: 0.12
       default_chunk_size: 3000
-      max_batch_size: 128
+      max_batch_size: 120
     - name: rerank-1
       type: reranker
       max_input_tokens: 8000


### PR DESCRIPTION
Ran into this when using embedding model voyageai:voyage-large-2-instruct

```
✨ Load directory completed
Failed to create embedding

Caused by:
    0: Failed to call embeddings api
    1: Invalid response data: {"detail":"Request to model 'voyage-large-2-instruct' failed. The max allowed tokens per submitted batch is 120000. Your batch has 121138 tokens after truncation. Please lower the number of tokens in the batch."} (status: 400)
```

https://docs.voyageai.com/reference/embeddings-api#:~:text=2%2C%20and-,120K%20for,-voyage%2Dlarge%2D2

Have changed out the maximum in models.yaml for the embedding models to max_batch_size 120 and the error does not appear now.
