### PR TITLE
fix: unexpected error while piping to shell execution on macOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,9 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
     }
     let is_repl = config.read().working_mode.is_repl();
     if cli.execute && !is_repl {
+        if cfg!(target_os = "macos") && !stdin().is_terminal() {
+            bail!("Unable to read the pipe for shell execution on MacOS")
+        }
         let input = create_input(&config, text, &cli.file).await?;
         shell_execute(&config, &SHELL, input).await?;
         return Ok(());


### PR DESCRIPTION
This PR clearly states that the usage of `... | aichat -e` is not supported on macOS.

```
$ echo pwd | aichat -e
Error: Unable to read the pipe for shell execution on MacOS
```

We're tired of waiting for the new version of inquire to be released. 
Once the new version of Inquire is released, we will remove the restrictions and support the feature on macOS.

close #531