### PR TITLE
feat: Provide shortcut keys for commonly used actions in repl mode

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -914,7 +914,7 @@ impl Config {
                         let ans = Confirm::new(
                             "Start a session that incorporates the last question and answer?",
                         )
-                        .with_default(false)
+                        .with_default(true)
                         .prompt()?;
                         if ans {
                             session.add_message(input, output)?;

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -498,6 +498,42 @@ Type ".help" for additional help.
             KeyCode::Enter,
             ReedlineEvent::Edit(vec![EditCommand::InsertNewline]),
         );
+        keybindings.add_binding(
+            KeyModifiers::CONTROL,
+            KeyCode::Char('s'),
+            ReedlineEvent::Multiple(vec![
+                ReedlineEvent::Edit(vec![
+                    EditCommand::InsertString(".session".to_string()),
+                ]),
+                ReedlineEvent::Submit,
+            ]),
+        );
+        keybindings.add_binding(
+            KeyModifiers::CONTROL,
+            KeyCode::Char('i'),
+            ReedlineEvent::Multiple(vec![
+                ReedlineEvent::Edit(vec![
+                    EditCommand::InsertString(".role ".to_string()),
+                ]),
+                ReedlineEvent::UntilFound(vec![
+                    ReedlineEvent::Menu(MENU_NAME.to_string()),
+                    ReedlineEvent::MenuNext,
+                ]),
+            ]),
+        );
+        keybindings.add_binding(
+            KeyModifiers::CONTROL,
+            KeyCode::Char('m'),
+            ReedlineEvent::Multiple(vec![
+                ReedlineEvent::Edit(vec![
+                    EditCommand::InsertString(".model ".to_string()),
+                ]),
+                ReedlineEvent::UntilFound(vec![
+                    ReedlineEvent::Menu(MENU_NAME.to_string()),
+                    ReedlineEvent::MenuNext,
+                ]),
+            ]),
+        );
     }
 
     fn create_edit_mode(config: &GlobalConfig) -> Box<dyn EditMode> {


### PR DESCRIPTION
Thank you for providing such an awesome tool.

I am an emacs user, and in emacs there is a concept of customizing more user-friendly shortcuts in different modes, providing better interaction and more efficient use of tools.

One common and frequently used operation in aichat-repl mode is to switch between roles, models, and sessions by typing `.role`, `.model`, and `.session` respectively during a conversation.

New shortcuts have been added in aichat-repl mode, and these shortcuts do not have any other default actions, so there will be no conflicts.

I have been using these shortcuts for some time now. This tool is updated quickly, and every time it is updated, this patch is applied. I hope this feature can be merged into the upstream.

Thank you.

