### PR TITLE
feat: support autodetect dark/light theme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "simplelog",
  "syntect",
  "sys-locale",
+ "terminal-colorsaurus",
  "textwrap",
  "time",
  "tokio",
@@ -3314,6 +3315,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal-colorsaurus"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7afe4c174a3cbfb52ebcb11b28965daf74fe9111d4e07e40689d05af06e26e8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio 1.0.3",
+ "terminal-trx",
+ "windows-sys 0.59.0",
+ "xterm-color",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975b4233aefa1b02456d5e53b22c61653c743e308c51cf4181191d8ce41753ab"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4427,6 +4454,12 @@ dependencies = [
  "mac",
  "markup5ever 0.12.1",
 ]
+
+[[package]]
+name = "xterm-color"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de5f056fb9dc8b7908754867544e26145767187aaac5a98495e88ad7cb8a80f"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ os_info = { version = "3.8.2", default-features = false }
 bm25 = { version = "2.0.1", features = ["parallelism"] }
 which = "7.0.1"
 fuzzy-matcher = "0.3.7"
+terminal-colorsaurus = "0.4.8"
 
 [dependencies.reqwest]
 version = "0.12.0"

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -86,24 +86,6 @@ pub fn estimate_token_length(text: &str) -> usize {
     output.ceil() as usize
 }
 
-pub fn light_theme_from_colorfgbg(colorfgbg: &str) -> Option<bool> {
-    let parts: Vec<_> = colorfgbg.split(';').collect();
-    let bg = match parts.len() {
-        2 => &parts[1],
-        3 => &parts[2],
-        _ => {
-            return None;
-        }
-    };
-    let bg = bg.parse::<u8>().ok()?;
-    let (r, g, b) = ansi_colours::rgb_from_ansi256(bg);
-
-    let v = 0.2126 * r as f32 + 0.7152 * g as f32 + 0.0722 * b as f32;
-
-    let light = v > 128.0;
-    Some(light)
-}
-
 pub fn strip_think_tag(text: &str) -> Cow<str> {
     THINK_TAG_RE.replace_all(text, "")
 }


### PR DESCRIPTION
- remove config `light_theme`
- add config `theme` (possible values: dark, light)
- autodetect with `terminal-colorsaurus`

close #1328