### PR TITLE
fix: Allow reading from special files (device, FIFO, etc)

### DIFF
--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -84,21 +84,18 @@ async fn list_files(
     if !entry_path.exists() {
         bail!("Not found: {}", entry_path.display());
     }
-    if entry_path.is_file() {
-        add_file(files, suffixes, entry_path);
-        return Ok(());
-    }
-    if !entry_path.is_dir() {
-        bail!("Not a directory: {:?}", entry_path);
-    }
-    let mut reader = tokio::fs::read_dir(entry_path).await?;
-    while let Some(entry) = reader.next_entry().await? {
-        let path = entry.path();
-        if path.is_file() {
-            add_file(files, suffixes, &path);
-        } else if path.is_dir() {
-            list_files(files, &path, suffixes).await?;
+    if entry_path.is_dir() {
+        let mut reader = tokio::fs::read_dir(entry_path).await?;
+        while let Some(entry) = reader.next_entry().await? {
+            let path = entry.path();
+            if path.is_dir() {
+                list_files(files, &path, suffixes).await?;
+            } else {
+                add_file(files, suffixes, &path);
+            }
         }
+    } else {
+        add_file(files, suffixes, entry_path);
     }
     Ok(())
 }


### PR DESCRIPTION
See: https://github.com/sigoden/aichat/issues/884

Don't check to see if the filename is a normal file as it will prevent reading from other types of files.  Only directories are treated differently.

FIFO:
```
industrial:~/projects/aichat$ target/debug/aichat -f <(echo I am a banana)
 It seems like you're trying to share some information or engage in a conversation. However, the text "I am a banana" doesn't provide much context for me to respond to
effectively. If you have any specific questions or topics you'd like to discuss, feel free to let me know!
```

File:
```
industrial:~/projects/aichat$ target/debug/aichat -f LICENSE-MIT "What license is this?"
 The provided text is the MIT License. Here are some key points about it:
[...]
```

Device:
```
industrial:~/projects/aichat$ target/debug/aichat -f /dev/null
 The term `/dev/null` is a special file in Unix-like operating systems, including Linux and macOS. It's often referred to as the "bit bucket" or the "black hole." Here are
some key points about `/dev/null`:
[...]
```

Directory:
```
industrial:~/projects/aichat$ target/debug/aichat -f scripts "How many files have you read?"
 Based on the provided files, it appears that you have implemented shell completions and integrations for a command-line tool named `aichat`. The completions are available
for multiple shell environments including PowerShell (`aichat.ps1`), Zsh (`aichat.zsh`), Fish (`aichat.fish`), Bash (`aichat.bash`), and Nushell (`aichat.nu`).
Additionally, there are shell integration scripts for these environments to facilitate real-time interaction with `aichat`.
```