### PR TITLE
feat: save rag in YAML instead of bin

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -338,7 +338,7 @@ impl Config {
     pub fn rag_file(&self, name: &str) -> Result<PathBuf> {
         let path = match &self.agent {
             Some(agent) => Self::agent_rag_file(agent.name(), name)?,
-            None => Self::rags_dir()?.join(format!("{name}.bin")),
+            None => Self::rags_dir()?.join(format!("{name}.yaml")),
         };
         Ok(path)
     }
@@ -359,7 +359,7 @@ impl Config {
     }
 
     pub fn agent_rag_file(agent_name: &str, rag_name: &str) -> Result<PathBuf> {
-        Ok(Self::agent_config_dir(agent_name)?.join(format!("{rag_name}.bin")))
+        Ok(Self::agent_config_dir(agent_name)?.join(format!("{rag_name}.yaml")))
     }
 
     pub fn agent_variables_file(name: &str) -> Result<PathBuf> {
@@ -1186,7 +1186,7 @@ impl Config {
                 let mut names = vec![];
                 for entry in rd.flatten() {
                     let name = entry.file_name();
-                    if let Some(name) = name.to_string_lossy().strip_suffix(".bin") {
+                    if let Some(name) = name.to_string_lossy().strip_suffix(".yaml") {
                         names.push(name.to_string());
                     }
                 }

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -326,10 +326,10 @@ impl Session {
         self.path = Some(session_path.display().to_string());
 
         let content = serde_yaml::to_string(&self)
-            .with_context(|| format!("Failed to serde session {}", self.name))?;
+            .with_context(|| format!("Failed to serde session '{}'", self.name))?;
         write(session_path, content).with_context(|| {
             format!(
-                "Failed to write session {} to {}",
+                "Failed to write session '{}' to '{}'",
                 self.name,
                 session_path.display()
             )

--- a/src/rag/serde_vectors.rs
+++ b/src/rag/serde_vectors.rs
@@ -10,16 +10,17 @@ pub fn serialize<S>(
 where
     S: Serializer,
 {
-    let encoded_map: IndexMap<DocumentId, String> = vectors
+    let encoded_map: IndexMap<String, String> = vectors
         .iter()
         .map(|(key, vec)| {
+            let (h, l) = split_document_id(*key);
             let byte_slice = unsafe {
                 std::slice::from_raw_parts(
                     vec.as_ptr() as *const u8,
                     vec.len() * std::mem::size_of::<f32>(),
                 )
             };
-            (*key, STANDARD.encode(byte_slice))
+            (format!("{h}-{l}"), STANDARD.encode(byte_slice))
         })
         .collect();
 
@@ -30,15 +31,24 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<IndexMap<DocumentId, Vec<f
 where
     D: Deserializer<'de>,
 {
-    let encoded_map: IndexMap<DocumentId, String> =
-        IndexMap::<DocumentId, String>::deserialize(deserializer)?;
+    let encoded_map: IndexMap<String, String> =
+        IndexMap::<String, String>::deserialize(deserializer)?;
 
     let mut decoded_map = IndexMap::new();
     for (key, base64_str) in encoded_map {
+        let decoded_key: DocumentId = key
+            .split_once('-')
+            .and_then(|(h, l)| {
+                let h = h.parse::<usize>().ok()?;
+                let l = l.parse::<usize>().ok()?;
+                Some(combine_document_id(h, l))
+            })
+            .ok_or_else(|| de::Error::custom(format!("Invalid key '{key}'")))?;
+
         let decoded_data = STANDARD.decode(&base64_str).map_err(de::Error::custom)?;
 
         if decoded_data.len() % std::mem::size_of::<f32>() != 0 {
-            return Err(de::Error::custom("Invalid byte length for f32 data"));
+            return Err(de::Error::custom(format!("Invalid vector at '{key}'")));
         }
 
         let num_f32s = decoded_data.len() / std::mem::size_of::<f32>();
@@ -52,7 +62,7 @@ where
             );
         }
 
-        decoded_map.insert(key, vec_f32);
+        decoded_map.insert(decoded_key, vec_f32);
     }
 
     Ok(decoded_map)

--- a/src/rag/serde_vectors.rs
+++ b/src/rag/serde_vectors.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::{de, Deserializer, Serializer};
+
+pub fn serialize<S>(
+    vectors: &IndexMap<DocumentId, Vec<f32>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let encoded_map: IndexMap<DocumentId, String> = vectors
+        .iter()
+        .map(|(key, vec)| {
+            let byte_slice = unsafe {
+                std::slice::from_raw_parts(
+                    vec.as_ptr() as *const u8,
+                    vec.len() * std::mem::size_of::<f32>(),
+                )
+            };
+            (*key, STANDARD.encode(byte_slice))
+        })
+        .collect();
+
+    encoded_map.serialize(serializer)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<IndexMap<DocumentId, Vec<f32>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let encoded_map: IndexMap<DocumentId, String> =
+        IndexMap::<DocumentId, String>::deserialize(deserializer)?;
+
+    let mut decoded_map = IndexMap::new();
+    for (key, base64_str) in encoded_map {
+        let decoded_data = STANDARD.decode(&base64_str).map_err(de::Error::custom)?;
+
+        if decoded_data.len() % std::mem::size_of::<f32>() != 0 {
+            return Err(de::Error::custom("Invalid byte length for f32 data"));
+        }
+
+        let num_f32s = decoded_data.len() / std::mem::size_of::<f32>();
+
+        let mut vec_f32 = vec![0.0f32; num_f32s];
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                decoded_data.as_ptr(),
+                vec_f32.as_mut_ptr() as *mut u8,
+                decoded_data.len(),
+            );
+        }
+
+        decoded_map.insert(key, vec_f32);
+    }
+
+    Ok(decoded_map)
+}


### PR DESCRIPTION
BREAHK CHANGING: save rag in YAML instead of bin

Here are the reasons:

1. Bincode cannot extend fields. In #847, two fields, `reranker_model` and `top_k`, were added to the RAG struct. When loading the RAG structure from the bin format, the following error occurs.
```
Error: Failed to load rag 'aichat-wiki' at '<aichat-config-dir>/rags/aichat-wiki.bin'

Caused by:
    tag for enum is not valid, found 32
```

2. Bincode cannot handle data structures like `serde_json::Value`.

3. YAML is a text format that allows users to view rag details, such as chunk content, embedding data, etc. Make it easier for us to debug or troubleshoot.


