### PR TITLE
feat: add model field `no_temperature`

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -53,6 +53,7 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
+      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
     - name: o1
       max_input_tokens: 200000
@@ -61,6 +62,7 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
+      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
     - name: o1-preview
       max_input_tokens: 128000
@@ -69,6 +71,7 @@
       output_price: 60
       supports_reasoning: true
       no_system_message: true
+      no_temperature: true
     - name: o1-mini
       max_input_tokens: 128000
       max_output_tokens: 65536
@@ -76,6 +79,7 @@
       output_price: 12
       supports_reasoning: true
       no_system_message: true
+      no_temperature: true
     - name: gpt-3.5-turbo
       max_input_tokens: 16385
       max_output_tokens: 4096
@@ -1044,6 +1048,7 @@
       input_price: 0.55
       output_price: 2.19
       supports_reasoning: true
+      no_temperature: true
 
 # Links:
 #  - https://open.bigmodel.cn/pricing
@@ -1174,6 +1179,7 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
+      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
     - name: openai/o1
       max_input_tokens: 128000
@@ -1182,6 +1188,7 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
+      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
     - name: openai/o1-preview
       max_input_tokens: 128000
@@ -1189,12 +1196,14 @@
       output_price: 60
       supports_reasoning: true
       no_system_message: true
+      no_temperature: true
     - name: openai/o1-mini
       max_input_tokens: 128000
       input_price: 3
       output_price: 12
       supports_reasoning: true
       no_system_message: true
+      no_temperature: true
     - name: openai/gpt-3.5-turbo
       max_input_tokens: 16385
       input_price: 0.5
@@ -1481,23 +1490,27 @@
       supports_function_calling: true
       supports_vision: true
       supports_reasoning: true
+      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
     - name: o1
       max_input_tokens: 200000
       supports_function_calling: true
       supports_vision: true
       supports_reasoning: true
+      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
     - name: o1-preview
       max_input_tokens: 128000
       supports_reasoning: true
       no_stream: true
       no_system_message: true
+      no_temperature: true
     - name: o1-mini
       max_input_tokens: 128000
       supports_reasoning: true
       no_stream: true
       no_system_message: true
+      no_temperature: true
     - name: text-embedding-3-large
       type: embedding
       max_tokens_per_chunk: 8191

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -198,6 +198,10 @@ impl Model {
         self.data.no_system_message
     }
 
+    pub fn no_temperature(&self) -> bool {
+        self.data.no_temperature
+    }
+
     pub fn system_prompt_prefix(&self) -> Option<&str> {
         self.data.system_prompt_prefix.as_deref()
     }
@@ -325,6 +329,8 @@ pub struct ModelData {
     no_stream: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     no_system_message: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    no_temperature: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     system_prompt_prefix: Option<String>,
 

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -240,8 +240,11 @@ impl Input {
         let mut messages = self.build_messages()?;
         patch_messages(&mut messages, model);
         model.guard_max_input_tokens(&messages)?;
-        let temperature = self.role().temperature();
-        let top_p = self.role().top_p();
+        let (temperature, top_p) = if model.no_temperature() {
+            (None, None)
+        } else {
+            (self.role().temperature(), self.role().top_p())
+        };
         let functions = self.config.read().select_functions(self.role());
         Ok(ChatCompletionsData {
             messages,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -270,8 +270,8 @@ impl Server {
         let ChatCompletionsReqBody {
             model,
             messages,
-            temperature,
-            top_p,
+            mut temperature,
+            mut top_p,
             max_tokens,
             stream,
             tools,
@@ -309,7 +309,14 @@ impl Server {
 
         let completion_id = generate_completion_id();
         let created = Utc::now().timestamp();
+
         patch_messages(&mut messages, client.model());
+
+        if client.model().no_temperature() {
+            temperature = None;
+            top_p = None;
+        }
+
         let data: ChatCompletionsData = ChatCompletionsData {
             messages,
             temperature,


### PR DESCRIPTION
Some reasoning models do not support temperature/top_p parameters, we can use `no_temperature: true` to eliminate these parameters.

