### PR TITLE
feat: abandon model field `supports_reasoning` (revert #1145)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,7 +95,6 @@ clients:
   #       max_input_tokens: 100000
   #       supports_vision: true
   #       supports_function_calling: true
-  #       supports_reasoning: true
   #     - name: xxxx                                  # Embedding model
   #       type: embedding
   #       default_chunk_size: 1500                        
@@ -128,7 +127,6 @@ clients:
     models:
       - name: deepseek-r1
         max_input_tokens: 131072
-        supports_reasoning: true
       - name: llama3.1
         max_input_tokens: 128000
         supports_function_calling: true

--- a/models.yaml
+++ b/models.yaml
@@ -38,7 +38,6 @@
       output_price: 4.4
       supports_vision: true
       supports_function_calling: true
-      supports_reasoning: true
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
@@ -50,7 +49,6 @@
       output_price: 60
       supports_vision: true
       supports_function_calling: true
-      supports_reasoning: true
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
@@ -61,7 +59,6 @@
       max_output_tokens: 32768
       input_price: 15
       output_price: 60
-      supports_reasoning: true
       no_system_message: true
       patch:
         body:
@@ -72,7 +69,6 @@
       max_output_tokens: 65536
       input_price: 3
       output_price: 12
-      supports_reasoning: true
       no_system_message: true
       patch:
         body:
@@ -130,7 +126,6 @@
       input_price: 0
       output_price: 0
       supports_vision: true
-      supports_reasoning: true
     - name: gemini-2.0-pro-exp
       max_input_tokens: 2097152
       max_output_tokens: 8192
@@ -405,12 +400,10 @@
       max_input_tokens: 127000
       input_price: 2
       output_price: 8
-      supports_reasoning: true
     - name: sonar-reasoning
       max_input_tokens: 127000
       input_price: 1
       output_price: 5
-      supports_reasoning: true
 
 # Links:
 #  - https://console.groq.com/docs/models
@@ -441,7 +434,6 @@
       max_input_tokens: 131072
       input_price: 0
       output_price: 0
-      supports_reasoning: true
 
 # Links:
 #  - https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models
@@ -473,7 +465,6 @@
       max_input_tokens: 32760
       max_output_tokens: 8192
       supports_vision: true
-      supports_reasoning: true
     - name: gemini-2.0-pro-exp-02-05
       max_input_tokens: 2097152
       max_output_tokens: 8192
@@ -759,7 +750,6 @@
       require_max_tokens: true
       input_price: 0
       output_price: 0
-      supports_reasoning: true
     - name: '@cf/baai/bge-large-en-v1.5'
       type: embedding
       input_price: 0
@@ -857,14 +847,12 @@
       max_input_tokens: 16384
       max_output_tokens: 16384
       supports_vision: true
-      supports_reasoning: true
     - name: qwq-32b-preview
       max_input_tokens: 30720
       max_output_tokens: 16384
       input_price: 0.49
       output_price: 0.98
       supports_function_calling: true
-      supports_reasoning: true
     - name: qwen-vl-max-latest
       max_input_tokens: 30720
       max_output_tokens: 2048
@@ -1021,7 +1009,6 @@
       max_output_tokens: 8192
       input_price: 0.55
       output_price: 2.19
-      supports_reasoning: true
 
 # Links:
 #  - https://open.bigmodel.cn/pricing
@@ -1066,7 +1053,6 @@
       max_input_tokens: 16384
       input_price: 1.4
       output_price: 1.4
-      supports_reasoning: true
     - name: embedding-3
       type: embedding
       max_input_tokens: 8192
@@ -1155,7 +1141,6 @@
       output_price: 4.4
       supports_vision: true
       supports_function_calling: true
-      supports_reasoning: true
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
@@ -1167,7 +1152,6 @@
       output_price: 60
       supports_vision: true
       supports_function_calling: true
-      supports_reasoning: true
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
@@ -1177,7 +1161,6 @@
       max_input_tokens: 128000
       input_price: 15
       output_price: 60
-      supports_reasoning: true
       no_system_message: true
       patch:
         body:
@@ -1187,7 +1170,6 @@
       max_input_tokens: 128000
       input_price: 3
       output_price: 12
-      supports_reasoning: true
       no_system_message: true
       patch:
         body:
@@ -1358,17 +1340,23 @@
       max_input_tokens: 163840
       input_price: 0.55
       output_price: 2.19
-      supports_reasoning: true
+      patch:
+        body:
+          include_reasoning: true
     - name: deepseek/deepseek-r1-distill-llama-70b
       max_input_tokens: 131072
       input_price: 0.23
       output_price: 0.69
-      supports_reasoning: true
+      patch:
+        body:
+          include_reasoning: true
     - name: deepseek/deepseek-r1-distill-qwen-32b
       max_input_tokens: 131072
       input_price: 0.12
       output_price: 0.18
-      supports_reasoning: true
+      patch:
+        body:
+          include_reasoning: true
     - name: qwen/qwen-max
       max_input_tokens: 32768
       max_output_tokens: 8192
@@ -1404,13 +1392,11 @@
       max_input_tokens: 32768
       input_price: 0.15
       output_price: 0.6
-      supports_reasoning: true
     - name: qwen/qvq-72b-preview
       max_input_tokens: 128000
       input_price: 0.25
       output_price: 0.5
       supports_vision: true
-      supports_reasoning: true
     - name: x-ai/grok-2-1212
       max_input_tokens: 131072
       input_price: 2
@@ -1453,7 +1439,9 @@
       max_input_tokens: 127000
       input_price: 1
       output_price: 5
-      supports_reasoning: true
+      patch:
+        body:
+          include_reasoning: true
     - name: perplexity/sonar
       max_input_tokens: 127000
       input_price: 1
@@ -1478,7 +1466,6 @@
       max_input_tokens: 200000
       supports_function_calling: true
       supports_vision: true
-      supports_reasoning: true
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
@@ -1488,7 +1475,6 @@
       max_input_tokens: 200000
       supports_function_calling: true
       supports_vision: true
-      supports_reasoning: true
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
@@ -1496,7 +1482,6 @@
           top_p: null
     - name: o1-preview
       max_input_tokens: 128000
-      supports_reasoning: true
       no_stream: true
       no_system_message: true
       patch:
@@ -1505,7 +1490,6 @@
           top_p: null
     - name: o1-mini
       max_input_tokens: 128000
-      supports_reasoning: true
       no_stream: true
       no_system_message: true
       patch:
@@ -1569,7 +1553,6 @@
       supports_function_calling: true
     - name: deepseek-r1
       max_input_tokens: 163840
-      supports_reasoning: true
     - name: phi-4
       max_input_tokens: 16384
     - name: phi-3.5-moe-instruct
@@ -1625,12 +1608,10 @@
       input_price: 0.25
       output_price: 0.50
       supports_vision: true
-      supports_reasoning: true
     - name: Qwen/QwQ-32B-Preview
       max_input_tokens: 32768
       input_price: 0.12
       output_price: 0.18
-      supports_reasoning: true
     - name: deepseek-ai/DeepSeek-V3
       max_input_tokens: 32768
       input_price: 0.85
@@ -1639,17 +1620,14 @@
       max_input_tokens: 16000
       input_price: 0.85
       output_price: 2.5
-      supports_reasoning: true
     - name: deepseek-ai/DeepSeek-R1-Distill-Llama-70B
       max_input_tokens: 131072
       input_price: 0.23
       output_price: 0.69
-      supports_reasoning: true
     - name: deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
       max_input_tokens: 131072
       input_price: 0.12
       output_price: 0.18
-      supports_reasoning: true
     - name: mistralai/Mistral-Small-24B-Instruct-2501
       max_input_tokens: 32768
       input_price: 0.07
@@ -1735,7 +1713,6 @@
       max_input_tokens: 32768
       input_price: 0.9
       output_price: 0.9
-      supports_reasoning: true
     - name: accounts/fireworks/models/qwen2-vl-72b-instruct
       max_input_tokens: 32768
       input_price: 0.9
@@ -1749,17 +1726,14 @@
       max_input_tokens: 160000
       input_price: 8
       output_price: 8
-      supports_reasoning: true
     - name: accounts/fireworks/models/deepseek-r1-distill-llama-70b
       max_input_tokens: 131072
       input_price: 0.9
       output_price: 0.9
-      supports_reasoning: true
     - name: accounts/fireworks/models/deepseek-r1-distill-qwen-32b
       max_input_tokens: 131072
       input_price: 0.9
       output_price: 0.9
-      supports_reasoning: true
     - name: accounts/fireworks/models/mistral-small-24b-instruct-2501
       max_input_tokens: 32768
       input_price: 0.9
@@ -1837,12 +1811,10 @@
       input_price: 1.386
       output_price: 1.386
       supports_vision: true
-      supports_reasoning: true
     - name: Qwen/QwQ-32B-Preview
       max_input_tokens: 32768
       input_price: 0.176
       output_price: 0.176
-      supports_reasoning: true
     - name: deepseek-ai/DeepSeek-V3
       max_input_tokens: 65536
       input_price: 0.28
@@ -1851,17 +1823,14 @@
       max_input_tokens: 65536
       input_price: 2.24
       output_price: 2.24
-      supports_reasoning: true
     - name: deepseek-ai/DeepSeek-R1-Distill-Llama-70B
       max_input_tokens: 32768
       input_price: 0.578 
       output_price: 0.578 
-      supports_reasoning: true
     - name: deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
       max_input_tokens: 32768
       input_price: 0.176
       output_price: 0.176
-      supports_reasoning: true
     - name: deepseek-ai/DeepSeek-V2.5
       max_input_tokens: 32768
       input_price: 0.7
@@ -1946,7 +1915,6 @@
       max_input_tokens: 32768
       input_price: 1.2
       output_price: 1.2
-      supports_reasoning: true
     - name: Qwen/Qwen2-VL-72B-Instruct
       max_input_tokens: 32768
       input_price: 1.2
@@ -1960,12 +1928,10 @@
       max_input_tokens: 163840
       input_price: 7
       output_price: 7
-      supports_reasoning: true
     - name: deepseek-ai/DeepSeek-R1-Distill-Llama-70B
       max_input_tokens: 131072
       input_price: 2
       output_price: 2
-      supports_reasoning: true
     - name: mistralai/Mistral-Small-24B-Instruct-2501
       max_input_tokens: 32768
       input_price: 0.8
@@ -2020,7 +1986,6 @@
       max_input_tokens: 32768
       input_price: 0.2
       output_price: 0.2
-      supports_reasoning: true
     - name: Qwen/Qwen2-VL-72B-Instruct
       max_input_tokens: 32768
       input_price: 0.4
@@ -2034,7 +1999,6 @@
       max_input_tokens: 163840
       input_price: 2
       output_price: 2
-      supports_reasoning: true
     - name: mistralai/Pixtral-12B-2409
       max_input_tokens: 128000
       input_price: 0.1
@@ -2080,17 +2044,14 @@
       max_input_tokens: 64000
       input_price: 4
       output_price: 4
-      supports_reasoning: true
     - name: deepseek/deepseek-r1-distill-llama-70b
       max_input_tokens: 32000
       input_price: 0.8
       output_price: 0.8
-      supports_reasoning: true
     - name: deepseek/deepseek-r1-distill-qwen-32b
       max_input_tokens: 128000
       input_price: 0.3
       output_price: 0.3
-      supports_reasoning: true
     - name: mistralai/mistral-nemo
       max_input_tokens: 131072
       input_price: 0.17

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -136,7 +136,6 @@ impl Model {
                     output_price,
                     supports_vision,
                     supports_function_calling,
-                    supports_reasoning,
                     ..
                 } = &self.data;
                 let max_input_tokens = stringify_option_value(max_input_tokens);
@@ -150,9 +149,6 @@ impl Model {
                 if *supports_function_calling {
                     capabilities.push('⚒');
                 };
-                if *supports_reasoning {
-                    capabilities.push('💭');
-                }
                 let capabilities: String = capabilities
                     .into_iter()
                     .map(|v| format!("{v} "))
@@ -189,10 +185,6 @@ impl Model {
 
     pub fn max_output_tokens(&self) -> Option<isize> {
         self.data.max_output_tokens
-    }
-
-    pub fn supports_reasoning(&self) -> bool {
-        self.data.supports_reasoning
     }
 
     pub fn no_stream(&self) -> bool {
@@ -326,8 +318,6 @@ pub struct ModelData {
     pub supports_vision: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub supports_function_calling: bool,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    supports_reasoning: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     no_stream: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]

--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -301,9 +301,6 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
     if let Some(v) = model.max_tokens_param() {
         body["max_tokens"] = v.into();
     }
-    if model.client_name().starts_with("openrouter") && model.supports_reasoning() {
-        body["include_reasoning"] = true.into();
-    }
     if let Some(v) = temperature {
         body["temperature"] = v.into();
     }


### PR DESCRIPTION
### Why?

1. There isn't much of a difference between reasoning and non-reasoning model, It's not worth introducing a field just for an indicator.

2. We We can now use model patching to handle the issue of reasoning models in OpenRouter requiring an additional field `include_reasoning`.
