### PR TITLE
feat: drop predefined models for ollama client

### DIFF
--- a/Argcfile.sh
+++ b/Argcfile.sh
@@ -313,7 +313,6 @@ _argc_before() {
         moonshot,moonshot-v1-8k,https://api.moonshot.cn/v1 \
         novita,meta-llama/llama-3.1-8b-instruct,https://api.novita.ai/v3/openai \
         openrouter,openai/gpt-4o-mini,https://openrouter.ai/api/v1 \
-        ollama,llama3.1:latest,http://${OLLAMA_HOST:-"127.0.0.1:11434"}/v1 \
         perplexity,llama-3.1-8b-instruct,https://api.perplexity.ai \
         qianwen,qwen-turbo-latest,https://dashscope.aliyuncs.com/compatible-mode/v1 \
         siliconflow,meta-llama/Meta-Llama-3.1-8B-Instruct,https://api.siliconflow.cn/v1 \

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -98,13 +98,10 @@ clients:
   #       supports_reasoning: true
   #     - name: xxxx                                  # Embedding model
   #       type: embedding
-  #       max_input_tokens: 200000
-  #       max_tokens_per_chunk: 2000
   #       default_chunk_size: 1500                        
   #       max_batch_size: 100
   #     - name: xxxx                                  # Reranker model
   #       type: reranker 
-  #       max_input_tokens: 2048
   #   patch:                                          # Patch api
   #     chat_completions:                             # Api type, possible values: chat_completions, embeddings, and rerank
   #       <regex>:                                    # The regex to match model names, e.g. '.*' 'gpt-4o' 'gpt-4o|gpt-4-.*'
@@ -125,19 +122,23 @@ clients:
 
   # For any platform compatible with OpenAI's API
   - type: openai-compatible
-    name: local
-    api_base: http://localhost:8080/v1
+    name: ollama
+    api_base: http://localhost:11434/v1
     api_key: xxx                                      # Optional
     models:
+      - name: deepseek-r1
+        max_input_tokens: 131072
+        supports_reasoning: true
       - name: llama3.1
         max_input_tokens: 128000
         supports_function_calling: true
-      - name: jina-embeddings-v2-base-en
+      - name: llama3.2-vision
+        max_input_tokens: 131072
+        supports_vision: true
+      - name: nomic-embed-text
         type: embedding
-        default_chunk_size: 1500
-        max_batch_size: 100
-      - name: jina-reranker-v2-base-multilingual
-        type: reranker
+        default_chunk_size: 1000
+        max_batch_size: 50
 
   # See https://ai.google.dev/docs
   - type: gemini
@@ -196,11 +197,6 @@ clients:
     name: groq
     api_base: https://api.groq.com/openai/v1
     api_key: xxx
-
-  # See https://github.com/jmorganca/ollama
-  - type: openai-compatible
-    name: ollama
-    api_base: http://localhost:11434/v1
 
   # See https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart
   - type: azure-openai

--- a/models.yaml
+++ b/models.yaml
@@ -441,35 +441,6 @@
       supports_reasoning: true
 
 # Links:
-#  - https://ollama.com/library
-#  - https://github.com/ollama/ollama/blob/main/docs/openai.md
-- provider: ollama
-  models:
-    - name: llama3.1
-      max_input_tokens: 131072
-      supports_function_calling: true
-    - name: llama3.2
-      max_input_tokens: 131072
-      supports_function_calling: true
-    - name: llama3.2-vision
-      max_input_tokens: 131072
-      supports_vision: true
-    - name: qwen2.5
-      max_input_tokens: 131072
-      supports_function_calling: true
-    - name: qwen2.5-coder
-      max_input_tokens: 32768
-      supports_function_calling: true
-    - name: deepseek-r1
-      max_input_tokens: 131072
-      supports_reasoning: true
-    - name: nomic-embed-text
-      type: embedding
-      max_tokens_per_chunk: 8192
-      default_chunk_size: 1000
-      max_batch_size: 50
-
-# Links:
 #  - https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models
 #  - https://cloud.google.com/vertex-ai/generative-ai/docs/model-garden/explore-models
 #  - https://cloud.google.com/vertex-ai/generative-ai/pricing

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,7 +33,7 @@ register_client!(
     (bedrock, "bedrock", BedrockConfig, BedrockClient),
 );
 
-pub const OPENAI_COMPATIBLE_PROVIDERS: [(&str, &str); 25] = [
+pub const OPENAI_COMPATIBLE_PROVIDERS: [(&str, &str); 24] = [
     ("ai21", "https://api.ai21.com/studio/v1"),
     (
         "cloudflare",
@@ -53,7 +53,6 @@ pub const OPENAI_COMPATIBLE_PROVIDERS: [(&str, &str); 25] = [
     ("moonshot", "https://api.moonshot.cn/v1"),
     ("novita", "https://api.novita.ai/v3/openai"),
     ("openrouter", "https://openrouter.ai/api/v1"),
-    ("ollama", "http://{OLLAMA_HOST}:11434/v1"),
     ("perplexity", "https://api.perplexity.ai"),
     (
         "qianwen",


### PR DESCRIPTION
After #1161 merged, We recommend using the `openai-compatible` client initialization process to generate model definitions based on your current Ollama.


![ollama](https://github.com/user-attachments/assets/7d565b17-07d4-4000-a9e6-6fc2ca9e8f46)
