### PR TITLE
feat: remove support for octoai

### DIFF
--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -92,7 +92,6 @@ OPENAI_COMPATIBLE_PLATFORMS=( \
   mistral,open-mistral-nemo,https://api.mistral.ai/v1 \
   moonshot,moonshot-v1-8k,https://api.moonshot.cn/v1 \
   openrouter,openai/gpt-4o-mini,https://openrouter.ai/api/v1 \
-  octoai,meta-llama-3.1-8b-instruct,https://text.octoai.run/v1 \
   ollama,llama3.1:latest,http://localhost:11434/v1 \
   perplexity,llama-3.1-8b-instruct,https://api.perplexity.ai \
   qianwen,qwen-turbo,https://dashscope.aliyuncs.com/compatible-mode/v1 \

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -296,12 +296,6 @@ clients:
     api_base: https://openrouter.ai/api/v1
     api_key: xxx
 
-  # See https://octo.ai/docs/getting-started/quickstart
-  - type: openai-compatible
-    name: octoai
-    api_base: https://text.octoai.run/v1
-    api_key: xxx
-
   # See https://docs.siliconflow.cn/docs/getting-started
   - type: openai-compatible
     name: siliconflow

--- a/models.yaml
+++ b/models.yaml
@@ -1355,37 +1355,6 @@
       input_price: 0.4
       output_price: 0.4
 
-# Links:
-#  - https://octo.ai/docs/getting-started/inference-models
-#  - https://octo.ai/docs/getting-started/pricing-and-billing
-- platform: octoai
-  models:
-    - name: meta-llama-3.1-405b-instruct
-      max_input_tokens: 131072
-      input_price: 3
-      output_price: 9
-      supports_function_calling: true
-    - name: meta-llama-3.1-70b-instruct
-      max_input_tokens: 131072
-      input_price: 0.9
-      output_price: 0.9
-      supports_function_calling: true
-    - name: meta-llama-3.1-8b-instruct
-      max_input_tokens: 131072
-      input_price: 0.15
-      output_price: 0.15
-      supports_function_calling: true
-    - name: mistral-nemo-instruct
-      max_input_tokens: 65536
-      input_price: 0.2
-      output_price: 0.2
-    - name: thenlper/gte-large
-      type: embedding
-      input_price: 0.05
-      max_tokens_per_chunk: 512
-      default_chunk_size: 1000
-      max_batch_size: 100
-
 # Links
 #  - https://siliconflow.cn/zh-cn/pricing#siliconcloud-1417
 #  - https://docs.siliconflow.cn/api-reference/chat-completions/chat-completions

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -35,7 +35,7 @@ register_client!(
     (ernie, "ernie", ErnieConfig, ErnieClient),
 );
 
-pub const OPENAI_COMPATIBLE_PLATFORMS: [(&str, &str); 21] = [
+pub const OPENAI_COMPATIBLE_PLATFORMS: [(&str, &str); 20] = [
     ("ai21", "https://api.ai21.com/studio/v1"),
     ("cloudflare", ""),
     ("deepinfra", "https://api.deepinfra.com/v1/openai"),
@@ -48,7 +48,6 @@ pub const OPENAI_COMPATIBLE_PLATFORMS: [(&str, &str); 21] = [
     ("mistral", "https://api.mistral.ai/v1"),
     ("moonshot", "https://api.moonshot.cn/v1"),
     ("openrouter", "https://openrouter.ai/api/v1"),
-    ("octoai", "https://text.octoai.run/v1"),
     ("ollama", ""),
     ("perplexity", "https://api.perplexity.ai"),
     (


### PR DESCRIPTION
Why? As an open-source LLM inference platform, it has too few models and updates are not timely.

Since OctoAI is an OpenAI-compatible client, users can still access it, but they need to manually configure the `models` field.
