### PR TITLE
fix: add minimal columns bound to prevent divide-by-zero

### DIFF
--- a/src/render/stream.rs
+++ b/src/render/stream.rs
@@ -204,5 +204,5 @@ fn split_line_tail(text: &str) -> (&str, &str) {
 
 fn need_rows(text: &str, columns: u16) -> u16 {
     let buffer_width = display_width(text).max(1) as u16;
-    buffer_width.div_ceil(columns)
+    buffer_width.div_ceil(columns.max(1))
 }


### PR DESCRIPTION
This change adds a minimal bound to the number of columns, preventing division by zero.

It's a rare but possible case. I encountered it when running aichat on an ARM device/QEMU over a serial line. Sure, using 1 as the lower bound is not an ideal solution as it can cause strange formatting in the output, but (to me) it looks better than a crash.

Thank you


Before fix:

<img width="754" height="353" alt="image" src="https://github.com/user-attachments/assets/77527395-d601-4927-aeb7-7d7153e6f18f" />

After fix:

<img width="773" height="390" alt="image" src="https://github.com/user-attachments/assets/05b293ba-d08e-461a-9465-60f1e3cdbad6" />


