### PR TITLE
feat: no longer support `.variable` repl command

### DIFF
--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -272,27 +272,6 @@ impl Agent {
         self.session_variables = Some(session_variables);
     }
 
-    pub fn set_variable(&mut self, key: &str, value: &str) -> Result<()> {
-        let variables = match self.session_variables.as_mut() {
-            Some(v) => v,
-            None => &mut self.shared_variables,
-        };
-        let Some(old_value) = variables.get(key) else {
-            bail!("Unknown variable '{key}'")
-        };
-        if old_value == value {
-            return Ok(());
-        }
-        variables.insert(key.to_string(), value.to_string());
-        if self.session_variables.is_some() {
-            self.update_session_dynamic_instructions(None)?;
-        } else {
-            self.update_shared_dynamic_instructions(true)?;
-        }
-
-        Ok(())
-    }
-
     pub fn defined_variables(&self) -> &[AgentVariable] {
         &self.definition.variables
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1503,28 +1503,6 @@ impl Config {
         }
     }
 
-    pub fn set_agent_variable(&mut self, data: &str) -> Result<()> {
-        let parts: Vec<&str> = data.split_whitespace().collect();
-        if parts.len() != 2 {
-            bail!("Usage: .variable <key> <value>");
-        }
-        match self.agent.as_mut() {
-            Some(agent) => {
-                if let Some(session) = self.session.as_ref() {
-                    session.guard_empty()?;
-                }
-                let key = parts[0];
-                let value = parts[1];
-                agent.set_variable(key, value)?;
-                if let Some(session) = self.session.as_mut() {
-                    session.sync_agent(agent);
-                }
-            }
-            None => bail!("No agent"),
-        };
-        Ok(())
-    }
-
     pub fn exit_agent(&mut self) -> Result<()> {
         self.exit_session()?;
         if self.agent.take().is_some() {
@@ -1739,14 +1717,6 @@ impl Config {
                 ".macro" => map_completion_values(Self::list_macros()),
                 ".starter" => match &self.agent {
                     Some(agent) => map_completion_values(agent.conversation_staters().to_vec()),
-                    None => vec![],
-                },
-                ".variable" => match &self.agent {
-                    Some(agent) => agent
-                        .defined_variables()
-                        .iter()
-                        .map(|v| (v.name.clone(), Some(v.description.clone())))
-                        .collect(),
                     None => vec![],
                 },
                 ".set" => {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -29,7 +29,7 @@ use std::{env, process};
 const MENU_NAME: &str = "completion_menu";
 
 lazy_static::lazy_static! {
-    static ref REPL_COMMANDS: [ReplCommand; 35] = [
+    static ref REPL_COMMANDS: [ReplCommand; 34] = [
         ReplCommand::new(".help", "Show this help message", AssertState::pass()),
         ReplCommand::new(".info", "View system info", AssertState::pass()),
         ReplCommand::new(".model", "Change the current LLM", AssertState::pass()),
@@ -103,11 +103,6 @@ lazy_static::lazy_static! {
             ".starter",
             "Use the conversation starter",
             AssertState::True(StateFlags::AGENT)
-        ),
-        ReplCommand::new(
-            ".variable",
-            "Set agent variable",
-            AssertState::TrueFalse(StateFlags::AGENT, StateFlags::SESSION)
         ),
         ReplCommand::new(
             ".info agent",
@@ -462,14 +457,6 @@ pub async fn run_repl_command(
                 None => {
                     let banner = config.read().agent_banner()?;
                     config.read().print_markdown(&banner)?;
-                }
-            },
-            ".variable" => match args {
-                Some(args) => {
-                    config.write().set_agent_variable(args)?;
-                }
-                _ => {
-                    println!("Usage: .variable <key> <value>")
                 }
             },
             ".save" => match split_first_arg(args) {


### PR DESCRIPTION
### Why?

- We have add cli options `--agent-variable <key> <value>` and extend repl cli `.agent <agent-name> [session-name] [key=value]...`, `.variable` is not necessary
- In non-empty session or In the agent with dynamic prompt, the `.variable` can cause inconsistencies and confusion.