### PR TITLE
feat: add openai's gpt-4.1 models

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -4,6 +4,23 @@
 #  - https://platform.openai.com/docs/api-reference/chat
 - provider: openai
   models:
+    - name: gpt-4.1
+      max_input_tokens: 1047576
+      input_price: 2
+      output_price: 8
+      supports_vision: true
+      supports_function_calling: true
+    - name: gpt-4.1-mini
+      max_input_tokens: 1047576
+      input_price: 0.4
+      output_price: 1.6
+      supports_vision: true
+      supports_function_calling: true
+    - name: gpt-4.1-nano
+      max_input_tokens: 1047576
+      input_price: 0.1
+      output_price: 0.4
+      supports_vision: true
     - name: gpt-4o
       max_input_tokens: 128000
       max_output_tokens: 16384
@@ -1269,6 +1286,24 @@
 #  - https://openrouter.ai/docs/api-reference/chat-completion
 - provider: openrouter
   models:
+    - name: openai/gpt-4.1
+      max_input_tokens: 1047576
+      input_price: 2
+      output_price: 8
+      supports_vision: true
+      supports_function_calling: true
+    - name: openai/gpt-4.1-mini
+      max_input_tokens: 1047576
+      input_price: 0.4
+      output_price: 1.6
+      supports_vision: true
+      supports_function_calling: true
+    - name: openai/gpt-4.1-nano
+      max_input_tokens: 1047576
+      input_price: 0.1
+      output_price: 0.4
+      supports_vision: true
+      supports_function_calling: true
     - name: openai/gpt-4o
       max_input_tokens: 128000
       input_price: 2.5


### PR DESCRIPTION
Updated the `models.yaml` file to include the new gpt-4.1 models (regular, mini, nano) for the openrouter and openai providers.

Also I think I ran into a bug, I tried specifying `sync_models_url` in my `config.yaml` and pointed it at the file in my repo's branch `https://raw.githubusercontent.com/pacmanmati/aichat/refs/heads/add-gpt-4.1/models.yaml`. However `.model` didn't autocomplete with the new models for openrouter/openai, it wasn't until I hardcoded the line in `src/config/mod.rs` to this:
```rs
const SYNC_MODELS_URL: &str =
    "https://raw.githubusercontent.com/pacmanmati/aichat/refs/heads/add-gpt-4.1/models.yaml";
```
 that it showed the new 4.1 models.