### PR TITLE
fix(input): skip unreadable files instead of throwing an error

### DIFF
--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -340,8 +340,16 @@ async fn load_paths(
             data_urls.insert(sha256(&data_url), file_path);
             medias.push(data_url)
         } else {
-            let text = read_file(&file_path)
-                .with_context(|| format!("Unable to read file '{file_path}'"))?;
+            let text = match read_file(&file_path) {
+                Ok(text) => text,
+                Err(e) => {
+                    println!(
+                        "{}",
+                        warning_text(&format!("⚠️ Skipping file '{file_path}': {e:?}"))
+                    );
+                    continue;
+                }
+            };
             files.push((file_path, text));
         }
     }


### PR DESCRIPTION
When I try to send in an entire codebase some files might fail to be read due to utf-8. 

This PR just logs warning instead of an error so that it's possible to use a subset of the folder.

Great tool 👏 