### PR TITLE
refactor: no gaurd vision model

### DIFF
--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -178,10 +178,6 @@ impl Model {
         self.data.max_output_tokens
     }
 
-    pub fn supports_vision(&self) -> bool {
-        self.data.supports_vision
-    }
-
     pub fn no_stream(&self) -> bool {
         self.data.no_stream
     }

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -249,9 +249,6 @@ impl Input {
         model: &Model,
         stream: bool,
     ) -> Result<ChatCompletionsData> {
-        if !self.medias.is_empty() && !model.supports_vision() {
-            bail!("The current model does not support vision. Is the model configured with `supports_vision: true`?");
-        }
         let mut messages = self.build_messages()?;
         if model.no_system_message() {
             patch_system_message(&mut messages);


### PR DESCRIPTION
Don't throw an error when we send an image to a model that does not have the `support_vision: true` configuration.