### PR TITLE
Add support for OSC52 clipboard codes for the REPL .copy command.

### DIFF
--- a/src/utils/clipboard.rs
+++ b/src/utils/clipboard.rs
@@ -44,7 +44,6 @@ pub fn set_text(text: &str) -> anyhow::Result<()> {
 }
 
 #[cfg(any(target_os = "android", target_os = "emscripten"))]
-pub fn set_text(text: &str) -> Result<()> {
-    // Try OSC52 even on platforms unsupported by arboard:
-    set_text_osc52(text).context("Failed to copy")
+pub fn set_text(_text: &str) -> anyhow::Result<()> {
+    Err(anyhow::anyhow!("No clipboard available").context("Failed to copy"))
 }

--- a/src/utils/clipboard.rs
+++ b/src/utils/clipboard.rs
@@ -1,4 +1,4 @@
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
 static CLIPBOARD: std::sync::LazyLock<std::sync::Mutex<Option<arboard::Clipboard>>> =
@@ -34,9 +34,8 @@ pub fn set_text(text: &str) -> anyhow::Result<()> {
     // If arboard failed, try OSC52:
     match set_text_osc52(text) {
         Ok(()) => Ok(()),
-        Err(osc_err) => {
-            Err(anyhow::anyhow!("No clipboard available").context(format!("Failed to copy (OSC52 error: {})", osc_err)))
-        }
+        Err(osc_err) => Err(anyhow::anyhow!("No clipboard available")
+            .context(format!("Failed to copy (OSC52 error: {})", osc_err))),
     }
 }
 

--- a/src/utils/clipboard.rs
+++ b/src/utils/clipboard.rs
@@ -24,15 +24,12 @@ fn set_text_osc52(text: &str) -> anyhow::Result<()> {
 pub fn set_text(text: &str) -> anyhow::Result<()> {
     // First try arboard:
     let mut clipboard = CLIPBOARD.lock().unwrap();
-    match clipboard.as_mut() {
-        Some(clipboard) => {
-            if let Ok(()) = clipboard.set_text(text) {
-                #[cfg(target_os = "linux")]
-                std::thread::sleep(std::time::Duration::from_millis(50));
-                return Ok(());
-            }
+    if let Some(clipboard) = clipboard.as_mut() {
+        if let Ok(()) = clipboard.set_text(text) {
+            #[cfg(target_os = "linux")]
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            return Ok(());
         }
-        None => {}
     }
     // If arboard failed, try OSC52:
     match set_text_osc52(text) {

--- a/src/utils/clipboard.rs
+++ b/src/utils/clipboard.rs
@@ -1,22 +1,50 @@
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+
 #[cfg(not(any(target_os = "android", target_os = "emscripten")))]
 static CLIPBOARD: std::sync::LazyLock<std::sync::Mutex<Option<arboard::Clipboard>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(arboard::Clipboard::new().ok()));
 
-#[cfg(not(any(target_os = "android", target_os = "emscripten")))]
-pub fn set_text(text: &str) -> anyhow::Result<()> {
-    let mut clipboard = CLIPBOARD.lock().unwrap();
-    match clipboard.as_mut() {
-        Some(clipboard) => {
-            clipboard.set_text(text)?;
-            #[cfg(target_os = "linux")]
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-        None => return Err(anyhow::anyhow!("No clipboard available").context("Failed to copy")),
+/// Attempts to set text to clipboard with OSC52 escape sequence
+/// Works in many modern terminals, including over SSH.
+fn set_text_osc52(text: &str) -> anyhow::Result<()> {
+    let encoded = BASE64.encode(text);
+    let seq = format!("\x1b]52;c;{}\x07", encoded);
+    // Write to stdout:
+    if let Err(e) = std::io::Write::write_all(&mut std::io::stdout(), seq.as_bytes()) {
+        return Err(anyhow::anyhow!("Failed to send OSC52 sequence").context(e));
+    }
+    // Flush stdout:
+    if let Err(e) = std::io::Write::flush(&mut std::io::stdout()) {
+        return Err(anyhow::anyhow!("Failed to flush OSC52 sequence").context(e));
     }
     Ok(())
 }
 
+#[cfg(not(any(target_os = "android", target_os = "emscripten")))]
+pub fn set_text(text: &str) -> anyhow::Result<()> {
+    // First try arboard:
+    let mut clipboard = CLIPBOARD.lock().unwrap();
+    match clipboard.as_mut() {
+        Some(clipboard) => {
+            if let Ok(()) = clipboard.set_text(text) {
+                #[cfg(target_os = "linux")]
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                return Ok(());
+            }
+        }
+        None => {}
+    }
+    // If arboard failed, try OSC52:
+    match set_text_osc52(text) {
+        Ok(()) => Ok(()),
+        Err(osc_err) => {
+            Err(anyhow::anyhow!("No clipboard available").context(format!("Failed to copy (OSC52 error: {})", osc_err)))
+        }
+    }
+}
+
 #[cfg(any(target_os = "android", target_os = "emscripten"))]
-pub fn set_text(_text: &str) -> anyhow::Result<()> {
-    Err(anyhow::anyhow!("No clipboard available").context("Failed to copy"))
+pub fn set_text(text: &str) -> Result<()> {
+    // Try OSC52 even on platforms unsupported by arboard:
+    set_text_osc52(text).context("Failed to copy")
 }


### PR DESCRIPTION
The `.copy` REPL command does not work when aichat runs on a headless server. It appears that the arboard crate only works with graphical Linux interfaces, X11 and Wayland. When these are not available, it fails. This PR adds a fallback to use an OSC52 terminal codes to access the clipboard through the terminal emulator. This works on pretty much all modern emulators. Seems to work on my testing, and seems to work correctly under X11 (I don’t have a Wayland system to test with).

Thanks for this excellent package! aichat is the best CLI/TUI LLM interface I found, and I use it every day.