### PR TITLE
Fix/glob pattern handling

### DIFF
--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -18,7 +18,7 @@ const SUMMARY_MAX_WIDTH: usize = 80;
 #[derive(Debug, Clone)]
 pub struct Input {
     config: GlobalConfig,
-    text: String,
+    pub text: String,
     raw: (String, Vec<String>),
     patched_text: Option<String>,
     last_reply: Option<String>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -171,6 +171,8 @@ pub struct Config {
     pub rag: Option<Arc<Rag>>,
     #[serde(skip)]
     pub agent: Option<Agent>,
+    #[serde(skip)]
+    pub run_output: Option<String>,
 }
 
 impl Default for Config {
@@ -235,6 +237,7 @@ impl Default for Config {
             session: None,
             rag: None,
             agent: None,
+            run_output: None,
         }
     }
 }
@@ -2033,7 +2036,10 @@ impl Config {
         output
     }
 
-    pub fn before_chat_completion(&mut self, input: &Input) -> Result<()> {
+    pub fn before_chat_completion(&mut self, input: &mut Input) -> Result<()> {
+        if let Some(output) = self.run_output.take() {
+            input.text.insert_str(0, &format!("{} ", output));
+        }
         self.last_message = Some(LastMessage::new(input.clone(), String::new()));
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,10 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
                 .use_session(session.as_ref().map(|v| v.as_str()))?;
         }
         if let Some(rag) = &cli.rag {
-            Config::use_rag(&config, Some(rag), abort_signal.clone()).await?;
+            Config::use_rag(&config, Some(rag), &cli.file, abort_signal.clone()).await?;
+            if !config.read().working_mode.is_repl() {
+                return Ok(());
+            }
         }
     }
     if cli.list_sessions {

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -425,7 +425,7 @@ pub async fn run_repl_command(
                 Config::maybe_autoname_session(config.clone());
             }
             ".rag" => {
-                Config::use_rag(config, args, abort_signal.clone()).await?;
+                Config::use_rag(config, args, &[], abort_signal.clone()).await?;
             }
             ".agent" => match split_first_arg(args) {
                 Some((agent_name, args)) => {


### PR DESCRIPTION
I have extended the glob pattern handling for adding RAG documents from folders in order to include more common simple patterns like '.\browser_use_doc\*.md'.