### PR TITLE
added session-auto-save

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,6 +26,8 @@ agent_prelude: null              # Set a session to use when starting a agent (e
 # ---- session ----
 # Controls the persistence of the session. if true, auto save; if false, not save; if null, asking the user
 save_session: null
+# Automatically save the session after each message exchange without prompting
+auto_save_session: false
 # Compress session when token count reaches or exceeds this threshold
 compress_threshold: 4000
 # Text prompt used for creating a concise summary of session message

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,9 @@ pub struct Cli {
     /// Ensure the new conversation is saved to the session
     #[clap(long)]
     pub save_session: bool,
+    /// Automatically save the session after each message
+    #[clap(long)]
+    pub auto_save_session: bool,
     /// Start a agent
     #[clap(short = 'a', long)]
     pub agent: Option<String>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -121,6 +121,7 @@ pub struct Config {
     pub agent_prelude: Option<String>,
 
     pub save_session: Option<bool>,
+    pub auto_save_session: bool,
     pub compress_threshold: usize,
     pub summarize_prompt: Option<String>,
     pub summary_prompt: Option<String>,
@@ -197,6 +198,7 @@ impl Default for Config {
             agent_prelude: None,
 
             save_session: None,
+            auto_save_session: false,
             compress_threshold: 4000,
             summarize_prompt: None,
             summary_prompt: None,
@@ -694,6 +696,10 @@ impl Config {
             "highlight" => {
                 let value = value.parse().with_context(|| "Invalid value")?;
                 config.write().highlight = value;
+            },
+            "auto_save_session" => {
+                let value = value.parse().with_context(|| "Invalid value")?;
+                config.write().auto_save_session = value;
             }
             _ => bail!("Unknown key '{key}'"),
         }
@@ -2051,6 +2057,11 @@ impl Config {
         self.last_message = Some(LastMessage::new(input.clone(), output.to_string()));
         if !self.dry_run {
             self.save_message(input, output)?;
+            
+            // Automatically save session if feature is enabled
+            if self.auto_save_session && self.session.is_some() {
+                self.save_session(None)?;
+            }
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,9 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
     if cli.save_session {
         config.write().set_save_session_this_time()?;
     }
+    if cli.auto_save_session {
+        config.write().auto_save_session = true;
+    }
     if cli.info {
         let info = config.read().info()?;
         println!("{}", info);


### PR DESCRIPTION
I implemented the session_auto_save change.

Note that I did not take into account any possible coupling of save_session and auto_save_session; however, I could not find any issues during testing. I updated both the repl .set auto_save_session true/false as well as the command --auto-save-session. I tested both with and without auto-save-session from both the command and repl. I also tested combinations of both save-session and auto-save-session, and I could not find any issues.

The only thing I found that I did not like was the inconsistency in:
    pub save_session: Option<bool>, #none
    pub auto_save_session: bool, #false
Where save_session is an option and the auto_save_session is hard-coded to default to false.