### PR TITLE
fix: bash completion syntax error

### DIFF
--- a/scripts/completions/aichat.bash
+++ b/scripts/completions/aichat.bash
@@ -60,12 +60,12 @@ _aichat() {
                     ;;
                 -f|--file)
                     local oldifs
-                    if [[ -v IFS ]]; then
+                    if [[ -n "${IFS+x}" ]]; then
                         oldifs="$IFS"
                     fi
                     IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
-                    if [[ -v oldifs ]]; then
+                    if [[ -n "${oldifs+x}" ]]; then
                         IFS="$oldifs"
                     fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then


### PR DESCRIPTION
This PR fixes the bash completion syntax error, due to the use of -v with [[ ]], which is not supported in older versions of Bash:
```
line 63: conditional binary operator expected
line 63: syntax error near `IFS'
line 63: `                    if [[ -v IFS ]]; then'
```