### PR TITLE
refactor: several improvements

### DIFF
--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -44,8 +44,9 @@ pub trait Client: Sync + Send {
         let mut builder = ReqwestClient::builder();
         let extra = self.extra_config();
         let timeout = extra.and_then(|v| v.connect_timeout).unwrap_or(10);
-        let proxy = extra.and_then(|v| v.proxy.clone());
-        builder = set_proxy(builder, proxy.as_ref())?;
+        if let Some(proxy) = extra.and_then(|v| v.proxy.as_deref()) {
+            builder = set_proxy(builder, proxy)?;
+        }
         if let Some(user_agent) = self.global_config().read().user_agent.as_ref() {
             builder = builder.user_agent(user_agent);
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -288,6 +288,8 @@ impl Config {
     pub fn config_dir() -> PathBuf {
         if let Ok(v) = env::var(get_env_name("config_dir")) {
             PathBuf::from(v)
+        } else if let Ok(v) = env::var("XDG_CONFIG_HOME") {
+            PathBuf::from(v).join(env!("CARGO_CRATE_NAME"))
         } else {
             let dir = dirs::config_dir().expect("No user's config directory");
             dir.join(env!("CARGO_CRATE_NAME"))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -288,8 +288,6 @@ impl Config {
     pub fn config_dir() -> PathBuf {
         if let Ok(v) = env::var(get_env_name("config_dir")) {
             PathBuf::from(v)
-        } else if let Ok(v) = env::var("XDG_CONFIG_HOME") {
-            PathBuf::from(v).join(env!("CARGO_CRATE_NAME"))
         } else {
             let dir = dirs::config_dir().expect("No user's config directory");
             dir.join(env!("CARGO_CRATE_NAME"))

--- a/src/render/markdown.rs
+++ b/src/render/markdown.rs
@@ -7,7 +7,7 @@ use syntect::highlighting::{Color as SyntectColor, FontStyle, Style, Theme};
 use syntect::parsing::SyntaxSet;
 use syntect::{easy::HighlightLines, parsing::SyntaxReference};
 
-/// Comes from https://github.com/sharkdp/bat/raw/5e77ca37e89c873e4490b42ff556370dc5c6ba4f/assets/syntaxes.bin
+/// Comes from <https://github.com/sharkdp/bat/raw/5e77ca37e89c873e4490b42ff556370dc5c6ba4f/assets/syntaxes.bin>
 const SYNTAXES: &[u8] = include_bytes!("../../assets/syntaxes.bin");
 
 lazy_static::lazy_static! {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -217,15 +217,12 @@ pub fn is_url(path: &str) -> bool {
 
 pub fn set_proxy(
     mut builder: reqwest::ClientBuilder,
-    proxy: Option<&String>,
+    proxy: &str,
 ) -> Result<reqwest::ClientBuilder> {
-    if let Some(proxy) = proxy {
-        builder = builder.no_proxy();
-        if !proxy.is_empty() && proxy != "-" {
-            builder = builder.proxy(
-                reqwest::Proxy::all(proxy).with_context(|| format!("Invalid proxy `{proxy}`"))?,
-            );
-        }
+    builder = builder.no_proxy();
+    if !proxy.is_empty() && proxy != "-" {
+        builder = builder
+            .proxy(reqwest::Proxy::all(proxy).with_context(|| format!("Invalid proxy `{proxy}`"))?);
     };
     Ok(builder)
 }

--- a/src/utils/request.rs
+++ b/src/utils/request.rs
@@ -29,7 +29,6 @@ const USER_AGENT: &str = "curl/8.6.0";
 lazy_static::lazy_static! {
     static ref CLIENT: Result<reqwest::Client> = {
         let builder = reqwest::ClientBuilder::new().timeout(Duration::from_secs(30));
-        let builder = set_proxy(builder, None)?;
         let client = builder.build()?;
         Ok(client)
     };


### PR DESCRIPTION
- improve proxy handling in client configuration, eliminate unneccessary `clone()`
- `src/render/markdown.rs`: eliminate a `#[warn(rustdoc::bare_urls)]` from `cargo doc`, turn bare URL into clickable links
- ~~`src/config/mod.rs`: delete a redundant conditional branch because `dirs::config_dir` has implemented the `XDG_HCONFIG_HOME` feature~~
