### PR TITLE
feat: add `cmd_prelude` and remove `prelude`

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,9 +19,9 @@ mapping_tools:                   # Alias for a tool or toolset
 use_tools: null                  # Which tools to use by default. (e.g. 'fs,web_search')
 
 # ---- prelude ----
-prelude: null                    # Set a default role or session to start with (e.g. role:<name>, session:<name>, <session>:<role>)
-repl_prelude: null               # Overrides the `prelude` setting specifically for conversations started in REPL
-agent_prelude: null              # Set a session to use when starting a agent. (e.g. temp, default)
+repl_prelude: null               # Set a default role or session for REPL mode (e.g. role:<name>, session:<name>, <session>:<role>)
+cmd_prelude: null                # Set a default role or session for CMD mode (e.g. role:<name>, session:<name>, <session>:<role>)
+agent_prelude: null              # Set a session to use when starting a agent (e.g. temp, default)
 
 # ---- session ----
 # Controls the persistence of the session. if true, auto save; if false, not save; if null, asking the user

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -116,8 +116,8 @@ pub struct Config {
     pub mapping_tools: IndexMap<String, String>,
     pub use_tools: Option<String>,
 
-    pub prelude: Option<String>,
     pub repl_prelude: Option<String>,
+    pub cmd_prelude: Option<String>,
     pub agent_prelude: Option<String>,
 
     pub save_session: Option<bool>,
@@ -192,8 +192,8 @@ impl Default for Config {
             mapping_tools: Default::default(),
             use_tools: None,
 
-            prelude: None,
             repl_prelude: None,
+            cmd_prelude: None,
             agent_prelude: None,
 
             save_session: None,
@@ -1606,8 +1606,8 @@ impl Config {
             return Ok(());
         }
         let prelude = match self.working_mode {
-            WorkingMode::Cmd => self.prelude.as_ref(),
-            WorkingMode::Repl => self.repl_prelude.as_ref().or(self.prelude.as_ref()),
+            WorkingMode::Repl => self.repl_prelude.as_ref(),
+            WorkingMode::Cmd => self.cmd_prelude.as_ref(),
             WorkingMode::Serve => return Ok(()),
         };
         let prelude = match prelude {
@@ -2280,11 +2280,11 @@ impl Config {
             self.use_tools = v;
         }
 
-        if let Some(v) = read_env_value::<String>(&get_env_name("prelude")) {
-            self.prelude = v;
-        }
         if let Some(v) = read_env_value::<String>(&get_env_name("repl_prelude")) {
             self.repl_prelude = v;
+        }
+        if let Some(v) = read_env_value::<String>(&get_env_name("cmd_prelude")) {
+            self.cmd_prelude = v;
         }
         if let Some(v) = read_env_value::<String>(&get_env_name("agent_prelude")) {
             self.agent_prelude = v;


### PR DESCRIPTION
Previously, we used `prelude` for both REPL and CMD modes. This was not flexible. After this PR is merged, please use `cmd_prelude` for CMD and `repl_prelude` for REPL.