### PR TITLE
fix: better handle OpenAI-Compatible streaming responses

### DIFF
--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -142,7 +142,8 @@ pub async fn openai_chat_completions_streaming(
                 reason_state = 1;
             }
             handler.text(text)?;
-        } else if let (Some(function), index, id) = (
+        }
+        if let (Some(function), index, id) = (
             data["choices"][0]["delta"]["tool_calls"][0]["function"].as_object(),
             data["choices"][0]["delta"]["tool_calls"][0]["index"].as_u64(),
             data["choices"][0]["delta"]["tool_calls"][0]["id"]


### PR DESCRIPTION
when the model response the function call and the content at same time, the function call will be missed.

```sh
2025-02-18T02:23:11.485Z [DEBUG] aichat::client::openai: stream-data: {"choices":[{"delta":{"content":"\n首先根据模型规则创建手机模型的JSON内容，然后调用 `fs_write` 函数将其保存。","role":"assistant","tool_calls":[{"function":{"arguments":"{\"contents\": \"{}\", \"path\": \"phone_model.json\"}","name":"fs_write"},"id":"call_y9r1is88k1ra6hfsjgy9szzt","index":0,"type":"function"}]},"finish_reason":"tool_calls","index":0}],"created":1739845391,"id":"021739845380522b669f33a9e610f838ec02b2a8d7741049b2fff","model":"doubao-pro-32k-241215","object":"chat.completion.chunk","usage":null}
```