### PR TITLE
feat: use HISTFILE to get history file when appending to shell history

### DIFF
--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -183,8 +183,14 @@ pub fn append_to_shell_history(shell: &str, command: &str, exit_code: i32) -> io
 
 fn get_history_file(shell: &str) -> Option<PathBuf> {
     match shell {
-        "bash" | "sh" => Some(home_dir()?.join(".bash_history")),
-        "zsh" => Some(home_dir()?.join(".zsh_history")),
+        "bash" | "sh" => env::var("HISTFILE")
+            .ok()
+            .map(PathBuf::from)
+            .or(Some(home_dir()?.join(".bash_history"))),
+        "zsh" => env::var("HISTFILE")
+            .ok()
+            .map(PathBuf::from)
+            .or(Some(home_dir()?.join(".zsh_history"))),
         "nushell" => Some(dirs::config_dir()?.join("nushell").join("history.txt")),
         "fish" => Some(
             home_dir()?


### PR DESCRIPTION
In bash and zsh the env variable HISTFILE can be set to configure the file to use in the shell history. 
This PR considers this env variable when appending the execute command to the shell history.