### PR TITLE
Fix Tool call 'xxx' have non-JSON arguments

### DIFF
--- a/src/client/bedrock.rs
+++ b/src/client/bedrock.rs
@@ -222,6 +222,9 @@ async fn chat_completions_streaming(
                                     json_str_from_map(tool_use, "name"),
                                 ) {
                                     if !function_name.is_empty() {
+                                        if function_arguments.is_empty() {
+                                            function_arguments = String::from("{}");
+                                        }
                                         let arguments: Value =
                                         function_arguments.parse().with_context(|| {
                                             format!("Tool call '{function_name}' have non-JSON arguments '{function_arguments}'")
@@ -259,6 +262,9 @@ async fn chat_completions_streaming(
                                 reasoning_state = 0;
                             }
                             if !function_name.is_empty() {
+                                if function_arguments.is_empty() {
+                                    function_arguments = String::from("{}");
+                                }
                                 let arguments: Value = function_arguments.parse().with_context(|| {
                                     format!("Tool call '{function_name}' have non-JSON arguments '{function_arguments}'")
                                 })?;


### PR DESCRIPTION
For a signficant amount of models the call of a tool does only pass an empty string instead of "{}". The empty string fails to be converted to JSON throwing the following error:

```
Error: Failed to call chat-completions api
Tool call 'xxx' have non-JSON arguments
```

I have observed this behavior for all newer claude sonnet models on bedrock but have observed that other clients use the same logic for parsing the string.

The fix is to simply set the string to "{}" if it is "" and keep the logic as before.

This is related to https://github.com/sigoden/llm-functions/issues/173 which I have opened in llm-functions because I originally thought it is related to the function definition.