### PR TITLE
feat: Allow user to specify TTS voice via query param

### DIFF
--- a/assets/playground.html
+++ b/assets/playground.html
@@ -856,6 +856,7 @@
         max_output_tokens: parseInt(QUERY.max_output_tokens) || null,
         temperature: QUERY.temperature ? parseFloat(QUERY.temperature) : null,
         top_p: QUERY.top_p ? parseFloat(QUERY.top_p) : null,
+        voice: QUERY.voice || "",
       };
 
       Alpine.data("app", () => ({
@@ -877,6 +878,7 @@
         sessionTitle: "",
         selectSessionId: null,
         sessions: [],
+        voice: null,
 
         async init() {
           await Promise.all([
@@ -985,10 +987,21 @@
           if (!!window.speechSynthesis) {
             if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
               window.speechSynthesis.cancel();
-            } else {
-              let utterance = new SpeechSynthesisUtterance(messageToUtter);
-              window.speechSynthesis.speak(utterance);
+              return;
             }
+
+            if (!this.voice && this.settings.voice) {
+              this.voice = window.speechSynthesis
+                .getVoices()
+                .find(voice => voice.name === this.settings.voice);
+
+              // If we couldnt find, clear the voice string to prevent retry
+              if (!this.voice) this.settings.voice = null;
+            }
+
+            let utterance = new SpeechSynthesisUtterance(messageToUtter);
+            utterance.voice = this.voice;
+            window.speechSynthesis.speak(utterance);
           }
         },
 


### PR DESCRIPTION
I like the TTS feature and wanted a way to change the default voice my browser gives me.

This change simply parses the string name of the voice you want and then sets it when you try to use TTS. It should only run the code to set the voice if user has requested a voice and a voice is not yet chosen.

In the case that the user sends an invalid voice name it simply will continue to use the default voice and clear the query param for voice to prevent a retry to set the voice. Tested this function only gets hit once regardless of success.

I love aichat and just wanted to write this feature for myself, if you want I am happy to make any changes or if you do not want this feature feel free to close :)