### PR TITLE
Improve AWS Bedrock support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ time = { version = "0.3.36", features = ["macros"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
 hmac = "0.12.1"
 aws-smithy-eventstream = "0.60.4"
+aws-config = { version = "1.6.3", features = ["behavior-version-latest"] }
+aws-credential-types = "1.2.3"
 urlencoding = "2.1.3"
 unicode-segmentation = "1.11.0"
 json-patch = { version = "4.0.0", default-features = false }


### PR DESCRIPTION
This change brings region and credential management in-line with how all standard AWS tools work, greatly increasing usability for anyone using Bedrock models.

If nothing is specified in the AIChat configuration, the "[default credential chain](https://docs.rs/aws-config/latest/aws_config/default_provider/credentials/struct.DefaultCredentialsChain.html)" is used, which means it can pull from environment variables (like `AWS_PROFILE` and `AWS_REGION`), IMDS, etc. In addition, a new configuration key `profile` has been added to specify that a specific "Profile" be used. This also means that `access_key_id`, `secret_access_key` and `region` are now optional.

With this change, you can use temporary (or permanent) credentials from the standard `~/.aws/credentials` file, on-the-fly role assumption with profiles, `credential_process`, SSO, etc.