### PR TITLE
Allow users to add custom (or new) models in a configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Download pre-built binaries for macOS, Linux, and Windows from [GitHub Releases]
 
 Integrate seamlessly with over 20 leading LLM providers through a unified interface. Supported providers include OpenAI, Claude, Gemini (Google AI Studio), Ollama, Groq, Azure-OpenAI, VertexAI, Bedrock, Github Models, Mistral, Deepseek, AI21, XAI Grok, Cohere, Perplexity, Cloudflare, OpenRouter, Ernie, Qianwen, Moonshot, ZhipuAI, Lingyiwanwu, MiniMax, Deepinfra, VoyageAI, any OpenAI-Compatible API provider.
 
+Add custom models or override existing ones using `models-merge.yaml` configuration. See [models-merge.example.yaml](models-merge.example.yaml) for examples.
+
 ### CMD Mode
 
 Explore powerful command-line functionalities with AIChat's CMD mode.

--- a/models-merge.example.yaml
+++ b/models-merge.example.yaml
@@ -1,0 +1,64 @@
+# Example models-merge.yaml
+# This file demonstrates how to add custom models while preserving existing ones.
+# Unlike models-override.yaml which replaces all models, models-merge.yaml extends 
+# the existing model definitions.
+#
+# Usage: Copy this file to models-merge.yaml and customize as needed.
+# Priority: models-override.yaml > models.yaml + models-merge.yaml > models.yaml only
+
+# Example 1: Add a new custom OpenAI-compatible model
+- provider: openai
+  models:
+    - name: my-custom-gpt-4
+      max_input_tokens: 32000
+      max_output_tokens: 4096
+      input_price: 3.0
+      output_price: 6.0
+      supports_vision: false
+      supports_function_calling: true
+
+# Example 2: Add a completely new provider with custom models
+- provider: my-local-provider
+  base_url: http://localhost:8080/v1
+  models:
+    - name: llama-3-70b-local
+      max_input_tokens: 8192 
+      max_output_tokens: 2048
+      input_price: 0
+      output_price: 0
+      supports_vision: false
+      supports_function_calling: true
+    - name: codellama-34b-local
+      max_input_tokens: 16384
+      max_output_tokens: 4096
+      input_price: 0
+      output_price: 0
+      supports_vision: false
+      supports_function_calling: false
+
+# Example 3: Override/update an existing model's parameters
+- provider: claude
+  models:
+    - name: claude-3-5-sonnet-20241022
+      # Override pricing for a specific model
+      input_price: 2.5   # Custom pricing
+      output_price: 7.5  # Custom pricing
+      # All other parameters remain as defined in the base models.yaml
+
+# Example 4: Add models to an existing provider
+- provider: gemini
+  models:
+    - name: gemini-pro-custom
+      max_input_tokens: 1000000
+      max_output_tokens: 8192
+      input_price: 1.25
+      output_price: 5.0
+      supports_vision: true
+      supports_function_calling: true
+
+# Notes:
+# - If a provider already exists, new models are added to that provider
+# - If a model name already exists, it will be replaced/updated
+# - If a provider doesn't exist, it will be added as a new provider
+# - All standard model parameters are supported (see models.yaml for reference)
+# - Pricing is typically in dollars per million tokens

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -429,6 +429,10 @@ impl Config {
         Self::local_path("models-override.yaml")
     }
 
+    pub fn models_merge_file() -> PathBuf {
+        Self::local_path("models-merge.yaml")
+    }
+
     pub fn state(&self) -> StateFlags {
         let mut flags = StateFlags::empty();
         if let Some(session) = &self.session {
@@ -1894,6 +1898,22 @@ impl Config {
             bail!("Incompatible version")
         }
         Ok(models_override.list)
+    }
+
+    pub fn load_models_merge() -> Result<Vec<ProviderModels>> {
+        let models_merge_path = Self::models_merge_file();
+        if !models_merge_path.exists() {
+            return Ok(vec![]);
+        }
+        let err = || {
+            format!(
+                "Failed to load models merge file at '{}'",
+                models_merge_path.display()
+            )
+        };
+        let content = read_to_string(&models_merge_path).with_context(err)?;
+        let models_merge: Vec<ProviderModels> = serde_yaml::from_str(&content).with_context(err)?;
+        Ok(models_merge)
     }
 
     pub fn render_options(&self) -> Result<RenderOptions> {


### PR DESCRIPTION
Right now, the only mechanisms for users to define models require fully overwriting the models defined in `models.yaml`, either in the main configuration file or in `models-overwrite.yaml`. This makes experimenting with new models difficult. The proposed patch adds support for a `models-merge.yaml` configuration file that merges with `models.yaml`, allowing additions and overwrites.