### PR TITLE
fix: better error handling for `aichat -e` on MacOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -174,9 +174,6 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         return Ok(());
     }
     if cli.execute && !is_repl {
-        if cfg!(target_os = "macos") && !stdin().is_terminal() {
-            bail!("Unable to read the pipe for shell execution on MacOS")
-        }
         let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
         shell_execute(&config, &SHELL, input, abort_signal.clone()).await?;
         return Ok(());
@@ -265,6 +262,9 @@ async fn shell_execute(
         return Ok(());
     }
     if *IS_STDOUT_TERMINAL {
+        if cfg!(target_os = "macos") && !stdin().is_terminal() {
+            bail!("Unable to read the pipe for shell execution on MacOS")
+        }
         let options = ["execute", "revise", "describe", "copy", "quit"];
         let command = color_text(eval_str.trim(), nu_ansi_term::Color::Rgb(255, 165, 0));
         let first_letter_color = nu_ansi_term::Color::Cyan;


### PR DESCRIPTION
After merging #930, zsh shell completions stopped working. This PR fixes it.

Closes #1307