### PR TITLE
feat: add patch `max_tokens: null` to openai/github o* serial models

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -41,6 +41,7 @@
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
+          max_tokens: null
           temperature: null
           top_p: null
     - name: o1
@@ -52,6 +53,7 @@
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
+          max_tokens: null
           temperature: null
           top_p: null
     - name: o1-preview
@@ -62,6 +64,7 @@
       no_system_message: true
       patch:
         body:
+          max_tokens: null
           temperature: null
           top_p: null
     - name: o1-mini
@@ -72,6 +75,7 @@
       no_system_message: true
       patch:
         body:
+          max_tokens: null
           temperature: null
           top_p: null
     - name: gpt-3.5-turbo
@@ -1469,6 +1473,7 @@
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
+          max_tokens: null
           temperature: null
           top_p: null
     - name: o1
@@ -1478,6 +1483,7 @@
       system_prompt_prefix: Formatting re-enabled
       patch:
         body:
+          max_tokens: null
           temperature: null
           top_p: null
     - name: o1-preview
@@ -1486,6 +1492,7 @@
       no_system_message: true
       patch:
         body:
+          max_tokens: null
           temperature: null
           top_p: null
     - name: o1-mini
@@ -1494,6 +1501,7 @@
       no_system_message: true
       patch:
         body:
+          max_tokens: null
           temperature: null
           top_p: null
     - name: text-embedding-3-large

--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -299,7 +299,11 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
     });
 
     if let Some(v) = model.max_tokens_param() {
-        body["max_tokens"] = v.into();
+        if model.patch().and_then(|v| v.get("body").and_then(|v| v.get("max_tokens"))) == Some(&Value::Null) {
+            body["max_completion_tokens"] = v.into();
+        } else {
+            body["max_tokens"] = v.into();
+        }
     }
     if let Some(v) = temperature {
         body["temperature"] = v.into();


### PR DESCRIPTION
OpenAI/GitHub's `o1/o3` serial models don't support `max_tokens`, only `max_completion_tokens` are supported. This PR implements these changes.

Relate to #1146