### PR TITLE
chore: added MacPorts installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AIChat is an all-in-one LLM CLI tool featuring Shell Assistant, CMD & REPL Mode,
 
 - **Rust Developers:** `cargo install aichat`
 - **Homebrew/Linuxbrew Users:** `brew install aichat`
+- **MacPorts Users:** `port install aichat`
 - **Pacman Users**: `pacman -S aichat`
 - **Windows Scoop Users:** `scoop install aichat`
 - **Android Termux Users:** `pkg install aichat`


### PR DESCRIPTION
I added the MacPorts installation guideline to let people know that `aichat` is available on their favorite package manager.