### PR TITLE
chore: remove redundant text check in use_embeddings method

### DIFF
--- a/src/config/input.rs
+++ b/src/config/input.rs
@@ -196,14 +196,11 @@ impl Input {
         if self.text.is_empty() {
             return Ok(());
         }
-        if !self.text.is_empty() {
-            let rag = self.config.read().rag.clone();
-            if let Some(rag) = rag {
-                let result =
-                    Config::search_rag(&self.config, &rag, &self.text, abort_signal).await?;
-                self.patched_text = Some(result);
-                self.rag_name = Some(rag.name().to_string());
-            }
+        let rag = self.config.read().rag.clone();
+        if let Some(rag) = rag {
+            let result = Config::search_rag(&self.config, &rag, &self.text, abort_signal).await?;
+            self.patched_text = Some(result);
+            self.rag_name = Some(rag.name().to_string());
         }
         Ok(())
     }


### PR DESCRIPTION
This PR removes redundant text check in the use_embeddings method of src/config/input.rs to simplify code and avoid unnecessary conditional checks.