### PR TITLE
feat(gemini): Pass API key in x-goog-api-key header for security

### DIFF
--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -41,7 +41,7 @@ fn prepare_chat_completions(
     self_: &GeminiClient,
     data: ChatCompletionsData,
 ) -> Result<RequestData> {
-    let api_key = self_.get_api_key()?;
+    let api_key = self_.get_api_key().ok();
     let api_base = self_
         .get_api_base()
         .unwrap_or_else(|_| API_BASE.to_string());
@@ -52,16 +52,19 @@ fn prepare_chat_completions(
     };
 
     let url = format!(
-        "{}/models/{}:{}?key={}",
+        "{}/models/{}:{}",
         api_base.trim_end_matches('/'),
         self_.model.real_name(),
-        func,
-        api_key
+        func
     );
 
     let body = gemini_build_chat_completions_body(data, &self_.model)?;
 
-    let request_data = RequestData::new(url, body);
+    let mut request_data = RequestData::new(url, body);
+
+    if let Some(api_key) = api_key {
+        request_data.header("x-goog-api-key", api_key);
+    }
 
     Ok(request_data)
 }

--- a/src/client/gemini.rs
+++ b/src/client/gemini.rs
@@ -41,7 +41,7 @@ fn prepare_chat_completions(
     self_: &GeminiClient,
     data: ChatCompletionsData,
 ) -> Result<RequestData> {
-    let api_key = self_.get_api_key().ok();
+    let api_key = self_.get_api_key()?;
     let api_base = self_
         .get_api_base()
         .unwrap_or_else(|_| API_BASE.to_string());
@@ -62,9 +62,7 @@ fn prepare_chat_completions(
 
     let mut request_data = RequestData::new(url, body);
 
-    if let Some(api_key) = api_key {
-        request_data.header("x-goog-api-key", api_key);
-    }
+    request_data.header("x-goog-api-key", api_key);
 
     Ok(request_data)
 }


### PR DESCRIPTION
Transmits the Gemini API key in the `x-goog-api-key` HTTP header instead of the URL query string. This enhances security by preventing key exposure in logs or history, aligning with best practices for API authentication.


Gemini official API document: https://ai.google.dev/gemini-api/docs/text-generation



