### PR TITLE
'.run' command for user-side command line executions.

### DIFF
--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -18,7 +18,7 @@ const SUMMARY_MAX_WIDTH: usize = 80;
 #[derive(Debug, Clone)]
 pub struct Input {
     config: GlobalConfig,
-    text: String,
+    pub text: String,
     raw: (String, Vec<String>),
     patched_text: Option<String>,
     last_reply: Option<String>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -171,6 +171,8 @@ pub struct Config {
     pub rag: Option<Arc<Rag>>,
     #[serde(skip)]
     pub agent: Option<Agent>,
+    #[serde(skip)]
+    pub run_output: Option<String>,
 }
 
 impl Default for Config {
@@ -235,6 +237,7 @@ impl Default for Config {
             session: None,
             rag: None,
             agent: None,
+            run_output: None,
         }
     }
 }
@@ -2033,7 +2036,10 @@ impl Config {
         output
     }
 
-    pub fn before_chat_completion(&mut self, input: &Input) -> Result<()> {
+    pub fn before_chat_completion(&mut self, input: &mut Input) -> Result<()> {
+        if let Some(output) = self.run_output.take() {
+            input.text.insert_str(0, &format!("{} ", output));
+        }
         self.last_message = Some(LastMessage::new(input.clone(), String::new()));
         Ok(())
     }


### PR DESCRIPTION
I've adeed a dot-command '.run', alike the one used in 'aichat', which allows to execute a command line to the system (powershell or 'shell' on non windows) and add the result prior to the following user prompt regardless of whether it is a session or normal REPL mode without chat memory.
This allow the user to add context like the clipboard content or any file content, using an according command line call directly, without having to make a tool-use agent execute the command. Also the command can be re-executed using up-arrow on changing outputs which is not possible when the agent needs to execute any command.