### PR TITLE
refactor: improve repl completeion

### DIFF
--- a/src/repl/completer.rs
+++ b/src/repl/completer.rs
@@ -42,7 +42,7 @@ impl Completer for ReplCompleter {
                     .map(|(v, _)| *v)
                     .collect::<Vec<&str>>()
                     .join(" ");
-                cmd.name.starts_with(&line)
+                cmd.name.starts_with(&line) && cmd.name != ".set"
             })
             .collect();
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -147,7 +147,7 @@ lazy_static::lazy_static! {
             "Regenerate the last response",
             AssertState::pass()
         ),
-        ReplCommand::new(".set", "Adjust settings", AssertState::pass()),
+        ReplCommand::new(".set", "Adjust runtime configuration", AssertState::pass()),
         ReplCommand::new(".delete", "Delete roles/sessions/RAGs/agents-config", AssertState::pass()),
         ReplCommand::new(".copy", "Copy the last response", AssertState::pass()),
         ReplCommand::new(".exit", "Exit the REPL", AssertState::pass()),


### PR DESCRIPTION
- Hide `.set` from completion; `.s<tab` will complete to `.session`.
- Sort `.set` key completions

https://github.com/user-attachments/assets/d461240b-9b9b-413a-a3bb-281b208d5df1

