### PR TITLE
refactor: no delete the existing role/session when saving with a new name

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -918,13 +918,7 @@ impl Config {
         }
         let role_path = Self::role_file(&role_name)?;
         if let Some(role) = self.role.as_mut() {
-            let old_name = role.name().to_string();
             role.save(&role_name, &role_path, self.working_mode.is_repl())?;
-            if old_name != role_name {
-                if let Ok(path) = Self::role_file(&old_name) {
-                    let _ = remove_file(&path);
-                }
-            }
         }
 
         Ok(())
@@ -1050,13 +1044,7 @@ impl Config {
         };
         let session_path = self.session_file(&session_name)?;
         if let Some(session) = self.session.as_mut() {
-            let old_name = session.name().to_string();
             session.save(&session_name, &session_path, self.working_mode.is_repl())?;
-            if old_name != session_name {
-                if let Ok(path) = self.session_file(&old_name) {
-                    let _ = remove_file(&path);
-                }
-            }
         }
         Ok(())
     }


### PR DESCRIPTION
Since we have the `.delete` repl command to easily delete the old one, we changed the behavior to keep the old file when saving with a different name.


```
.save role new-role
.save session new-session
```

Also relate to #842