### PR TITLE
fix: don't trim the input text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,12 +73,7 @@ pub struct Cli {
 
 impl Cli {
     pub fn text(&self) -> Option<String> {
-        let text = self
-            .text
-            .iter()
-            .map(|x| x.trim().to_string())
-            .collect::<Vec<String>>()
-            .join(" ");
+        let text = self.text.to_vec().join(" ");
         if text.is_empty() {
             return None;
         }

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -91,7 +91,7 @@ impl Input {
         }
         for (path, contents) in files {
             texts.push(format!(
-                "============ PATH: {path} ============\n\n{contents}\n"
+                "============ PATH: {path} ============\n{contents}\n"
             ));
         }
         let (role, with_session, with_agent) = resolve_role(&config.read(), role);


### PR DESCRIPTION
Previously, we thought that the blank text before and after the input text was meaningless, so we automatically trimmed it.

This PR fixed it.

close #1055 