### PR TITLE
feat: `.agent` accepts session name

### DIFF
--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -29,7 +29,7 @@ pub struct Session {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     role_name: Option<String>,
-    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     agent_variables: IndexMap<String, String>,
 
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -42,6 +42,27 @@ pub async fn expand_glob_paths<T: AsRef<str>>(paths: &[T]) -> Result<Vec<String>
     Ok(new_paths)
 }
 
+pub fn list_file_names<T: AsRef<Path>>(dir: Option<T>, ext: &str) -> Vec<String> {
+    let dir = match dir {
+        Some(v) => v,
+        None => return vec![],
+    };
+    match std::fs::read_dir(dir) {
+        Ok(rd) => {
+            let mut names = vec![];
+            for entry in rd.flatten() {
+                let name = entry.file_name();
+                if let Some(name) = name.to_string_lossy().strip_suffix(ext) {
+                    names.push(name.to_string());
+                }
+            }
+            names.sort_unstable();
+            names
+        }
+        Err(_) => vec![],
+    }
+}
+
 pub fn get_patch_extension(path: &str) -> Option<String> {
     Path::new(&path)
         .extension()


### PR DESCRIPTION
```
.agent <agent-name> [session-name]
```

> auto-complete both agent & session name