### PR TITLE
feat: support `.edit rag-docs`

### DIFF
--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -128,17 +128,23 @@ impl Rag {
         Ok(rag)
     }
 
-    pub async fn rebuild(
+    pub fn document_paths(&self) -> &[String] {
+        &self.data.document_paths
+    }
+
+    pub async fn refresh_document_paths<T>(
         &mut self,
+        document_paths: &[T],
         config: &GlobalConfig,
         abort_signal: AbortSignal,
-    ) -> Result<()> {
-        debug!("rebuild rag: {}", self.name);
+    ) -> Result<()>
+    where
+        T: AsRef<str>,
+    {
         let loaders = config.read().document_loaders.clone();
         let spinner = create_spinner("Starting").await;
-        let paths = self.data.document_paths.clone();
         tokio::select! {
-            ret = self.sync_documents(loaders, &paths, Some(spinner.clone())) => {
+            ret = self.sync_documents(loaders, document_paths, Some(spinner.clone())) => {
                 spinner.stop();
                 ret?;
             }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -31,7 +31,7 @@ lazy_static::lazy_static! {
 const MENU_NAME: &str = "completion_menu";
 
 lazy_static::lazy_static! {
-    static ref REPL_COMMANDS: [ReplCommand; 34] = [
+    static ref REPL_COMMANDS: [ReplCommand; 35] = [
         ReplCommand::new(".help", "Show this help message", AssertState::pass()),
         ReplCommand::new(".info", "View system info", AssertState::pass()),
         ReplCommand::new(".model", "Change the current LLM", AssertState::pass()),
@@ -104,6 +104,11 @@ lazy_static::lazy_static! {
             ".rag",
             "Init or use the RAG",
             AssertState::False(StateFlags::AGENT)
+        ),
+        ReplCommand::new(
+            ".edit rag-docs",
+            "Edit the RAG documents",
+            AssertState::True(StateFlags::RAG),
         ),
         ReplCommand::new(
             ".rebuild rag",
@@ -360,8 +365,11 @@ impl Repl {
                         Some(("session", _)) => {
                             self.config.write().edit_session()?;
                         }
+                        Some(("rag-docs", _)) => {
+                            Config::edit_rag_docs(&self.config, self.abort_signal.clone()).await?;
+                        }
                         _ => {
-                            println!(r#"Usage: .edit <role|session>"#)
+                            println!(r#"Usage: .edit <role|session|rag-docs>"#)
                         }
                     }
                 }


### PR DESCRIPTION
We can use `.edit rag-docs` REPL command to add/remove document paths.

![aichat-edit-rag-docs](https://github.com/user-attachments/assets/ea231915-f156-4005-a277-d81357e26157)

resolve #950