### PR TITLE
feat: new model field `system_prompt_prefix`

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -53,6 +53,7 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
+      system_prompt_prefix: Formatting re-enabled
     - name: o1
       max_input_tokens: 200000
       input_price: 15
@@ -60,6 +61,7 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
+      system_prompt_prefix: Formatting re-enabled
     - name: o1-preview
       max_input_tokens: 128000
       max_output_tokens: 32768
@@ -1172,6 +1174,7 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
+      system_prompt_prefix: Formatting re-enabled
     - name: openai/o1
       max_input_tokens: 128000
       input_price: 15
@@ -1179,6 +1182,7 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
+      system_prompt_prefix: Formatting re-enabled
     - name: openai/o1-preview
       max_input_tokens: 128000
       input_price: 15
@@ -1477,11 +1481,13 @@
       supports_function_calling: true
       supports_vision: true
       supports_reasoning: true
+      system_prompt_prefix: Formatting re-enabled
     - name: o1
       max_input_tokens: 200000
       supports_function_calling: true
       supports_vision: true
       supports_reasoning: true
+      system_prompt_prefix: Formatting re-enabled
     - name: o1-preview
       max_input_tokens: 128000
       supports_reasoning: true

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -198,6 +198,10 @@ impl Model {
         self.data.no_system_message
     }
 
+    pub fn system_prompt_prefix(&self) -> Option<&str> {
+        self.data.system_prompt_prefix.as_deref()
+    }
+
     pub fn max_tokens_per_chunk(&self) -> Option<usize> {
         self.data.max_tokens_per_chunk
     }
@@ -321,6 +325,8 @@ pub struct ModelData {
     no_stream: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     no_system_message: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_prompt_prefix: Option<String>,
 
     // embedding-only properties
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 use crate::client::{
-    init_client, patch_system_message, ChatCompletionsData, Client, ImageUrl, Message,
-    MessageContent, MessageContentPart, MessageContentToolCalls, MessageRole, Model,
+    init_client, patch_messages, ChatCompletionsData, Client, ImageUrl, Message, MessageContent,
+    MessageContentPart, MessageContentToolCalls, MessageRole, Model,
 };
 use crate::function::ToolResult;
 use crate::utils::{base64_encode, is_loader_protocol, sha256, AbortSignal};
@@ -238,9 +238,7 @@ impl Input {
         stream: bool,
     ) -> Result<ChatCompletionsData> {
         let mut messages = self.build_messages()?;
-        if model.no_system_message() {
-            patch_system_message(&mut messages);
-        }
+        patch_messages(&mut messages, model);
         model.guard_max_input_tokens(&messages)?;
         let temperature = self.role().temperature();
         let top_p = self.role().top_p();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -309,9 +309,7 @@ impl Server {
 
         let completion_id = generate_completion_id();
         let created = Utc::now().timestamp();
-        if client.model().no_system_message() {
-            patch_system_message(&mut messages);
-        }
+        patch_messages(&mut messages, client.model());
         let data: ChatCompletionsData = ChatCompletionsData {
             messages,
             temperature,


### PR DESCRIPTION
We use `system_prompt_prefix: Formatting re-enabled` to o1/o3-mini models to generating responses with markdown formatting again.