### PR TITLE
feat: supports override agent instructions via agent config

### DIFF
--- a/config.agent.example.yaml
+++ b/config.agent.example.yaml
@@ -2,10 +2,10 @@
 # Location `<aichat-config-dir>/agents/<agent-name>/config.yaml`
 
 model: openai:gpt-4o             # Specify the LLM to use
-temperature: null                # Set default temperature parameter
-top_p: null                      # Set default top-p parameter, range (0, 1)
+temperature: null                # Set default temperature parameter, range (0, 1)
+top_p: null                      # Set default top-p parameter, with a range of (0, 1) or (0, 2) depending on the model
 use_tools: null                  # Which additional tools to use by agent. (e.g. 'fs,web_search')
 agent_prelude: null              # Set a session to use when starting the agent. (e.g. temp, default)
-
+instructions: null               # Override the instructions for the agent, have no effect for dynamic instructions
 variables:                       # Custom default values for the agent variables
   <key>: <value>

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,7 +1,7 @@
 # ---- llm ----
 model: openai:gpt-4o             # Specify the LLM to use
-temperature: null                # Set default temperature parameter
-top_p: null                      # Set default top-p parameter, range (0, 1)
+temperature: null                # Set default temperature parameter (0, 1)
+top_p: null                      # Set default top-p parameter, with a range of (0, 1) or (0, 2) depending on the model
 
 # ---- behavior ----
 stream: true                     # Controls whether to use the stream-style API.


### PR DESCRIPTION
Agent's config.yaml allow adding `instructions` field to override the instructions for the agent, have no effect for dynamic instructions.
```
instructions: null 
```

Also supports override it via `<AGENT_NAME>_INSTRUCTiONS` environment variable.