### PR TITLE
feat: add model field `patch`

### DIFF
--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -154,7 +154,11 @@ pub trait Client: Sync + Send {
 
     fn patch_request_data(&self, request_data: &mut RequestData) {
         let model_type = self.model().model_type();
-        let map = std::env::var(get_env_name(&format!(
+        if let Some(patch) = self.model().patch() {
+            request_data.apply_patch(patch.clone());
+        }
+
+        let patch_map = std::env::var(get_env_name(&format!(
             "patch_{}_{}",
             self.model().client_name(),
             model_type.api_name(),
@@ -166,11 +170,11 @@ pub trait Client: Sync + Send {
                 .and_then(|v| model_type.extract_patch(v))
                 .cloned()
         });
-        let map = match map {
+        let patch_map = match patch_map {
             Some(v) => v,
             _ => return,
         };
-        for (key, patch) in map {
+        for (key, patch) in patch_map {
             let key = ESCAPE_SLASH_RE.replace_all(&key, r"\/");
             if let Ok(regex) = Regex::new(&format!("^({key})$")) {
                 if let Ok(true) = regex.is_match(self.model().name()) {
@@ -260,6 +264,8 @@ impl RequestData {
             for (key, value) in patch_headers {
                 if let Some(value) = value.as_str() {
                     self.header(key, value)
+                } else if value.is_null() {
+                    self.headers.swap_remove(key);
                 }
             }
         }

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -9,6 +9,7 @@ use crate::utils::{estimate_token_length, strip_think_tag};
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fmt::Display;
 
 const PER_MESSAGES_TOKENS: usize = 5;
@@ -178,6 +179,10 @@ impl Model {
         }
     }
 
+    pub fn patch(&self) -> Option<&Value> {
+        self.data.patch.as_ref()
+    }
+
     pub fn max_input_tokens(&self) -> Option<usize> {
         self.data.max_input_tokens
     }
@@ -313,6 +318,8 @@ pub struct ModelData {
     pub input_price: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_price: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch: Option<Value>,
 
     // chat-only properties
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Now, model definition can have its own patch configuration.

```yaml
...
    - name: o3-mini-high
      real_name: o3-mini
      max_input_tokens: 200000
      input_price: 1.1
      output_price: 4.4
      supports_vision: true
      supports_function_calling: true
      supports_reasoning: true
      no_temperature: true
      system_prompt_prefix: Formatting re-enabled
      patch:
        body:
          reasoning_effort: high

...
    - name: gemini-2.0-flash-online
      real_name: gemini-2.0-flash
      max_input_tokens: 1048576
      max_output_tokens: 8192
      supports_vision: true
      supports_function_calling: true
      patch:
        body:
          tools: 
            - google_search: {}
```