### PR TITLE
refactor: no side effect `--save-session`

### DIFF
--- a/scripts/completions/aichat.fish
+++ b/scripts/completions/aichat.fish
@@ -3,7 +3,7 @@ complete -c aichat -l prompt -d 'Use the system prompt'
 complete -c aichat -s r -l role -x -a "(aichat --list-roles)" -d 'Select a role' -r
 complete -c aichat -s s -l session -x  -a"(aichat --list-sessions)" -d 'Start or join a session' -r
 complete -c aichat -l empty-session -d 'Ensure the session is empty'
-complete -c aichat -l save-session -d 'Force the session to be saved'
+complete -c aichat -l save-session -d 'Ensure the new conversation is saved to the session'
 complete -c aichat -s a -l agent -x  -a"(aichat --list-agents)" -d 'Start a agent' -r
 complete -c aichat -s R -l rag -x  -a"(aichat --list-rags)" -d 'Start a RAG' -r
 complete -c aichat -l serve -d 'Serve the LLM API and WebAPP'

--- a/scripts/completions/aichat.nu
+++ b/scripts/completions/aichat.nu
@@ -41,7 +41,7 @@ module completions {
     --role(-r): string@"nu-complete aichat role"        # Select a role
     --session(-s): string@"nu-complete aichat session"  # Start or join a session
     --empty-session                                     # Ensure the session is empty
-    --save-session                                      # Force the session to be saved
+    --save-session                                      # Ensure the new conversation is saved to the session
     --agent(-a): string@"nu-complete aichat agent"      # Start a agent
     --rag(-R): string@"nu-complete aichat rag"          # Start a RAG
     --serve                                             # Serve the LLM API and WebAPP

--- a/scripts/completions/aichat.ps1
+++ b/scripts/completions/aichat.ps1
@@ -28,7 +28,7 @@ Register-ArgumentCompleter -Native -CommandName 'aichat' -ScriptBlock {
             [CompletionResult]::new('-s', '-s', [CompletionResultType]::ParameterName, 'Start or join a session')
             [CompletionResult]::new('--session', '--session', [CompletionResultType]::ParameterName, 'Start or join a session')
             [CompletionResult]::new('--empty-session', '--empty-session', [CompletionResultType]::ParameterName, 'Ensure the session is empty')
-            [CompletionResult]::new('--save-session', '--save-session', [CompletionResultType]::ParameterName, 'Force the session to be saved')
+            [CompletionResult]::new('--save-session', '--save-session', [CompletionResultType]::ParameterName, 'Ensure the new conversation is saved to the session')
             [CompletionResult]::new('-a', '-a', [CompletionResultType]::ParameterName, 'Start a agent')
             [CompletionResult]::new('--agent', '--agent', [CompletionResultType]::ParameterName, 'Start a agent')
             [CompletionResult]::new('-R', '-R', [CompletionResultType]::ParameterName, 'Start a RAG')

--- a/scripts/completions/aichat.zsh
+++ b/scripts/completions/aichat.zsh
@@ -23,7 +23,7 @@ _aichat() {
 '-s[Start or join a session]:SESSION:->sessions' \
 '--session[Start or join a session]:SESSION:->sessions' \
 '--empty-session[Ensure the session is empty]' \
-'--save-session[Force the session to be saved]' \
+'--save-session[Ensure the new conversation is saved to the session]' \
 '-a[Start a agent]:AGENT:->agents' \
 '--agent[Start a agent]:AGENT:->agents' \
 '-R[Start a RAG]:RAG:->rags' \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Cli {
     /// Ensure the session is empty
     #[clap(long)]
     pub empty_session: bool,
-    /// Force the session to be saved
+    /// Ensure the new conversation is saved to the session
     #[clap(long)]
     pub save_session: bool,
     /// Start a agent

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1108,6 +1108,16 @@ impl Config {
         self.last_message = None;
         Ok(())
     }
+
+    pub fn set_append_conversation(&mut self) -> Result<()> {
+        if let Some(session) = self.session.as_mut() {
+            session.set_append_conversation();
+        } else {
+            bail!("No session")
+        }
+        Ok(())
+    }
+
     pub fn list_sessions(&self) -> Vec<String> {
         list_file_names(self.sessions_dir(), ".yaml")
     }

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -50,6 +50,8 @@ pub struct Session {
     #[serde(skip)]
     dirty: bool,
     #[serde(skip)]
+    append_conversation: bool,
+    #[serde(skip)]
     compressing: bool,
 }
 
@@ -276,6 +278,10 @@ impl Session {
         }
     }
 
+    pub fn set_append_conversation(&mut self) {
+        self.append_conversation = true;
+    }
+
     pub fn set_compress_threshold(&mut self, value: Option<usize>) {
         if self.compress_threshold != value {
             self.compress_threshold = value;
@@ -308,7 +314,10 @@ impl Session {
     }
 
     pub fn exit(&mut self, session_dir: &Path, is_repl: bool) -> Result<()> {
-        let save_session = self.save_session();
+        let mut save_session = self.save_session();
+        if self.append_conversation {
+            save_session = Some(true);
+        }
         if self.dirty && save_session != Some(false) {
             let mut session_name = self.name().to_string();
             if save_session.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         config.write().empty_session()?;
     }
     if cli.save_session {
-        config.write().set_save_session(Some(true));
+        config.write().set_append_conversation()?;
     }
     if cli.info {
         let info = config.read().info()?;


### PR DESCRIPTION
In the past, `--save-session` would add `save_session: true` configuration to the session YAML file.
This PR get rid of that side effect.