### PR TITLE
fix: `.copy` does not work after session compression

### DIFF
--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -665,7 +665,7 @@ pub async fn run_repl_command(
                     .read()
                     .last_message
                     .as_ref()
-                    .filter(|v| v.continuous && !v.output.is_empty())
+                    .filter(|v| !v.output.is_empty())
                     .map(|v| v.output.clone())
                 {
                     Some(v) => v,


### PR DESCRIPTION
Close #1348 