### PR TITLE
feat: env vars take precedence over client config

### DIFF
--- a/src/client/macros.rs
+++ b/src/client/macros.rs
@@ -226,14 +226,12 @@ macro_rules! impl_client_trait {
 macro_rules! config_get_fn {
     ($field_name:ident, $fn_name:ident) => {
         fn $fn_name(&self) -> anyhow::Result<String> {
-            let api_key = self.config.$field_name.clone();
-            api_key
-                .or_else(|| {
-                    let env_prefix = Self::name(&self.config);
-                    let env_name =
-                        format!("{}_{}", env_prefix, stringify!($field_name)).to_ascii_uppercase();
-                    std::env::var(&env_name).ok()
-                })
+            let env_prefix = Self::name(&self.config);
+            let env_name =
+                format!("{}_{}", env_prefix, stringify!($field_name)).to_ascii_uppercase();
+            std::env::var(&env_name)
+                .ok()
+                .or_else(|| self.config.$field_name.clone())
                 .ok_or_else(|| anyhow::anyhow!("Miss '{}'", stringify!($field_name)))
         }
     };


### PR DESCRIPTION
When both the `api_key` configuration option and the `<PROVIDER>_API_KEY` environment variable are provided, AIChat gives priority to the `<PROVIDER>_API_KEY` environment variable.