### PR TITLE
feat(bedrock): prioritize AWS env vars and support session tokens

### DIFF
--- a/src/client/bedrock.rs
+++ b/src/client/bedrock.rs
@@ -26,30 +26,8 @@ pub struct BedrockConfig {
 }
 
 impl BedrockClient {
-    // Removed macro to allow environment variable priority for access keys
-    // config_get_fn!(access_key_id, get_access_key_id);
-    // config_get_fn!(secret_access_key, get_secret_access_key);
-
-    pub fn get_access_key_id(&self) -> Result<String> {
-        if let Ok(val) = std::env::var("AWS_ACCESS_KEY_ID") {
-            return Ok(val);
-        }
-        if let Some(val) = &self.config.access_key_id {
-            return Ok(val.clone());
-        }
-        bail!("AWS_ACCESS_KEY_ID not set in environment or config");
-    }
-
-    pub fn get_secret_access_key(&self) -> Result<String> {
-        if let Ok(val) = std::env::var("AWS_SECRET_ACCESS_KEY") {
-            return Ok(val);
-        }
-        if let Some(val) = &self.config.secret_access_key {
-            return Ok(val.clone());
-        }
-        bail!("AWS_SECRET_ACCESS_KEY not set in environment or config");
-    }
-
+    config_get_fn!(access_key_id, get_access_key_id);
+    config_get_fn!(secret_access_key, get_secret_access_key);
     config_get_fn!(region, get_region);
 
     pub const PROMPTS: [PromptAction<'static>; 3] = [
@@ -407,7 +385,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
                     if !text.is_empty() {
                         assistant_parts.push(json!({
                             "text": text,
-                        }));
+                        }))
                     }
                     for tool_result in tool_results {
                         assistant_parts.push(json!({
@@ -459,7 +437,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
             {
                 "text": v,
             }
-        ]);
+        ])
     }
 
     if let Some(v) = model.max_tokens_param() {
@@ -488,7 +466,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
             .collect();
         body["toolConfig"] = json!({
             "tools": tools,
-        });
+        })
     }
     Ok(body)
 }
@@ -520,14 +498,14 @@ fn extract_chat_completions(data: &Value) -> Result<ChatCompletionsOutput> {
                         name.to_string(),
                         input.clone(),
                         Some(id.to_string()),
-                    ));
+                    ))
                 }
             }
         }
     }
 
     if let Some(reasoning) = reasoning {
-        text = format!("<think>\n{reasoning}\n</think>\n\n{text}");
+        text = format!("<think>\n{reasoning}\n</think>\n\n{text}")
     }
 
     if text.is_empty() && tool_calls.is_empty() {


### PR DESCRIPTION
When using the bedrock interface, its very typical to use AWS_PROFILES and aws sso login --profile <profile> in environments where you might have multiple AWS accesses.

This PR will allow people to dynamically utilize that aws system by having the bedrock interfaces check the env for these variables first so that we can dynamically change them as often as needed.

a simple way to do this is to `eval "$(aws configure export-credentials --profile <profile> --format env)"` after the aws sso login