### PR TITLE
Fix o1-pro and o3-pro by adding support for OpenAI Responses API

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -141,7 +141,7 @@
       output_price: 600
       supports_vision: true
       supports_function_calling: true
-      system_prompt_prefix: Formatting re-enabled
+      uses_responses_api: true
       patch:
         body:
           max_tokens: null

--- a/src/client/model.rs
+++ b/src/client/model.rs
@@ -199,6 +199,10 @@ impl Model {
         self.data.system_prompt_prefix.as_deref()
     }
 
+    pub fn uses_responses_api(&self) -> bool {
+        self.data.uses_responses_api
+    }
+
     pub fn max_tokens_per_chunk(&self) -> Option<usize> {
         self.data.max_tokens_per_chunk
     }
@@ -324,6 +328,8 @@ pub struct ModelData {
     no_system_message: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     system_prompt_prefix: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    uses_responses_api: bool,
 
     // embedding-only properties
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -474,7 +474,8 @@ impl Config {
             return Ok((log_level, None));
         }
         let log_path = match env::var(get_env_name("log_path")) {
-            Ok(v) => Some(PathBuf::from(v)),
+            Ok(v) if !v.is_empty() => Some(PathBuf::from(v)),
+            Ok(_) => None, // Empty string means stdout
             Err(_) => match is_serve {
                 true => None,
                 false => Some(Config::local_path(&format!(


### PR DESCRIPTION
I couldn't get o1-pro and o3-pro to work in aichat: they errored out with messages saying that these models required using the Responses API rather than the Chat Completions API. This patch adds preliminary support for the Responses API, and enables its use for o1-pro (o3-pro is not yet in the models.yaml file).