### PR TITLE
feat: abandon model field `no_temperature` (revert #1164)

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -39,8 +39,11 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
-      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: o1
       max_input_tokens: 200000
       input_price: 15
@@ -48,8 +51,11 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
-      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: o1-preview
       max_input_tokens: 128000
       max_output_tokens: 32768
@@ -57,7 +63,10 @@
       output_price: 60
       supports_reasoning: true
       no_system_message: true
-      no_temperature: true
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: o1-mini
       max_input_tokens: 128000
       max_output_tokens: 65536
@@ -65,7 +74,10 @@
       output_price: 12
       supports_reasoning: true
       no_system_message: true
-      no_temperature: true
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: gpt-3.5-turbo
       max_input_tokens: 16385
       max_output_tokens: 4096
@@ -1010,7 +1022,6 @@
       input_price: 0.55
       output_price: 2.19
       supports_reasoning: true
-      no_temperature: true
 
 # Links:
 #  - https://open.bigmodel.cn/pricing
@@ -1145,8 +1156,11 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
-      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: openai/o1
       max_input_tokens: 128000
       input_price: 15
@@ -1154,22 +1168,31 @@
       supports_vision: true
       supports_function_calling: true
       supports_reasoning: true
-      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: openai/o1-preview
       max_input_tokens: 128000
       input_price: 15
       output_price: 60
       supports_reasoning: true
       no_system_message: true
-      no_temperature: true
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: openai/o1-mini
       max_input_tokens: 128000
       input_price: 3
       output_price: 12
       supports_reasoning: true
       no_system_message: true
-      no_temperature: true
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: openai/gpt-3.5-turbo
       max_input_tokens: 16385
       input_price: 0.5
@@ -1456,27 +1479,39 @@
       supports_function_calling: true
       supports_vision: true
       supports_reasoning: true
-      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: o1
       max_input_tokens: 200000
       supports_function_calling: true
       supports_vision: true
       supports_reasoning: true
-      no_temperature: true
       system_prompt_prefix: Formatting re-enabled
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: o1-preview
       max_input_tokens: 128000
       supports_reasoning: true
       no_stream: true
       no_system_message: true
-      no_temperature: true
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: o1-mini
       max_input_tokens: 128000
       supports_reasoning: true
       no_stream: true
       no_system_message: true
-      no_temperature: true
+      patch:
+        body:
+          temperature: null
+          top_p: null
     - name: text-embedding-3-large
       type: embedding
       max_tokens_per_chunk: 8191

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -203,10 +203,6 @@ impl Model {
         self.data.no_system_message
     }
 
-    pub fn no_temperature(&self) -> bool {
-        self.data.no_temperature
-    }
-
     pub fn system_prompt_prefix(&self) -> Option<&str> {
         self.data.system_prompt_prefix.as_deref()
     }
@@ -336,8 +332,6 @@ pub struct ModelData {
     no_stream: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     no_system_message: bool,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    no_temperature: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     system_prompt_prefix: Option<String>,
 

--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -240,11 +240,7 @@ impl Input {
         let mut messages = self.build_messages()?;
         patch_messages(&mut messages, model);
         model.guard_max_input_tokens(&messages)?;
-        let (temperature, top_p) = if model.no_temperature() {
-            (None, None)
-        } else {
-            (self.role().temperature(), self.role().top_p())
-        };
+        let (temperature, top_p) = (self.role().temperature(), self.role().top_p());
         let functions = self.config.read().select_functions(self.role());
         Ok(ChatCompletionsData {
             messages,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -270,8 +270,8 @@ impl Server {
         let ChatCompletionsReqBody {
             model,
             messages,
-            mut temperature,
-            mut top_p,
+            temperature,
+            top_p,
             max_tokens,
             stream,
             tools,
@@ -311,11 +311,6 @@ impl Server {
         let created = Utc::now().timestamp();
 
         patch_messages(&mut messages, client.model());
-
-        if client.model().no_temperature() {
-            temperature = None;
-            top_p = None;
-        }
 
         let data: ChatCompletionsData = ChatCompletionsData {
             messages,

--- a/src/utils/request.rs
+++ b/src/utils/request.rs
@@ -163,11 +163,11 @@ pub async fn fetch_models(api_base: &str, api_key: Option<&str>) -> Result<Vec<S
         Ok(ref client) => client,
         Err(ref err) => bail!("{err}"),
     };
-    let mut request_builder = client.get(format!("{}/models", api_base.trim_end_matches('/')));
+    let mut builder = client.get(format!("{}/models", api_base.trim_end_matches('/')));
     if let Some(api_key) = api_key {
-        request_builder = request_builder.bearer_auth(api_key);
+        builder = builder.bearer_auth(api_key);
     }
-    let res_body: Value = request_builder.send().await?.json().await?;
+    let res_body: Value = builder.send().await?.json().await?;
     let result: Vec<String> = res_body
         .get("data")
         .and_then(|v| v.as_array())


### PR DESCRIPTION
With #1169, we can use `patch` to get rid of temperature/top_p parameters, so there's no need to introduce a new model field.