### PR TITLE
fix: openai-compatible handles empty tool call arguments

### DIFF
--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -110,6 +110,9 @@ pub async fn openai_chat_completions_streaming(
     let handle = |message: SseMmessage| -> Result<bool> {
         if message.data == "[DONE]" {
             if !function_name.is_empty() {
+                if function_arguments.is_empty() {
+                    function_arguments = String::from("{}");
+                }
                 let arguments: Value = function_arguments.parse().with_context(|| {
                     format!("Tool call '{function_name}' have non-JSON arguments '{function_arguments}'")
                 })?;
@@ -153,6 +156,9 @@ pub async fn openai_chat_completions_streaming(
             let maybe_call_id = format!("{}/{}", id.unwrap_or_default(), index.unwrap_or_default());
             if maybe_call_id != call_id && maybe_call_id.len() >= call_id.len() {
                 if !function_name.is_empty() {
+                    if function_arguments.is_empty() {
+                        function_arguments = String::from("{}");
+                    }
                     let arguments: Value = function_arguments.parse().with_context(|| {
                         format!("Tool call '{function_name}' have non-JSON arguments '{function_arguments}'")
                     })?;


### PR DESCRIPTION
Some functions don't require parameters, and under normal circumstances, the arguments should be '{}'. However, some LLMs return an empty string instead. This PR addresses this issue.
```
Caused by:
    0: Tool call 'get_ipinfo' have non-JSON arguments ''
    1: EOF while parsing a value at line 1 column 0
```