### PR TITLE
feat: support AWS session token

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -232,6 +232,7 @@ clients:
   - type: bedrock
     access_key_id: xxx
     secret_access_key: xxx
+    session_token: xxx          # Optional
     region: xxx
 
   # See https://developers.cloudflare.com/workers-ai/


### PR DESCRIPTION
Add an optional session token to an HTTP header `X-Amz-Security-Token`.
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html#RequestWithSTS