### PR TITLE
feat: strip reasoning contents in history messages

### DIFF
--- a/assets/arena.html
+++ b/assets/arena.html
@@ -870,6 +870,7 @@
               });
             }
           }
+          sanitizeMessages(messages);
           const body = {
             model: chat.model,
             messages: messages,
@@ -991,6 +992,20 @@
       });
     }
 
+    function sanitizeMessages(messages) {
+      let messagesLen = messages.length;
+      for (let i = 0; i < messagesLen; i++) {
+        const message = messages[i];
+        if (typeof message.content === "string" && message.role === "assistant" && i !== messagesLen - 1) {
+          message.content = stripThinkTag(message.content);
+        }
+      }
+    }
+
+    function stripThinkTag(text) {
+      return text.replace(/^\s*<think>([\s\S]*?)<\/think>(\s*|$)/g, '')
+    }
+
     function setupMarked() {
       const renderer = {
         code({ text, lang }) {
@@ -1013,7 +1028,12 @@
         name: 'think',
         level: 'block',
         start(src) {
-          return src.indexOf('<think>');
+          const match = /^(\s*)<think>/.exec(src);
+          if (match) {
+            return match[1].length
+          } else {
+            return -1;
+          }
         },
         tokenizer(src, tokens) {
           const rule = /^\s*<think>([\s\S]*?)(<\/think>|$)/;

--- a/assets/playground.html
+++ b/assets/playground.html
@@ -1298,6 +1298,7 @@
               messages = [...promptMessages, ...messages];
             }
           }
+          sanitizeMessages(messages);
           const body = {
             model: this.settings.model,
             messages: messages,
@@ -1458,6 +1459,20 @@
       return { system: prompt, cases: [] }
     }
 
+    function sanitizeMessages(messages) {
+      let messagesLen = messages.length;
+      for (let i = 0; i < messagesLen; i++) {
+        const message = messages[i];
+        if (typeof message.content === "string" && message.role === "assistant" && i !== messagesLen - 1) {
+          message.content = stripThinkTag(message.content);
+        }
+      }
+    }
+
+    function stripThinkTag(text) {
+      return text.replace(/^\s*<think>([\s\S]*?)<\/think>(\s*|$)/g, '')
+    }
+
     function convertImageToDataURL(imageFile) {
       return new Promise((resolve, reject) => {
         if (!imageFile) {
@@ -1494,7 +1509,12 @@
         name: 'think',
         level: 'block',
         start(src) {
-          return src.indexOf('<think>');
+          const match = /^(\s*)<think>/.exec(src);
+          if (match) {
+            return match[1].length
+          } else {
+            return -1;
+          }
         },
         tokenizer(src, tokens) {
           const rule = /^\s*<think>([\s\S]*?)(<\/think>|$)/;

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -65,6 +65,10 @@ impl MessageRole {
     pub fn is_user(&self) -> bool {
         matches!(self, MessageRole::User)
     }
+
+    pub fn is_assistant(&self) -> bool {
+        matches!(self, MessageRole::Assistant)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,11 +26,13 @@ use anyhow::{Context, Result};
 use fancy_regex::Regex;
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use is_terminal::IsTerminal;
+use std::borrow::Cow;
 use std::{env, path::PathBuf, process};
 use unicode_segmentation::UnicodeSegmentation;
 
 lazy_static::lazy_static! {
     pub static ref CODE_BLOCK_RE: Regex = Regex::new(r"(?ms)```\w*(.*)```").unwrap();
+    pub static ref THINK_TAG_RE: Regex = Regex::new(r"(?s)^\s*<think>.*?</think>(\s*|$)").unwrap();
     pub static ref IS_STDOUT_TERMINAL: bool = std::io::stdout().is_terminal();
     pub static ref NO_COLOR: bool = env::var("NO_COLOR").ok().and_then(|v| parse_bool(&v)).unwrap_or_default() || !*IS_STDOUT_TERMINAL;
 }
@@ -57,6 +59,10 @@ pub fn parse_bool(value: &str) -> Option<bool> {
         "0" | "false" => Some(false),
         _ => None,
     }
+}
+
+pub fn strip_think_tag(input: &str) -> Cow<str> {
+    THINK_TAG_RE.replace_all(input, "")
 }
 
 pub fn estimate_token_length(text: &str) -> usize {


### PR DESCRIPTION
In the session, AIChat will send chat history messages to the LLM provider. The `<think>{text}</think>` in the assistant's message needs to be removed, except for the last one (for `.regenerate`).

The rule also apply to the webui.