### PR TITLE
feat: add a default base_url to ollama

### DIFF
--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -322,7 +322,7 @@ _argc_before() {
         mistral,mistral-small-latest,https://api.mistral.ai/v1 \
         moonshot,moonshot-v1-8k,https://api.moonshot.cn/v1 \
         openrouter,openai/gpt-4o-mini,https://openrouter.ai/api/v1 \
-        ollama,llama3.1:latest,${OLLAMA_HOST:-"http://127.0.0.1:11434"}/v1 \
+        ollama,llama3.1:latest,http://${OLLAMA_HOST:-"127.0.0.1:11434"}/v1 \
         perplexity,llama-3.1-8b-instruct,https://api.perplexity.ai \
         qianwen,qwen-turbo-latest,https://dashscope.aliyuncs.com/compatible-mode/v1 \
         siliconflow,meta-llama/Meta-Llama-3.1-8B-Instruct,https://api.siliconflow.cn/v1 \

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -49,7 +49,7 @@ pub const OPENAI_COMPATIBLE_PLATFORMS: [(&str, &str); 22] = [
     ("mistral", "https://api.mistral.ai/v1"),
     ("moonshot", "https://api.moonshot.cn/v1"),
     ("openrouter", "https://openrouter.ai/api/v1"),
-    ("ollama", ""),
+    ("ollama", "http://127.0.0.1:11434/v1"),
     ("perplexity", "https://api.perplexity.ai"),
     (
         "qianwen",


### PR DESCRIPTION
Some users don't know how to set the `api_base` of ollama.

![image](https://github.com/user-attachments/assets/67671be1-f955-4f85-b18c-92a2de1f5778)

It is better to set a default value to facilitate new users to use ollama.
