### PR TITLE
refactor: change default sync_models_url

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,11 +79,11 @@ right_prompt:
   '{color.purple}{?session {?consume_tokens {consume_tokens}({consume_percent}%)}{!consume_tokens {consume_tokens}}}{color.reset}'
 
 # ---- misc ----
-serve_addr: 127.0.0.1:8000                  # Default serve listening address 
+serve_addr: 127.0.0.1:8000                  # Server listening address 
 user_agent: null                            # Set User-Agent HTTP header, use `auto` for aichat/<current-version>
 save_shell_history: true                    # Whether to save shell execution command to the history file
-# Sync models changes from the specified URL, using a CDN link rather than a direct GitHub raw link due to the higher availability and reliability of the CDN.
-sync_models_url: https://cdn.jsdelivr.net/gh/sigoden/aichat/models.yaml # Or https://raw.githubusercontent.com/sigoden/aichat/refs/heads/main/models.yaml
+# URL to sync model changes from, e.g., https://cdn.jsdelivr.net/gh/sigoden/aichat@main/models.yaml
+sync_models_url: https://raw.githubusercontent.com/sigoden/aichat/refs/heads/main/models.yaml
 
 # ---- clients ----
 clients:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,7 +64,8 @@ const CLIENTS_FIELD: &str = "clients";
 
 const SERVE_ADDR: &str = "127.0.0.1:8000";
 
-const SYNC_MODELS_URL: &str = "https://cdn.jsdelivr.net/gh/sigoden/aichat/models.yaml";
+const SYNC_MODELS_URL: &str =
+    "https://raw.githubusercontent.com/sigoden/aichat/refs/heads/main/models.yaml";
 
 const SUMMARIZE_PROMPT: &str =
     "Summarize the discussion briefly in 200 words or less to use as a prompt for future context.";


### PR DESCRIPTION
The CDN can't update in time, so change it to github link.

```
sync_models_url: https://raw.githubusercontent.com/sigoden/aichat/refs/heads/main/models.yaml
```

Relate to #1114 