### PR TITLE
Add fallback to ANTHROPIC_ env vars for Claude client configuration

### DIFF
--- a/src/client/macros.rs
+++ b/src/client/macros.rs
@@ -231,6 +231,14 @@ macro_rules! config_get_fn {
                 format!("{}_{}", env_prefix, stringify!($field_name)).to_ascii_uppercase();
             std::env::var(&env_name)
                 .ok()
+                .or_else(|| {
+                    if env_prefix.contains("claude") {
+                        let alt_env_name = format!("ANTHROPIC_{}", stringify!($field_name)).to_ascii_uppercase();
+                        std::env::var(&alt_env_name).ok()
+                    } else {
+                        None
+                    }
+                })
                 .or_else(|| self.config.$field_name.clone())
                 .ok_or_else(|| anyhow::anyhow!("Miss '{}'", stringify!($field_name)))
         }


### PR DESCRIPTION
The `claude` tool proper looks for ANTHROPIC_API_KEY.

Users may have this configured already for the `claude` code tool and expect things to 'just work' when invoking `aichat`.