### PR TITLE
fix gemini model

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -216,7 +216,7 @@
       output_price: 0
       supports_vision: true
       supports_function_calling: true
-    - name: gemini-2.5-pro-exp-03-25
+    - name: gemini-2.5-pro-preview-03-25
       max_input_tokens: 1048576
       max_output_tokens: 65536
       input_price: 0


### PR DESCRIPTION
Current Behavior:
```
> .model gemini:gemini-2.5-pro-exp-03-25

> Hello
Error: Failed to call chat-completions api

Caused by:
    You exceeded your current quota. Please migrate to Gemini 2.5 Pro Preview (models/gemini-2.5-pro-preview-03-25) for higher quota limits. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. (status: RESOURCE_EXHAUSTED)
```

Fixed behavior:
```
> .model gemini:gemini-2.5-pro-preview-03-25

> Hello
Hello! How can I help you today?
```