### PR TITLE
feat: support RAG-scoped rag_top_k and rag_reranker_model

### DIFF
--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -386,7 +386,7 @@ impl Repl {
                 }
                 ".set" => match args {
                     Some(args) => {
-                        self.config.write().update(args)?;
+                        Config::update(&self.config, args)?;
                     }
                     _ => {
                         println!("Usage: .set <key> <value>...")


### PR DESCRIPTION
After this PR merges, AIChat will allow each RAG to have its own `rag_reranker_model` and `rag_top_k` configuration.

For example, global  `rag_top_k` can be 4, rag1's `top_k` can be 5, rag2's `top_k` can be 3.