### PR TITLE
fix: incorrect model when switching role in session context

### DIFF
--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -841,7 +841,7 @@ impl Debug for DocumentId {
 
 impl DocumentId {
     pub fn new(file_index: usize, document_index: usize) -> Self {
-        let value = file_index << (usize::BITS / 2) | document_index;
+        let value = (file_index << (usize::BITS / 2)) | document_index;
         Self(value)
     }
 


### PR DESCRIPTION
When switching the role in session context, AIChat incorrectly uses the default model to override the current session model.

close #1191 