### PR TITLE
feat: discontinue `rag_min_score_*` config items

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,13 +35,11 @@ summary_prompt: 'This is a summary of the chat history as a recap: '
 
 # ---- RAG ----
 # See [RAG-Guide](https://github.com/sigoden/aichat/wiki/RAG-Guide) for more details.
-rag_embedding_model: null                   # Specifies the embedding model to use
-rag_reranker_model: null                    # Specifies the rerank model to use
-rag_top_k: 5                                # Specifies the number of documents to retrieve
-rag_chunk_size: null                        # Specifies the chunk size
-rag_chunk_overlap: null                     # Specifies the chunk overlap
-rag_min_score_vector_search: 0              # Specifies the minimum relevance score for vector-based searching
-rag_min_score_keyword_search: 0             # Specifies the minimum relevance score for keyword-based searching
+rag_embedding_model: null        # Specifies the embedding model used for context retrieval
+rag_reranker_model: null         # Specifies the reranker model used for sorting retrieved documents
+rag_top_k: 5                     # Specifies the number of documents to retrieve for answering queries
+rag_chunk_size: null             # Defines the size of chunks for document processing in characters
+rag_chunk_overlap: null          # Defines the overlap between chunks
 # Defines the query structure using variables like __CONTEXT__ and __INPUT__ to tailor searches to specific needs
 rag_template: |
   Answer the query based on the context while respecting the rules. (user query, some textual context and rules, all inside xml tags)

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -297,19 +297,11 @@ impl Rag {
         &self,
         text: &str,
         top_k: usize,
-        min_score_vector_search: f32,
-        min_score_keyword_search: f32,
         rerank_model: Option<&str>,
         abort_signal: AbortSignal,
     ) -> Result<(String, Vec<DocumentId>)> {
         let ret = abortable_run_with_spinner(
-            self.hybird_search(
-                text,
-                top_k,
-                min_score_vector_search,
-                min_score_keyword_search,
-                rerank_model,
-            ),
+            self.hybird_search(text, top_k, rerank_model),
             "Searching",
             abort_signal,
         )
@@ -497,13 +489,11 @@ impl Rag {
         &self,
         query: &str,
         top_k: usize,
-        min_score_vector_search: f32,
-        min_score_keyword_search: f32,
         rerank_model: Option<&str>,
     ) -> Result<Vec<(DocumentId, String)>> {
         let (vector_search_results, keyword_search_results) = tokio::join!(
-            self.vector_search(query, top_k, min_score_vector_search),
-            self.keyword_search(query, top_k, min_score_keyword_search)
+            self.vector_search(query, top_k, 0.0),
+            self.keyword_search(query, top_k, 0.0),
         );
 
         let vector_search_results = vector_search_results?;


### PR DESCRIPTION
We will be discontinuing the `rag_min_score_*` configuration items.

Reasons:
- Their functionality overlaps with `rag_top_k`, and they are not as efficient or flexible as `rag_top_k`.
- Scores generated by different embedding models vary, making it impossible to configure them uniformly.
- Scores can only be inspected through debug logs, which is overly complicated.