### PR TITLE
feat: remove supports for huggingface

### DIFF
--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -87,7 +87,6 @@ OPENAI_COMPATIBLE_PLATFORMS=( \
   fireworks,accounts/fireworks/models/llama-v3p1-8b-instruct,https://api.fireworks.ai/inference/v1 \
   github,gpt-4o-mini,https://models.inference.ai.azure.com \
   groq,llama3-8b-8192,https://api.groq.com/openai/v1 \
-  huggingface,meta-llama/Meta-Llama-3-8B-Instruct,https://api-inference.huggingface.co/v1 \
   hunyuan,hunyuan-large,https://api.hunyuan.cloud.tencent.com/v1 \
   lingyiwanwu,yi-large,https://api.lingyiwanwu.com/v1 \
   mistral,open-mistral-nemo,https://api.mistral.ai/v1 \

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -244,12 +244,6 @@ clients:
     api_base: https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai/v1
     api_key: xxx
 
-  # See https://huggingface.co/inference-api/serverless
-  - type: openai-compatible
-    name: huggingface
-    api_base: https://api-inference.huggingface.co/v1
-    api_key: xxx
-
   # See https://cloud.baidu.com/doc/WENXINWORKSHOP/index.html
   - type: ernie
     api_key: xxx

--- a/models.yaml
+++ b/models.yaml
@@ -686,30 +686,6 @@
       max_batch_size: 100
 
 # Links:
-#  - https://huggingface.co/models?other=text-generation-inference
-#  - https://huggingface.co/docs/text-generation-inference/en/reference/api_reference
-- platform: huggingface
-  models:
-    - name: NousResearch/Hermes-3-Llama-3.1-8B
-      max_input_tokens: 8192
-      max_output_tokens: 4096
-      require_max_tokens: true
-      input_price: 0
-      output_price: 0
-    - name: mistralai/Mistral-Small-Instruct-2409
-      max_input_tokens: 128000
-      max_output_tokens: 4096
-      require_max_tokens: true
-      input_price: 0
-      output_price: 0
-    - name: mistralai/Mistral-Nemo-Instruct-2407
-      max_input_tokens: 128000
-      max_output_tokens: 4096
-      require_max_tokens: true
-      input_price: 0
-      output_price: 0
-
-# Links:
 #  - https://cloud.baidu.com/doc/WENXINWORKSHOP/s/Nlks5zkzu
 #  - https://cloud.baidu.com/doc/WENXINWORKSHOP/s/hlrk4akp7
 - platform: ernie

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -35,7 +35,7 @@ register_client!(
     (ernie, "ernie", ErnieConfig, ErnieClient),
 );
 
-pub const OPENAI_COMPATIBLE_PLATFORMS: [(&str, &str); 22] = [
+pub const OPENAI_COMPATIBLE_PLATFORMS: [(&str, &str); 21] = [
     ("ai21", "https://api.ai21.com/studio/v1"),
     ("cloudflare", ""),
     ("deepinfra", "https://api.deepinfra.com/v1/openai"),
@@ -43,7 +43,6 @@ pub const OPENAI_COMPATIBLE_PLATFORMS: [(&str, &str); 22] = [
     ("fireworks", "https://api.fireworks.ai/inference/v1"),
     ("github", "https://models.inference.ai.azure.com"),
     ("groq", "https://api.groq.com/openai/v1"),
-    ("huggingface", "https://api-inference.huggingface.co/v1"),
     ("hunyuan", "https://api.hunyuan.cloud.tencent.com/v1"),
     ("lingyiwanwu", "https://api.lingyiwanwu.com/v1"),
     ("mistral", "https://api.mistral.ai/v1"),


### PR DESCRIPTION
The models listed on Hugging Face are incomplete and unstable. Please add models manually.

```yaml
  # See https://huggingface.co/inference-api/serverless
  - type: openai-compatible
    name: huggingface
    api_base: https://api-inference.huggingface.co/v1
    api_key: hf_xxx
    models:
    - name: NousResearch/Hermes-3-Llama-3.1-8B
      max_input_tokens: 8192
      max_output_tokens: 4096
      require_max_tokens: true
      input_price: 0
      output_price: 0
    - name: mistralai/Mistral-Small-Instruct-2409
      max_input_tokens: 128000
      max_output_tokens: 4096
      require_max_tokens: true
      input_price: 0
      output_price: 0
    - name: mistralai/Mistral-Nemo-Instruct-2407
      max_input_tokens: 128000
      max_output_tokens: 4096
      require_max_tokens: true
      input_price: 0
      output_price: 0
```