### PR TITLE
feat: when saving input to message.md, use file paths instead of file contents

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1759,7 +1759,7 @@ impl Config {
         }
         let timestamp = now();
         let summary = input.summary();
-        let input_markdown = input.render();
+        let raw_input = input.raw();
         let scope = if self.agent.is_none() {
             let role_name = if input.role().is_derived() {
                 None
@@ -1775,7 +1775,9 @@ impl Config {
         } else {
             String::new()
         };
-        let output = format!("# CHAT: {summary} [{timestamp}]{scope}\n{input_markdown}\n--------\n{output}\n--------\n\n",);
+        let output = format!(
+            "# CHAT: {summary} [{timestamp}]{scope}\n{raw_input}\n--------\n{output}\n--------\n\n",
+        );
         file.write_all(output.as_bytes())
             .with_context(|| "Failed to save message")
     }

--- a/src/config/role.rs
+++ b/src/config/role.rs
@@ -235,7 +235,7 @@ impl Role {
         } else if self.is_embedded_prompt() {
             self.prompt.replace(INPUT_PLACEHOLDER, &input_markdown)
         } else {
-            format!("{}\n\n{}", self.prompt, input.render())
+            format!("{}\n\n{}", self.prompt, input_markdown)
         }
     }
 


### PR DESCRIPTION
After the PR is merged, if the input contains files, the saved message will only include file paths, not the file contents.
