### PR TITLE
fix: openai api omits tool_calls message content

### DIFF
--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -241,7 +241,7 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
             match content {
                 MessageContent::ToolCalls(MessageContentToolCalls {
                         tool_results,
-                        text,
+                        text: _,
                         sequence,
                     }) => {
                     if !sequence {
@@ -255,9 +255,8 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
                                 },
                             })
                         }).collect();
-                        let text = if text.is_empty() { Value::Null } else { text.into() };
                         let mut messages = vec![
-                            json!({ "role": MessageRole::Assistant, "content": text, "tool_calls": tool_calls })
+                            json!({ "role": MessageRole::Assistant, "tool_calls": tool_calls })
                         ];
                         for tool_result in tool_results {
                             messages.push(
@@ -274,7 +273,6 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
                             vec![
                                 json!({
                                     "role": MessageRole::Assistant,
-                                    "content": "",
                                     "tool_calls": [
                                         {
                                             "id": tool_result.call.id,


### PR DESCRIPTION
Some LLM providers have issues with messages that have a tool_calls field but a null content. This PR fixes the issue by removing the `content` field.

```diff
    {
      "role": "assistant",
-     "content": null,
      "tool_calls": [
        {
          "id": "call_46bf3500093a41d8b8f842",
          "type": "function",
          "function": {
            "name": "get_current_weather",
            "arguments": "{\"location\":\"Paris\"}"
          }
        }
      ]
    }
```

