### PR TITLE
feat: no longer support role arguments

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -885,8 +885,8 @@ impl Config {
 
     pub fn retrieve_role(&self, name: &str) -> Result<Role> {
         let names = Self::list_roles(false);
-        let mut role = if let Some(role_name) = Role::match_name(&names, name) {
-            let path = Self::role_file(&role_name);
+        let mut role = if names.contains(&name.to_string()) {
+            let path = Self::role_file(name);
             let content = read_to_string(&path)?;
             Role::new(name, &content)
         } else {
@@ -942,9 +942,7 @@ impl Config {
     }
 
     pub fn upsert_role(&mut self, name: &str) -> Result<()> {
-        let names = Self::list_roles(false);
-        let role_name = Role::match_name(&names, name).unwrap_or_else(|| name.to_string());
-        let role_path = Self::role_file(&role_name);
+        let role_path = Self::role_file(name);
         ensure_parent_exists(&role_path)?;
         let editor = self.editor()?;
         edit_file(&editor, &role_path)?;
@@ -1026,7 +1024,7 @@ impl Config {
 
     pub fn has_role(name: &str) -> bool {
         let names = Self::list_roles(true);
-        Role::match_name(&names, name).is_some()
+        names.contains(&name.to_string())
     }
 
     pub fn use_session(&mut self, session_name: Option<&str>) -> Result<()> {


### PR DESCRIPTION
### Why

Because role arguments are not valuable.

The prompt needs to be carefully designed, and any changes may affect the whole system. The placeholder replacement mechanism of role arguments is not practical.