### PR TITLE
feat: `--code` (tty) strips `<think>` tag

### DIFF
--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -421,7 +421,7 @@ pub async fn call_chat_completions(
             } = ret;
             if !text.is_empty() {
                 if extract_code {
-                    text = extract_code_block(&text).to_string();
+                    text = extract_code_block(&strip_think_tag(&text)).to_string();
                 }
                 if print {
                     client.global_config().read().print_markdown(&text)?;


### PR DESCRIPTION
```
$ aichat -m groq:qwen-qwq-32b -c async sleep in js | tee
async function sleep(ms) {
  return new Promise(resolve => setTimeout(resolve, ms));
}
```
Relate to #1223 