### PR TITLE
refactor: throw error if using non-exist RAG in CMD mode

### DIFF
--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -32,6 +32,9 @@ impl Agent {
     ) -> Result<Self> {
         let functions_dir = Config::agent_functions_dir(name)?;
         let definition_file_path = functions_dir.join("index.yaml");
+        if !definition_file_path.exists() {
+            bail!("Unknown agent `{name}`");
+        }
         let functions_file_path = functions_dir.join("functions.json");
         let variables_path = Config::agent_variables_file(name)?;
         let rag_path = Config::agent_rag_file(name, "rag")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
     } else if text.is_none() && cli.file.is_empty() {
         WorkingMode::Repl
     } else {
-        WorkingMode::Command
+        WorkingMode::Cmd
     };
     setup_logger(working_mode.is_serve())?;
     let config = Arc::new(RwLock::new(Config::init(working_mode)?));

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -26,5 +26,5 @@ pub async fn render_stream(
 }
 
 pub fn render_error(err: anyhow::Error) {
-    eprintln!("{}", error_text(&pretty_error(&err)));
+    eprint!("{}", error_text(&pretty_error(&err)));
 }


### PR DESCRIPTION
```
$ aichat --rag abc hi
Error: Unknown RAG 'abc'
```