### PR TITLE
feat: prelude supports <session>:<role>

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,7 +19,7 @@ mapping_tools:                   # Alias for a tool or toolset
 use_tools: null                  # Which tools to use by default. (e.g. 'fs,web_search')
 
 # ---- prelude ----
-prelude: null                    # Set a default role or session to start with (e.g. role:<name>, session:<name>)
+prelude: null                    # Set a default role or session to start with (e.g. role:<name>, session:<name>, <session>:<role>)
 repl_prelude: null               # Overrides the `prelude` setting specifically for conversations started in REPL
 agent_prelude: null              # Set a session to use when starting a agent. (e.g. temp, default)
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1398,6 +1398,14 @@ impl Config {
                     self.use_session(Some(name)).with_context(err_msg)?;
                 }
             }
+            Some((session_name, role_name)) => {
+                if self.session.is_none() {
+                    self.use_session(Some(session_name)).with_context(err_msg)?;
+                    if let Some(true) = self.session.as_ref().map(|v| v.is_empty()) {
+                        self.use_role(role_name).with_context(err_msg)?;
+                    }
+                }
+            }
             _ => {
                 bail!("{}", err_msg())
             }


### PR DESCRIPTION
Now, `prelude` and `repl_prelude` support three types as follows:
- `role:<name>`
- `session:<name>`
- `<session>:<role>`