### PR TITLE
fix: Set `max_output_token` to 24000 for `claude:claude-opus-4-1-20250805:thinking`

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -239,7 +239,7 @@
     - name: claude-opus-4-1-20250805:thinking
       real_name: claude-opus-4-1-20250805
       max_input_tokens: 200000
-      max_output_tokens: 8192
+      max_output_tokens: 24000
       require_max_tokens: true
       input_price: 15
       output_price: 75


### PR DESCRIPTION
Without this fix I get:

```
aichat
Welcome to aichat 0.30.0
Type ".help" for additional help.
> .model claude:claude-opus-4-1-20250805:thinking

> test
Error: Failed to call chat-completions api

Caused by:
    `max_tokens` must be greater than `thinking.budget_tokens`. Please consult our documentation at https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#max-tokens-and-context-window-size (type: invalid_request_error)
```

All the other thinking instances of Opus 4.1 have the correct value.