### PR TITLE
feat: Add multi-line input mode for REPL

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,6 +10,7 @@ keybindings: emacs               # Choose keybinding style (emacs, vi)
 editor: null                     # Specifies the command used to edit input buffer or session. (e.g. vim, emacs, nano).
 wrap: no                         # Controls text wrapping (no, auto, <max-width>)
 wrap_code: false                 # Enables or disables wrapping of code blocks
+default_multi_line: false        # Use multi-line mode by default. When true, Enter adds newline and Alt+Enter submits.
 
 # ---- function-calling ----
 # Visit https://github.com/sigoden/llm-functions for setup instructions

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -111,6 +111,7 @@ pub struct Config {
     pub editor: Option<String>,
     pub wrap: Option<String>,
     pub wrap_code: bool,
+    pub default_multi_line: bool,
 
     pub function_calling: bool,
     pub mapping_tools: IndexMap<String, String>,
@@ -187,6 +188,7 @@ impl Default for Config {
             editor: None,
             wrap: None,
             wrap_code: false,
+            default_multi_line: false,
 
             function_calling: true,
             mapping_tools: Default::default(),
@@ -2266,6 +2268,9 @@ impl Config {
         }
         if let Some(Some(v)) = read_env_bool(&get_env_name("wrap_code")) {
             self.wrap_code = v;
+        }
+        if let Some(Some(v)) = read_env_bool(&get_env_name("default_multi_line")) {
+            self.default_multi_line = v;
         }
 
         if let Some(Some(v)) = read_env_bool(&get_env_name("function_calling")) {


### PR DESCRIPTION
Added a `default_multi_line` configuration parameter that changes the default REPL input behavior from single-line to multi-line mode.
When enabled:
* Enter key adds a new line instead of submitting input
* `Alt+Enter` submits the input
* Dot commands (.help, .exit, etc.) still execute on Enter
* User receives a hint about multi-line mode on startup

I use this tool extensively and this feature makes the REPL more comfortable for writing longer prompts.