### PR TITLE
feat: change agent config/variables

### DIFF
--- a/config.agent.example.yaml
+++ b/config.agent.example.yaml
@@ -1,0 +1,10 @@
+# Agent-specific configuration
+
+model: openai:gpt-4o             # Specify the LLM to use
+temperature: null                # Set default temperature parameter
+top_p: null                      # Set default top-p parameter, range (0, 1)
+use_tools: null                  # Which additional tools to use by agent. (e.g. 'fs,web_search')
+agent_prelude: null              # Set a session to use when starting the agent. (e.g. temp, default)
+
+variables:                       # Custom default values for the agent variables
+  <key>: <value>

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -51,7 +51,6 @@ const FUNCTIONS_DIR_NAME: &str = "functions";
 const FUNCTIONS_FILE_NAME: &str = "functions.json";
 const FUNCTIONS_BIN_DIR_NAME: &str = "bin";
 const AGENTS_DIR_NAME: &str = "agents";
-const AGENT_VARIABLES_FILE_NAME: &str = "variables.yaml";
 
 pub const TEMP_ROLE_NAME: &str = "%%";
 pub const TEMP_RAG_NAME: &str = "temp";
@@ -365,10 +364,6 @@ impl Config {
 
     pub fn agent_rag_file(agent_name: &str, rag_name: &str) -> Result<PathBuf> {
         Ok(Self::agent_data_dir(agent_name)?.join(format!("{rag_name}.yaml")))
-    }
-
-    pub fn agent_variables_file(name: &str) -> Result<PathBuf> {
-        Ok(Self::agent_data_dir(name)?.join(AGENT_VARIABLES_FILE_NAME))
     }
 
     pub fn agents_functions_dir() -> Result<PathBuf> {
@@ -1417,14 +1412,6 @@ impl Config {
             None => bail!("No agent"),
         };
         Ok(())
-    }
-
-    pub fn save_agent_config(&mut self) -> Result<()> {
-        let agent = match &self.agent {
-            Some(v) => v,
-            None => bail!("No agent"),
-        };
-        agent.save_config()
     }
 
     pub fn exit_agent(&mut self) -> Result<()> {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -31,7 +31,7 @@ lazy_static::lazy_static! {
 const MENU_NAME: &str = "completion_menu";
 
 lazy_static::lazy_static! {
-    static ref REPL_COMMANDS: [ReplCommand; 35] = [
+    static ref REPL_COMMANDS: [ReplCommand; 34] = [
         ReplCommand::new(".help", "Show this help message", AssertState::pass()),
         ReplCommand::new(".info", "View system info", AssertState::pass()),
         ReplCommand::new(".model", "Change the current LLM", AssertState::pass()),
@@ -139,11 +139,6 @@ lazy_static::lazy_static! {
         ReplCommand::new(
             ".variable",
             "Set agent variable",
-            AssertState::True(StateFlags::AGENT)
-        ),
-        ReplCommand::new(
-            ".save agent-config",
-            "Save the current agent config to file",
             AssertState::True(StateFlags::AGENT)
         ),
         ReplCommand::new(
@@ -346,11 +341,8 @@ impl Repl {
                         Some(("session", name)) => {
                             self.config.write().save_session(name)?;
                         }
-                        Some(("agent-config", _)) => {
-                            self.config.write().save_agent_config()?;
-                        }
                         _ => {
-                            println!(r#"Usage: .save <role|session|agent-config> [name]"#)
+                            println!(r#"Usage: .save <role|session> [name]"#)
                         }
                     }
                 }


### PR DESCRIPTION
- abandon `.save agent-config`
- add variables to agent config.yaml
- don't save agent variables after initializing the agent and using `.variable <key> <value>`