### PR TITLE
feat: enhence `.regenerate`

### DIFF
--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -189,6 +189,7 @@ impl Input {
             self.role = role;
         }
         self.regenerate = true;
+        self.tool_calls = None;
     }
 
     pub async fn use_embeddings(&mut self, abort_signal: AbortSignal) -> Result<()> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2051,7 +2051,7 @@ impl Config {
         output: &str,
         tool_results: &[ToolResult],
     ) -> Result<()> {
-        if output.is_empty() || !tool_results.is_empty() {
+        if !tool_results.is_empty() {
             return Ok(());
         }
         self.last_message = Some(LastMessage::new(input.clone(), output.to_string()));

--- a/src/config/session.rs
+++ b/src/config/session.rs
@@ -515,7 +515,13 @@ impl Session {
         if input.continue_output().is_some() {
             return messages;
         } else if input.regenerate() {
-            messages.pop();
+            while let Some(last) = messages.last() {
+                if !last.role.is_user() {
+                    messages.pop();
+                } else {
+                    break;
+                }
+            }
             return messages;
         }
         let mut need_add_msg = true;


### PR DESCRIPTION
- Work with tool calls.
- Handle empty responses in sessions. (close #1338)
- Tolerate corrupted session messages. (close #1306)