### PR TITLE
Added support for role, rag or session "with/slashes"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aichat"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ansi_colours",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aichat"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 authors = ["sigoden <sigoden@gmail.com>"]
 description = "All-in-one LLM CLI Tool"

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -58,6 +58,14 @@ pub fn list_file_names<T: AsRef<Path>>(dir: T, ext: &str) -> Vec<String> {
         Ok(rd) => {
             let mut names = vec![];
             for entry in rd.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    names.extend(
+                        list_file_names(&path, ext)
+                            .into_iter()
+                            .map(|v| format!("{}/{}", entry.file_name().to_string_lossy(), v)),
+                    );
+                }
                 let name = entry.file_name();
                 if let Some(name) = name.to_string_lossy().strip_suffix(ext) {
                     names.push(name.to_string());


### PR DESCRIPTION
• Updated package version in Cargo.toml and Cargo.lock • Refactored role and rag listing methods to use a new utility function for improved readability and maintainability • Enhanced temp file naming to replace slashes with double colons for better compatibility • Improved directory traversal in list_file_names to support nested directories