### PR TITLE
fix: invalid schema because array schema is missing items

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -112,6 +112,8 @@ pub struct JsonSchema {
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<IndexMap<String, JsonSchema>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Box<JsonSchema>>,
     #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
     pub enum_value: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
fix error that array schema`{"type":"array"}` miss `items` property.
```
Error: Failed to call chat-completions api

Caused by:
    Invalid schema for function 'filesystem_read_multiple_files': In context=('properties', 'paths'), array schema missing items. (type: invalid_request_error)
```