### PR TITLE
Add support for MCP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "reedline",
  "reqwest",
  "reqwest-eventsource",
+ "rmcp",
  "rust-embed",
  "scraper",
  "serde",
@@ -448,7 +449,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -712,8 +713,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -731,12 +742,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn",
 ]
@@ -1038,12 +1074,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1051,6 +1103,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1093,6 +1156,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1935,7 +1999,7 @@ dependencies = [
  "combine",
  "libc",
  "mach2",
- "nix",
+ "nix 0.26.4",
  "sysctl",
  "thiserror 1.0.69",
  "widestring",
@@ -1968,6 +2032,18 @@ dependencies = [
  "libc",
  "memoffset",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2227,6 +2303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "path-absolutize"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2487,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix 0.30.1",
+ "tokio",
+ "tracing",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -2591,6 +2687,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2830,42 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f35acda8f89fca5fd8c96cae3c6d5b4c38ea0072df4c8030915f3b5ff469c1c"
+dependencies = [
+ "base64",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "process-wrap",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9f1d5220aaa23b79c3d02e18f7a554403b3ccea544bbb6c69d6bcb3e854a274"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -2876,6 +3028,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,18 +3124,39 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2966,15 +3165,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ which = "8.0.0"
 fuzzy-matcher = "0.3.7"
 terminal-colorsaurus = "0.4.8"
 duct = "1.0.0"
+rmcp = { version = "0.8.1", features = ["client", "transport-child-process"] }
 
 [dependencies.reqwest]
 version = "0.12.0"

--- a/MCP.md
+++ b/MCP.md
@@ -15,6 +15,7 @@ For more information, visit: https://modelcontextprotocol.io
 - **Name Conflict Prevention**: MCP tools are prefixed with `mcp__<server>__<tool>` to avoid conflicts
 - **REPL Commands**: Manage MCP server connections interactively
 - **Configuration-Driven**: Define MCP servers in your aichat config file
+- **Tool Calling Permissions**: Fine-grained control over tool execution with support for permanent and runtime permissions
 
 ## Configuration
 
@@ -48,6 +49,7 @@ mcp_servers:
 - **env** (optional): Environment variables for the server process
 - **enabled** (optional, default: true): Whether to auto-connect on startup
 - **description** (optional): Human-readable description
+- **trusted** (optional, default: false): Whether to bypass all permission checks for tools from this server
 
 See `config.mcp.example.yaml` for more examples.
 
@@ -107,6 +109,230 @@ Popular MCP servers you can use with aichat:
 ### Community Servers
 
 Visit https://github.com/modelcontextprotocol for more servers.
+
+## Tool Calling Permissions
+
+AIChat provides a comprehensive permissions system to control tool execution, supporting both MCP tools and local functions. This system offers two patterns:
+1. **Permanent permissions** via configuration file
+2. **One-time "human-in-the-loop" permissions** during runtime
+
+### Global Permission Level
+
+Control all tool calls with a single setting:
+
+```yaml
+tool_call_permission: ask  # Options: always (default), ask, never
+```
+
+### Fine-Grained Tool Permissions
+
+Define specific permissions for individual tools or patterns:
+
+```yaml
+tool_permissions:
+  allowed:                     # Always allowed (no prompt)
+    - fs_cat
+    - fs_ls
+    - mcp__filesystem__read_file
+  denied:                      # Always denied
+    - fs_rm
+    - mcp__*__delete_*         # Supports wildcards
+  ask:                         # Always prompt
+    - fs_write
+    - mcp__*__write_*
+```
+
+### Pattern Matching
+
+Support for wildcard patterns:
+- `fs_*` - matches all tools starting with "fs_"
+- `mcp__*` - matches all MCP tools
+- `mcp__filesystem__*` - matches all tools from filesystem server
+- `mcp__*__write_*` - matches all write operations from any MCP server
+
+### Trusted MCP Servers
+
+Mark MCP servers as trusted to bypass permission checks:
+
+```yaml
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    enabled: true
+    trusted: false  # Set to true to bypass all permission checks
+```
+
+**Use with caution**: Trusted servers bypass all permission checks for their tools.
+
+### Session-Level Permissions
+
+During a session, you can grant permissions that persist for that session only:
+
+```
+Tool call requested: mcp__filesystem__write_file
+
+Allow this tool call?
+> Yes (this time only)     # Allow once
+  Yes (for this session)   # Allow for entire session
+  No                       # Deny
+```
+
+Session permissions are automatically cleared when you exit the session.
+
+### Runtime Configuration
+
+Change permission settings at runtime:
+
+```bash
+.set tool_call_permission ask
+.set verbose_tool_calls true
+```
+
+### Verbose Tool Calls
+
+Enable verbose mode to see all tool calls, even when automatically allowed:
+
+```yaml
+verbose_tool_calls: true  # Print tool call info for all calls (default: false)
+```
+
+When enabled, you'll see output like:
+
+```
+🔧 Tool Call: mcp__filesystem__read_file [auto-allowed (allowed list)]
+   Arguments: {
+     "path": "/tmp/example.txt"
+   }
+```
+
+This is useful for:
+- Debugging which tools are being called
+- Understanding permission decisions
+- Monitoring AI assistant behavior
+- Learning what tools the AI chooses to use
+
+### Permission Examples
+
+#### Example 1: Strict Security
+
+```yaml
+tool_call_permission: never
+tool_permissions:
+  allowed:
+    - fs_cat
+    - fs_ls
+```
+
+Only `fs_cat` and `fs_ls` are allowed; all other tools are denied.
+
+#### Example 2: Interactive Mode
+
+```yaml
+tool_call_permission: ask
+```
+
+Every tool call will prompt for permission.
+
+#### Example 3: Smart Defaults
+
+```yaml
+tool_permissions:
+  allowed:
+    - fs_cat
+    - fs_ls
+    - mcp__*__read_*   # All read operations allowed
+  denied:
+    - fs_rm
+    - mcp__*__delete_* # All delete operations denied
+```
+
+Read operations are allowed, destructive operations are denied, and everything else prompts.
+
+#### Example 4: Trusted Development Environment
+
+```yaml
+tool_call_permission: always
+```
+
+All tools are allowed without prompting (default behavior).
+
+#### Example 5: Per-Server Trust
+
+```yaml
+# Trust filesystem server but not others
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    enabled: true
+    trusted: true    # All filesystem tools bypass permission checks
+
+  - name: git
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-git"]
+    enabled: true
+    trusted: false   # Git tools still require permissions
+```
+
+### Permission Check Flow
+
+When a tool is called, the following checks are performed in order:
+
+1. Check if tool was already allowed in current session
+2. Check if MCP tool is from a trusted server
+3. Check specific tool permissions (denied → allowed → ask)
+4. Fall back to global `tool_call_permission` setting
+5. Prompt user if needed
+6. Execute or deny based on result
+
+### Security Considerations
+
+- **Default behavior**: All tools allowed (backward compatible)
+- **Trusted servers**: Use with caution - bypasses all checks
+- **Pattern matching**: Test patterns carefully to avoid unintended matches
+- **Session permissions**: Only persist for the current session
+- **Permission denial**: Returns error message to LLM instead of executing
+
+### Configuration Reference
+
+#### Global Permission
+
+```yaml
+tool_call_permission: <level>
+```
+
+Values: `always`, `ask`, `never`
+
+#### Tool Permissions
+
+```yaml
+tool_permissions:
+  allowed: [<tools>]   # Always allowed
+  denied: [<tools>]    # Always denied
+  ask: [<tools>]       # Always prompt
+```
+
+#### Verbose Tool Calls
+
+```yaml
+verbose_tool_calls: <boolean>
+```
+
+Values: `true`, `false` (default)
+
+When `true`, prints information about every tool call including:
+- Tool name
+- Permission decision (auto-allowed, denied, etc.)
+- Arguments being passed to the tool
+
+#### MCP Server Trust
+
+```yaml
+mcp_servers:
+  - name: <name>
+    trusted: <boolean>  # true to bypass permission checks
+```
 
 ## Example Workflows
 
@@ -182,3 +408,11 @@ In REPL:
 - Filesystem server: Ensure the specified directory is readable/writable
 - Git server: Ensure you have access to the repository
 - Database servers: Verify file permissions and credentials
+
+### Tool Permission Denied
+
+If a tool call is denied by the permission system:
+1. Check your `tool_call_permission` setting
+2. Review `tool_permissions` configuration
+3. Consider marking the server as `trusted: true` if you fully trust it
+4. Grant session-level permission when prompted

--- a/MCP.md
+++ b/MCP.md
@@ -1,0 +1,184 @@
+# MCP (Model Context Protocol) Integration
+
+AIChat supports the Model Context Protocol (MCP), allowing it to connect to external servers that provide tools, resources, and other capabilities.
+
+## What is MCP?
+
+The Model Context Protocol is an open standard that enables AI applications to securely connect to external data sources and tools. MCP servers expose capabilities that can be used by AI assistants to extend their functionality beyond their base capabilities.
+
+For more information, visit: https://modelcontextprotocol.io
+
+## Features
+
+- **Automatic Tool Discovery**: MCP tools are automatically discovered when connecting to servers
+- **Seamless Integration**: MCP tools work alongside local functions with no code changes
+- **Name Conflict Prevention**: MCP tools are prefixed with `mcp__<server>__<tool>` to avoid conflicts
+- **REPL Commands**: Manage MCP server connections interactively
+- **Configuration-Driven**: Define MCP servers in your aichat config file
+
+## Configuration
+
+Add MCP servers to your `config.yaml`:
+
+```yaml
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-filesystem"
+      - "/tmp"
+    enabled: true
+    description: "File system operations"
+
+  - name: git
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-git"
+    enabled: true
+    description: "Git repository operations"
+```
+
+### Configuration Fields
+
+- **name** (required): Unique identifier for the server
+- **command** (required): Command to execute the MCP server
+- **args** (optional): Arguments passed to the command
+- **env** (optional): Environment variables for the server process
+- **enabled** (optional, default: true): Whether to auto-connect on startup
+- **description** (optional): Human-readable description
+
+See `config.mcp.example.yaml` for more examples.
+
+## Usage
+
+### REPL Commands
+
+```bash
+# List all configured MCP servers
+.mcp list
+
+# Connect to a server
+.mcp connect filesystem
+
+# Disconnect from a server
+.mcp disconnect filesystem
+
+# List all available MCP tools
+.mcp tools
+
+# List tools from a specific server
+.mcp tools filesystem
+```
+
+### Using MCP Tools
+
+MCP tools are automatically available when function calling is enabled. They can be used just like local functions:
+
+```bash
+# Enable all tools (local + MCP)
+aichat --role %functions% "read the file /tmp/example.txt"
+
+# Use specific MCP tools in a role
+# In your role definition:
+use_tools: "mcp__filesystem__read_file,mcp__git__log"
+```
+
+### Tool Naming
+
+MCP tools are prefixed to avoid name conflicts:
+- Format: `mcp__<server>__<tool>`
+- Example: `mcp__filesystem__read_file` (filesystem server's `read_file` tool)
+
+## Available MCP Servers
+
+Popular MCP servers you can use with aichat:
+
+### Official Servers
+
+- **@modelcontextprotocol/server-filesystem** - File system operations
+- **@modelcontextprotocol/server-git** - Git repository operations
+- **@modelcontextprotocol/server-sqlite** - SQLite database queries
+- **@modelcontextprotocol/server-postgres** - PostgreSQL database queries
+- **@modelcontextprotocol/server-github** - GitHub API integration
+- **@modelcontextprotocol/server-slack** - Slack integration
+
+### Community Servers
+
+Visit https://github.com/modelcontextprotocol for more servers.
+
+## Example Workflows
+
+### File Operations
+
+```yaml
+# config.yaml
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/projects"]
+    enabled: true
+```
+
+In REPL:
+```
+> Can you read and summarize the README.md file?
+(AIChat will use mcp__filesystem__read_file to read the file)
+```
+
+### Git Operations
+
+```yaml
+# config.yaml
+mcp_servers:
+  - name: git
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-git"]
+    enabled: true
+```
+
+In REPL:
+```
+> What commits were made in the last week?
+(AIChat will use mcp__git__log to query git history)
+```
+
+### Database Queries
+
+```yaml
+# config.yaml
+mcp_servers:
+  - name: sqlite
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-sqlite", "/path/to/db.sqlite"]
+    enabled: true
+```
+
+In REPL:
+```
+> How many users are in the database?
+(AIChat will use mcp__sqlite__query to run SQL queries)
+```
+
+## Troubleshooting
+
+### Server Won't Connect
+
+1. Ensure the MCP server command is installed and in PATH
+2. Check server logs (if available)
+3. Verify arguments and environment variables are correct
+4. Try connecting manually: `.mcp connect <server>`
+
+### Tools Not Appearing
+
+1. Verify server is connected: `.mcp list`
+2. Check available tools: `.mcp tools <server>`
+3. Ensure `function_calling` is enabled in config
+4. Check `use_tools` configuration in your role
+
+### Permission Errors
+
+- Filesystem server: Ensure the specified directory is readable/writable
+- Git server: Ensure you have access to the repository
+- Database servers: Verify file permissions and credentials

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ We have created a new repository [https://github.com/sigoden/llm-functions](http
 
 Integrate external tools to automate tasks, retrieve information, and perform actions directly within your workflow.
 
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers are natively supported. See [MCP.md](MCP.md) for detailed documentation.
+
 ![aichat-tool](https://github.com/user-attachments/assets/7459a111-7258-4ef0-a2dd-624d0f1b4f92)
 
 #### AI Agents (CLI version of OpenAI GPTs)

--- a/config.agent.example.yaml
+++ b/config.agent.example.yaml
@@ -9,3 +9,19 @@ agent_prelude: null              # Set a session to use when starting the agent.
 instructions: null               # Override the instructions for the agent, have no effect for dynamic instructions
 variables:                       # Custom default values for the agent variables
   <key>: <value>
+
+# ---- tool permissions ----
+# Control which tools this agent can call and whether to prompt for permission
+# tool_call_permission: ask      # Permission level for this agent: 'always', 'ask', or 'never'
+# tool_permissions:              # Fine-grained control over individual tools for this agent
+#   allowed:                     # Tools that are always allowed (no prompt)
+#     - fs_cat
+#     - fs_ls
+#   denied:                      # Tools that are always denied
+#     - fs_rm
+#     - mcp__*__delete_*         # Supports wildcards
+#   ask:                         # Tools that always prompt for permission
+#     - fs_write
+#     - fs_mkdir
+tool_call_permission: null       # If null, inherits from global config
+tool_permissions: null           # If null, inherits from global config

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,30 @@ mapping_tools:                   # Alias for a tool or toolset
   fs: 'fs_cat,fs_ls,fs_mkdir,fs_rm,fs_write'
 use_tools: null                  # Which tools to use by default. (e.g. 'fs,web_search')
 
+# ---- mcp servers ----
+# function_calling must be set to true to enable tool calling in MCP servers.
+mcp_servers:
+  # - name: custom
+  #   command: /path/to/custom-mcp-server
+  #   args:
+  #     - "--config"
+  #     - "/path/to/config.json"
+  #   env:
+  #     API_KEY: "your-api-key-here"
+  #     CUSTOM_SETTING: "value"
+  #   enabled: false
+  #   description: "Custom MCP server"
+  # Filesystem server - provides file read/write operations
+  - name: filesystem             # Name of the server
+    command: npx                 # Command that starts the server
+    args:                        # Arguments to pass to the command
+      - "-y"
+      - "@modelcontextprotocol/server-filesystem"
+      - "/tmp"                   # Root directory for filesystem operations
+    enabled: true                # Enable or disable the server
+    description: "File system operations (read, write, list)"
+
+
 # ---- prelude ----
 repl_prelude: null               # Set a default role or session for REPL mode (e.g. role:<name>, session:<name>, <session>:<role>)
 cmd_prelude: null                # Set a default role or session for CMD mode (e.g. role:<name>, session:<name>, <session>:<role>)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,25 @@ mapping_tools:                   # Alias for a tool or toolset
   fs: 'fs_cat,fs_ls,fs_mkdir,fs_rm,fs_write'
 use_tools: null                  # Which tools to use by default. (e.g. 'fs,web_search')
 
+# ---- tool permissions ----
+# Control which tools can be called and whether to prompt for permission
+# tool_call_permission: ask      # Global permission level: 'always' (default), 'ask', or 'never'
+# verbose_tool_calls: false      # Print tool calls even when automatically approved
+# tool_permissions:              # Fine-grained control over individual tools
+#   allowed:                     # Tools that are always allowed (no prompt)
+#     - fs_cat
+#     - fs_ls
+#     - mcp__filesystem__read_file
+#   denied:                      # Tools that are always denied
+#     - fs_rm
+#     - mcp__*__delete_*         # Supports wildcards
+#   ask:                         # Tools that always prompt for permission
+#     - fs_write
+#     - fs_mkdir
+#     - mcp__*__write_*          # Pattern: any MCP server's write operations
+tool_call_permission: always
+verbose_tool_calls: false
+
 # ---- mcp servers ----
 # function_calling must be set to true to enable tool calling in MCP servers.
 mcp_servers:
@@ -30,6 +49,7 @@ mcp_servers:
   #     API_KEY: "your-api-key-here"
   #     CUSTOM_SETTING: "value"
   #   enabled: false
+  #   trusted: false             # If true, bypasses tool permission checks
   #   description: "Custom MCP server"
   # Filesystem server - provides file read/write operations
   - name: filesystem             # Name of the server
@@ -39,6 +59,7 @@ mcp_servers:
       - "@modelcontextprotocol/server-filesystem"
       - "/tmp"                   # Root directory for filesystem operations
     enabled: true                # Enable or disable the server
+    trusted: false # If true, bypasses tool permission checks (use with caution!)
     description: "File system operations (read, write, list)"
 
 

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::{
-    config::{Config, GlobalConfig, Input},
+    config::{Config, GlobalConfig, Input, RoleLike},
     function::{eval_tool_calls, FunctionDeclaration, ToolCall, ToolResult},
     render::render_stream,
     utils::*,
@@ -432,7 +432,15 @@ pub async fn call_chat_completions(
                     client.global_config().read().print_markdown(&text)?;
                 }
             }
-            Ok((text, eval_tool_calls(client.global_config(), tool_calls)?))
+            Ok((
+                text,
+                eval_tool_calls(
+                    client.global_config(),
+                    tool_calls,
+                    input.role().tool_call_permission(),
+                    input.role().tool_permissions(),
+                )?,
+            ))
         }
         Err(err) => Err(err),
     }
@@ -463,7 +471,15 @@ pub async fn call_chat_completions_streaming(
             if !text.is_empty() && !text.ends_with('\n') {
                 println!();
             }
-            Ok((text, eval_tool_calls(client.global_config(), tool_calls)?))
+            Ok((
+                text,
+                eval_tool_calls(
+                    client.global_config(),
+                    tool_calls,
+                    input.role().tool_call_permission(),
+                    input.role().tool_permissions(),
+                )?,
+            ))
         }
         Err(err) => {
             if !text.is_empty() {

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -50,7 +50,7 @@ impl Agent {
         };
         let mut definition = AgentDefinition::load(&definition_file_path)?;
         let functions = if functions_file_path.exists() {
-            Functions::init(&functions_file_path)?
+            Functions::init(&functions_file_path, None)?
         } else {
             Functions::default()
         };

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -49,10 +49,19 @@ impl Agent {
             AgentConfig::new(&config.read())
         };
         let mut definition = AgentDefinition::load(&definition_file_path)?;
-        let functions = if functions_file_path.exists() {
-            Functions::init(&functions_file_path, None)?
+
+        // Get MCP tools from the global config if available
+        let mcp_manager = config.read().mcp_manager.clone();
+        let mcp_tools = if let Some(manager) = mcp_manager {
+            Some(manager.get_all_tools().await)
         } else {
-            Functions::default()
+            None
+        };
+
+        let functions = if functions_file_path.exists() {
+            Functions::init(&functions_file_path, mcp_tools)?
+        } else {
+            Functions::init_from_mcp(mcp_tools)
         };
         definition.replace_tools_placeholder(&functions);
 
@@ -348,6 +357,14 @@ impl RoleLike for Agent {
         self.config.use_tools.clone()
     }
 
+    fn tool_call_permission(&self) -> Option<String> {
+        self.config.tool_call_permission.clone()
+    }
+
+    fn tool_permissions(&self) -> Option<ToolPermissions> {
+        self.config.tool_permissions.clone()
+    }
+
     fn set_model(&mut self, model: Model) {
         self.config.model_id = Some(model.id());
         self.model = model;
@@ -364,6 +381,14 @@ impl RoleLike for Agent {
     fn set_use_tools(&mut self, value: Option<String>) {
         self.config.use_tools = value;
     }
+
+    fn set_tool_call_permission(&mut self, value: Option<String>) {
+        self.config.tool_call_permission = value;
+    }
+
+    fn set_tool_permissions(&mut self, value: Option<ToolPermissions>) {
+        self.config.tool_permissions = value;
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -377,6 +402,10 @@ pub struct AgentConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_tools: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_permission: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_permissions: Option<ToolPermissions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_prelude: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
@@ -388,6 +417,8 @@ impl AgentConfig {
     pub fn new(config: &Config) -> Self {
         Self {
             use_tools: config.use_tools.clone(),
+            tool_call_permission: config.tool_call_permission.clone(),
+            tool_permissions: config.tool_permissions.clone(),
             agent_prelude: config.agent_prelude.clone(),
             ..Default::default()
         }
@@ -415,6 +446,14 @@ impl AgentConfig {
         }
         if let Some(v) = read_env_value::<String>(&with_prefix("use_tools")) {
             self.use_tools = v;
+        }
+        if let Some(v) = read_env_value::<String>(&with_prefix("tool_call_permission")) {
+            self.tool_call_permission = v;
+        }
+        if let Ok(v) = env::var(with_prefix("tool_permissions")) {
+            if let Ok(v) = serde_json::from_str(&v) {
+                self.tool_permissions = Some(v);
+            }
         }
         if let Some(v) = read_env_value::<String>(&with_prefix("agent_prelude")) {
             self.agent_prelude = v;

--- a/src/function/permission.rs
+++ b/src/function/permission.rs
@@ -1,0 +1,300 @@
+use super::ToolCall;
+use crate::config::{GlobalConfig, ToolPermissions};
+use crate::utils::{color_text, dimmed_text};
+use anyhow::Result;
+use fancy_regex::Regex;
+use inquire::Select;
+use nu_ansi_term::Color;
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+static WILDCARD_PATTERN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\*").unwrap());
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PermissionLevel {
+    Always, // Always allow without prompting
+    Never,  // Always deny
+    Ask,    // Prompt user each time
+}
+
+impl PermissionLevel {
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "always" => PermissionLevel::Always,
+            "never" => PermissionLevel::Never,
+            "ask" => PermissionLevel::Ask,
+            _ => PermissionLevel::Ask, // Default to ask for safety
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ToolPermission {
+    config: GlobalConfig,
+    session_allowed: HashSet<String>,
+    role_tool_call_permission: Option<String>,
+    role_tool_permissions: Option<ToolPermissions>,
+}
+
+impl ToolPermission {
+    pub fn new(config: &GlobalConfig) -> Self {
+        // Load existing session permissions if in a session
+        let session_allowed = config
+            .read()
+            .session
+            .as_ref()
+            .map(|s| s.get_session_tool_permissions().clone())
+            .unwrap_or_default();
+
+        Self {
+            config: config.clone(),
+            session_allowed,
+            role_tool_call_permission: None,
+            role_tool_permissions: None,
+        }
+    }
+
+    pub fn new_with_role(
+        config: &GlobalConfig,
+        role_tool_call_permission: Option<String>,
+        role_tool_permissions: Option<ToolPermissions>,
+    ) -> Self {
+        // Load existing session permissions if in a session
+        let session_allowed = config
+            .read()
+            .session
+            .as_ref()
+            .map(|s| s.get_session_tool_permissions().clone())
+            .unwrap_or_default();
+
+        Self {
+            config: config.clone(),
+            session_allowed,
+            role_tool_call_permission,
+            role_tool_permissions,
+        }
+    }
+
+    /// Check if a tool call is permitted
+    pub fn check_permission(&mut self, tool_call: &ToolCall) -> Result<bool> {
+        let tool_name = &tool_call.name;
+
+        // Check if already allowed in this session
+        if self.session_allowed.contains(tool_name) {
+            // Print tool call info if verbose mode is enabled
+            if self.config.read().verbose_tool_calls {
+                self.print_tool_call_info(tool_call, "auto-allowed (session)");
+            }
+            return Ok(true);
+        }
+
+        let config = self.config.read();
+
+        // Check if this is an MCP tool from a trusted server
+        if tool_name.starts_with("mcp__") {
+            if config.mcp_manager.is_some() {
+                // Extract server name from tool name (format: mcp__<server>__<tool>)
+                if let Some(server_name) = crate::mcp::extract_server_name(tool_name) {
+                    // Check MCP server configs for trust status
+                    if let Some(server_config) =
+                        config.mcp_servers.iter().find(|s| s.name == server_name)
+                    {
+                        if server_config.trusted {
+                            // Print tool call info if verbose mode is enabled
+                            if config.verbose_tool_calls {
+                                drop(config);
+                                self.print_tool_call_info(
+                                    tool_call,
+                                    "auto-allowed (trusted server)",
+                                );
+                            }
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Get the default permission level (role-specific overrides global)
+        let default_permission = if let Some(perm) = &self.role_tool_call_permission {
+            PermissionLevel::from_str(perm)
+        } else if let Some(perm) = &config.tool_call_permission {
+            PermissionLevel::from_str(perm)
+        } else {
+            PermissionLevel::Always // Default behavior: always allow
+        };
+
+        // Check specific tool permissions (role-specific overrides global)
+        let tool_perms = self
+            .role_tool_permissions
+            .as_ref()
+            .or(config.tool_permissions.as_ref());
+        if let Some(tool_perms) = tool_perms {
+            // Check denied list first
+            if let Some(denied) = &tool_perms.denied {
+                if self.matches_any_pattern(tool_name, denied) {
+                    if config.verbose_tool_calls {
+                        drop(config);
+                        self.print_tool_call_info(tool_call, "denied");
+                    }
+                    return Ok(false);
+                }
+            }
+
+            // Check allowed list
+            if let Some(allowed) = &tool_perms.allowed {
+                if self.matches_any_pattern(tool_name, allowed) {
+                    if config.verbose_tool_calls {
+                        drop(config);
+                        self.print_tool_call_info(tool_call, "auto-allowed (allowed list)");
+                    }
+                    return Ok(true);
+                }
+            }
+
+            // Check ask list
+            if let Some(ask) = &tool_perms.ask {
+                if self.matches_any_pattern(tool_name, ask) {
+                    drop(config); // Release lock before prompting
+                    return self.prompt_user(tool_call);
+                }
+            }
+        }
+
+        let verbose = config.verbose_tool_calls;
+        // Fall back to global permission setting
+        drop(config);
+        match default_permission {
+            PermissionLevel::Always => {
+                if verbose {
+                    self.print_tool_call_info(tool_call, "auto-allowed (global)");
+                }
+                Ok(true)
+            }
+            PermissionLevel::Never => {
+                if verbose {
+                    self.print_tool_call_info(tool_call, "denied (global)");
+                }
+                Ok(false)
+            }
+            PermissionLevel::Ask => self.prompt_user(tool_call),
+        }
+    }
+
+    /// Prompt the user for permission
+    fn prompt_user(&mut self, tool_call: &ToolCall) -> Result<bool> {
+        // Format arguments for display
+        let args_display = if tool_call.arguments.is_object() {
+            serde_json::to_string_pretty(&tool_call.arguments).unwrap_or_else(|_| "{}".to_string())
+        } else {
+            tool_call.arguments.to_string()
+        };
+
+        // Truncate long arguments
+        let args_display = if args_display.len() > 200 {
+            format!("{}... (truncated)", &args_display[..200])
+        } else {
+            args_display
+        };
+        println!();
+        println!(
+            "Can I run {} with the following arguments?\n{}",
+            color_text(tool_call.name.as_str(), Color::Cyan),
+            dimmed_text(args_display.as_str())
+        );
+
+        let options = vec!["Yes (this time only)", "Yes (for this session)", "No"];
+
+        let choice = Select::new("Allow this tool call?", options)
+            .with_help_message("Choose how to respond to this tool call")
+            .prompt();
+
+        match choice {
+            Ok("Yes (this time only)") => Ok(true),
+            Ok("Yes (for this session)") => {
+                self.session_allowed.insert(tool_call.name.clone());
+
+                // Save to session if we're in one
+                if let Some(session) = self.config.write().session.as_mut() {
+                    session.add_session_tool_permission(tool_call.name.clone());
+                }
+
+                Ok(true)
+            }
+            Ok("No") => Ok(false),
+            _ => Ok(false), // Default to no on error or cancellation
+        }
+    }
+
+    /// Check if a tool name matches any pattern in a list
+    fn matches_any_pattern(&self, tool_name: &str, patterns: &[String]) -> bool {
+        patterns
+            .iter()
+            .any(|pattern| self.matches_pattern(tool_name, pattern))
+    }
+
+    /// Check if a tool name matches a pattern (supports wildcards)
+    fn matches_pattern(&self, tool_name: &str, pattern: &str) -> bool {
+        if pattern == tool_name {
+            return true;
+        }
+
+        // Convert glob pattern to regex
+        if pattern.contains('*') {
+            let regex_pattern = WILDCARD_PATTERN.replace_all(pattern, ".*");
+            let regex_pattern = format!("^{}$", regex_pattern);
+            if let Ok(re) = Regex::new(&regex_pattern) {
+                if let Ok(is_match) = re.is_match(tool_name) {
+                    return is_match;
+                }
+            }
+        }
+
+        false
+    }
+
+    /// Clear session permissions (call on session exit)
+    pub fn clear_session_permissions(&mut self) {
+        self.session_allowed.clear();
+    }
+
+    /// Check if a tool is permanently allowed in config
+    pub fn is_permanently_allowed(&self, tool_name: &str) -> bool {
+        let config = self.config.read();
+
+        if let Some(tool_perms) = &config.tool_permissions {
+            if let Some(allowed) = &tool_perms.allowed {
+                return self.matches_any_pattern(tool_name, allowed);
+            }
+        }
+
+        false
+    }
+
+    /// Print tool call information for verbose mode
+    fn print_tool_call_info(&self, tool_call: &ToolCall, status: &str) {
+        let prompt = format!(
+            "Call {} {} [{}]",
+            tool_call.name, tool_call.arguments, status
+        );
+        println!("{}", dimmed_text(&prompt));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pattern_matching() {
+        let config = GlobalConfig::default();
+        let permission = ToolPermission::new(&config);
+
+        assert!(permission.matches_pattern("fs_cat", "fs_cat"));
+        assert!(permission.matches_pattern("fs_cat", "fs_*"));
+        assert!(permission.matches_pattern("mcp__filesystem__read", "mcp__*"));
+        assert!(permission.matches_pattern("mcp__filesystem__write", "mcp__*__write*"));
+        assert!(!permission.matches_pattern("fs_cat", "fs_ls"));
+        assert!(!permission.matches_pattern("web_search", "fs_*"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod client;
 mod config;
 mod function;
+mod mcp;
 mod rag;
 mod render;
 mod repl;
@@ -53,6 +54,7 @@ async fn main() -> Result<()> {
         || cli.list_sessions;
     setup_logger(working_mode.is_serve())?;
     let config = Arc::new(RwLock::new(Config::init(working_mode, info_flag).await?));
+
     if let Err(err) = run(config, cli, text).await {
         render_error(err);
         std::process::exit(1);

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -1,0 +1,419 @@
+use anyhow::{anyhow, bail, Result};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use rmcp::model::CallToolRequestParam;
+use rmcp::service::{RoleClient, RunningService, ServiceExt};
+use rmcp::transport::TokioChildProcess;
+use tokio::process::Command;
+
+use super::config::McpServerConfig;
+use super::convert::mcp_tool_to_function;
+use crate::function::FunctionDeclaration;
+
+/// Wrapper around an MCP client connection
+pub struct McpClient {
+    name: String,
+    config: McpServerConfig,
+    tools: Arc<RwLock<Vec<FunctionDeclaration>>>,
+    connected: Arc<RwLock<bool>>,
+    service: Arc<RwLock<Option<RunningService<RoleClient, ()>>>>,
+}
+
+impl std::fmt::Debug for McpClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpClient")
+            .field("name", &self.name)
+            .field("config", &self.config)
+            .field("tools", &self.tools)
+            .field("connected", &self.connected)
+            .field("service", &"<MCP Service>")
+            .finish()
+    }
+}
+
+impl McpClient {
+    /// Create a new MCP client (not yet connected)
+    pub fn new(config: McpServerConfig) -> Self {
+        let name = config.name.clone();
+        Self {
+            name,
+            config,
+            tools: Arc::new(RwLock::new(Vec::new())),
+            connected: Arc::new(RwLock::new(false)),
+            service: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Get the server name
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Check if the client is connected
+    pub async fn is_connected(&self) -> bool {
+        *self.connected.read().await
+    }
+
+    /// Connect to the MCP server
+    ///
+    /// This will:
+    /// 1. Start the MCP server process via child process transport
+    /// 2. Initialize the service and get server info
+    /// 3. Discover available tools
+    /// 4. Convert tools to FunctionDeclarations
+    pub async fn connect(&self) -> Result<()> {
+        if *self.connected.read().await {
+            return Ok(());
+        }
+
+        log::info!("Connecting to MCP server '{}'...", self.name);
+
+        // Step 1: Create command for child process
+        let mut cmd = Command::new(&self.config.command);
+        cmd.args(&self.config.args);
+
+        // Set environment variables
+        for (key, value) in &self.config.env {
+            cmd.env(key, value);
+        }
+
+        // Step 2: Create transport and service
+        let transport = TokioChildProcess::new(cmd).map_err(|e| {
+            anyhow!(
+                "Failed to create transport for MCP server '{}': {}",
+                self.name,
+                e
+            )
+        })?;
+
+        // Allow an empty role to listen on the transport. This is a peculiarity
+        // of the MCP library. Any type that implements the ServiceExt trait can
+        // serve the transport. Since we don't need a custom type here, the unit
+        // type is sufficient.
+        let role = ();
+        let service = role.serve(transport).await.map_err(|e| {
+            anyhow!(
+                "Failed to initialize MCP service for server '{}': {}",
+                self.name,
+                e
+            )
+        })?;
+
+        log::info!("MCP server '{}' initialized successfully", self.name);
+
+        // Get server info
+        let server_info = service.peer_info();
+        log::debug!("Connected to server: {:?}", server_info);
+
+        // Step 3: Discover available tools
+        let mut discovered_tools = Vec::new();
+
+        log::debug!("Listing tools from MCP server '{}'...", self.name);
+
+        match service.list_tools(Default::default()).await {
+            Ok(tools_result) => {
+                log::info!(
+                    "Found {} tools from MCP server '{}'",
+                    tools_result.tools.len(),
+                    self.name
+                );
+
+                // Step 4: Convert tools to FunctionDeclarations
+                for tool in tools_result.tools {
+                    // Convert input_schema to JSON Value
+                    let schema_value = serde_json::to_value(&tool.input_schema)
+                        .unwrap_or_else(|_| serde_json::json!({}));
+
+                    match mcp_tool_to_function(
+                        &self.name,
+                        &tool.name,
+                        &tool.description.unwrap_or_default(),
+                        &schema_value,
+                    ) {
+                        Ok(func_decl) => {
+                            log::debug!("Registered MCP tool: {}", func_decl.name);
+                            discovered_tools.push(func_decl);
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "Failed to convert tool '{}' from server '{}': {}",
+                                tool.name,
+                                self.name,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to list tools from MCP server '{}': {}",
+                    self.name,
+                    e
+                );
+            }
+        }
+
+        // Update internal state
+        *self.tools.write().await = discovered_tools;
+        *self.service.write().await = Some(service);
+        *self.connected.write().await = true;
+
+        log::info!(
+            "Successfully connected to MCP server '{}' with {} tools",
+            self.name,
+            self.tools.read().await.len()
+        );
+
+        Ok(())
+    }
+
+    /// Disconnect from the MCP server
+    pub async fn disconnect(&self) -> Result<()> {
+        if !*self.connected.read().await {
+            return Ok(());
+        }
+
+        log::info!("Disconnecting from MCP server '{}'...", self.name);
+
+        // Gracefully shutdown the service
+        if let Some(service) = self.service.write().await.take() {
+            if let Err(e) = service.cancel().await {
+                log::warn!("Error during shutdown of MCP server '{}': {}", self.name, e);
+            }
+        }
+
+        *self.connected.write().await = false;
+        *self.tools.write().await = Vec::new();
+
+        log::info!("Disconnected from MCP server '{}'", self.name);
+
+        Ok(())
+    }
+
+    /// Get the list of available tools from this server
+    pub async fn get_tools(&self) -> Vec<FunctionDeclaration> {
+        self.tools.read().await.clone()
+    }
+
+    /// Call a tool on this MCP server
+    ///
+    /// # Arguments
+    /// * `tool_name` - The unprefixed tool name (without "mcp_<server>_" prefix)
+    /// * `arguments` - JSON arguments for the tool
+    pub async fn call_tool(&self, tool_name: &str, arguments: Value) -> Result<Value> {
+        if !*self.connected.read().await {
+            bail!("MCP server '{}' is not connected", self.name);
+        }
+
+        log::debug!(
+            "Calling tool '{}' on MCP server '{}' with arguments: {}",
+            tool_name,
+            self.name,
+            arguments
+        );
+
+        // Get the service
+        let service = self.service.read().await;
+        let service = service
+            .as_ref()
+            .ok_or_else(|| anyhow!("MCP service not initialized for server '{}'", self.name))?;
+
+        // Prepare the call tool parameters
+        let arguments_map = if let Value::Object(map) = arguments {
+            Some(map)
+        } else if arguments.is_null() {
+            None
+        } else {
+            return Err(anyhow!(
+                "Tool arguments must be a JSON object or null, got: {}",
+                arguments
+            ));
+        };
+
+        let params = CallToolRequestParam {
+            name: tool_name.to_string().into(),
+            arguments: arguments_map,
+        };
+
+        // Call the tool via MCP protocol
+        let result = service.call_tool(params).await.map_err(|e| {
+            anyhow!(
+                "Failed to call tool '{}' on MCP server '{}': {}",
+                tool_name,
+                self.name,
+                e
+            )
+        })?;
+
+        log::debug!(
+            "Tool '{}' on server '{}' returned successfully",
+            tool_name,
+            self.name
+        );
+
+        // Convert the result to JSON
+        let result_json = serde_json::to_value(&result)
+            .map_err(|e| anyhow!("Failed to serialize tool result: {}", e))?;
+
+        Ok(result_json)
+    }
+}
+
+/// Manager for MCP server connections
+#[derive(Debug)]
+pub struct McpManager {
+    clients: Arc<RwLock<HashMap<String, Arc<McpClient>>>>,
+}
+
+impl McpManager {
+    /// Create a new MCP manager
+    pub fn new() -> Self {
+        Self {
+            clients: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Initialize MCP servers from configurations
+    pub async fn initialize(&self, configs: Vec<McpServerConfig>) -> Result<()> {
+        let mut clients = self.clients.write().await;
+
+        for config in configs {
+            if !config.enabled {
+                continue;
+            }
+
+            let name = config.name.clone();
+            let client = Arc::new(McpClient::new(config));
+            clients.insert(name, client);
+        }
+
+        Ok(())
+    }
+
+    /// Connect to a specific server
+    pub async fn connect(&self, server_name: &str) -> Result<()> {
+        let clients = self.clients.read().await;
+        let client = clients
+            .get(server_name)
+            .ok_or_else(|| anyhow!("MCP server '{}' not found", server_name))?;
+
+        client.connect().await
+    }
+
+    /// Connect to all enabled servers
+    pub async fn connect_all(&self) -> Result<()> {
+        let clients = self.clients.read().await;
+
+        for client in clients.values() {
+            if let Err(e) = client.connect().await {
+                log::warn!("Failed to connect to MCP server '{}': {}", client.name(), e);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Disconnect from a specific server
+    pub async fn disconnect(&self, server_name: &str) -> Result<()> {
+        let clients = self.clients.read().await;
+        let client = clients
+            .get(server_name)
+            .ok_or_else(|| anyhow!("MCP server '{}' not found", server_name))?;
+
+        client.disconnect().await
+    }
+
+    /// Disconnect from all servers
+    pub async fn disconnect_all(&self) -> Result<()> {
+        let clients = self.clients.read().await;
+
+        for client in clients.values() {
+            if let Err(e) = client.disconnect().await {
+                log::warn!(
+                    "Failed to disconnect from MCP server '{}': {}",
+                    client.name(),
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get all available tools from all connected servers
+    pub async fn get_all_tools(&self) -> Vec<FunctionDeclaration> {
+        let clients = self.clients.read().await;
+        let mut tools = Vec::new();
+
+        for client in clients.values() {
+            if client.is_connected().await {
+                tools.extend(client.get_tools().await);
+            }
+        }
+
+        tools
+    }
+
+    /// Get tools from a specific server
+    pub async fn get_server_tools(&self, server_name: &str) -> Result<Vec<FunctionDeclaration>> {
+        let clients = self.clients.read().await;
+        let client = clients
+            .get(server_name)
+            .ok_or_else(|| anyhow!("MCP server '{}' not found", server_name))?;
+
+        Ok(client.get_tools().await)
+    }
+
+    /// Call a tool on the appropriate MCP server
+    ///
+    /// # Arguments
+    /// * `prefixed_name` - The full tool name including "mcp_<server>_" prefix
+    /// * `arguments` - JSON arguments for the tool
+    pub async fn call_tool(&self, prefixed_name: &str, arguments: Value) -> Result<Value> {
+        // Parse the prefixed name to extract server name and tool name
+        let parts: Vec<&str> = prefixed_name
+            .strip_prefix("mcp__")
+            .ok_or_else(|| anyhow!("Invalid MCP tool name: {}", prefixed_name))?
+            .splitn(2, "__")
+            .collect();
+
+        if parts.len() != 2 {
+            bail!("Invalid MCP tool name format: {}", prefixed_name);
+        }
+
+        let server_name = parts[0];
+        let tool_name = parts[1];
+
+        let clients = self.clients.read().await;
+        let client = clients
+            .get(server_name)
+            .ok_or_else(|| anyhow!("MCP server '{}' not found", server_name))?;
+
+        client.call_tool(tool_name, arguments).await
+    }
+
+    /// List all configured servers with their status
+    pub async fn list_servers(&self) -> Vec<(String, bool, Option<String>)> {
+        let clients = self.clients.read().await;
+        let mut servers = Vec::new();
+
+        for (name, client) in clients.iter() {
+            let connected = client.is_connected().await;
+            let description = client.config.description.clone();
+            servers.push((name.clone(), connected, description));
+        }
+
+        servers.sort_by(|a, b| a.0.cmp(&b.0));
+        servers
+    }
+}
+
+impl Default for McpManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/mcp/config.rs
+++ b/src/mcp/config.rs
@@ -1,0 +1,75 @@
+use serde::{Deserialize, Serialize};
+
+/// Configuration for an MCP server
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct McpServerConfig {
+    /// Unique name for this server
+    pub name: String,
+
+    /// Command to execute to start the MCP server
+    pub command: String,
+
+    /// Arguments to pass to the command
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// Environment variables to set for the server process
+    #[serde(default)]
+    pub env: std::collections::HashMap<String, String>,
+
+    /// Whether this server is enabled
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Optional description of what this server provides
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl McpServerConfig {
+    /// Create a new MCP server configuration
+    pub fn new(name: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            command: command.into(),
+            args: vec![],
+            env: Default::default(),
+            enabled: true,
+            description: None,
+        }
+    }
+
+    /// Add an argument to the command
+    pub fn with_arg(mut self, arg: impl Into<String>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Add multiple arguments to the command
+    pub fn with_args(mut self, args: Vec<String>) -> Self {
+        self.args.extend(args);
+        self
+    }
+
+    /// Add an environment variable
+    pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set the description
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set whether the server is enabled
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+}

--- a/src/mcp/config.rs
+++ b/src/mcp/config.rs
@@ -21,6 +21,10 @@ pub struct McpServerConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
 
+    /// Whether this server is trusted (bypasses permission checks)
+    #[serde(default)]
+    pub trusted: bool,
+
     /// Optional description of what this server provides
     #[serde(default)]
     pub description: Option<String>,
@@ -39,6 +43,7 @@ impl McpServerConfig {
             args: vec![],
             env: Default::default(),
             enabled: true,
+            trusted: false,
             description: None,
         }
     }
@@ -70,6 +75,12 @@ impl McpServerConfig {
     /// Set whether the server is enabled
     pub fn with_enabled(mut self, enabled: bool) -> Self {
         self.enabled = enabled;
+        self
+    }
+
+    /// Set whether the server is trusted
+    pub fn with_trusted(mut self, trusted: bool) -> Self {
+        self.trusted = trusted;
         self
     }
 }

--- a/src/mcp/convert.rs
+++ b/src/mcp/convert.rs
@@ -1,0 +1,134 @@
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::function::{FunctionDeclaration, JsonSchema};
+
+/// Convert MCP tool schema to aichat FunctionDeclaration
+pub fn mcp_tool_to_function(
+    server_name: &str,
+    tool_name: &str,
+    tool_description: &str,
+    input_schema: &Value,
+) -> Result<FunctionDeclaration> {
+    // Prefix the tool name with server name to avoid conflicts
+    // Use double underscores around server name as sentinel markers
+    let prefixed_name = format!("mcp__{}__{}", server_name, tool_name);
+
+    // Convert the input schema to our JsonSchema format
+    let parameters = convert_json_schema(input_schema)
+        .with_context(|| format!("Failed to convert schema for tool {}", tool_name))?;
+
+    Ok(FunctionDeclaration {
+        name: prefixed_name,
+        description: tool_description.to_string(),
+        parameters,
+        agent: false,
+    })
+}
+
+/// Convert a JSON Schema object to our JsonSchema type
+fn convert_json_schema(schema: &Value) -> Result<JsonSchema> {
+    let mut json_schema = JsonSchema {
+        type_value: schema
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        description: schema
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        properties: None,
+        items: None,
+        any_of: None,
+        enum_value: None,
+        default: schema.get("default").cloned(),
+        required: None,
+    };
+
+    // Handle properties for object types
+    if let Some(properties) = schema.get("properties").and_then(|v| v.as_object()) {
+        let mut converted_props = indexmap::IndexMap::new();
+        for (key, value) in properties {
+            converted_props.insert(key.clone(), convert_json_schema(value)?);
+        }
+        json_schema.properties = Some(converted_props);
+    }
+
+    // Handle required fields
+    if let Some(required) = schema.get("required").and_then(|v| v.as_array()) {
+        json_schema.required = Some(
+            required
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect(),
+        );
+    }
+
+    // Handle array items
+    if let Some(items) = schema.get("items") {
+        json_schema.items = Some(Box::new(convert_json_schema(items)?));
+    }
+
+    // Handle anyOf
+    if let Some(any_of) = schema.get("anyOf").and_then(|v| v.as_array()) {
+        let mut converted = vec![];
+        for item in any_of {
+            converted.push(convert_json_schema(item)?);
+        }
+        json_schema.any_of = Some(converted);
+    }
+
+    // Handle enum
+    if let Some(enum_values) = schema.get("enum").and_then(|v| v.as_array()) {
+        json_schema.enum_value = Some(
+            enum_values
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect(),
+        );
+    }
+
+    Ok(json_schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_simple_schema_conversion() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name"
+                }
+            },
+            "required": ["name"]
+        });
+
+        let result = convert_json_schema(&schema).unwrap();
+        assert_eq!(result.type_value, Some("object".to_string()));
+        assert!(result.properties.is_some());
+        assert_eq!(result.required, Some(vec!["name".to_string()]));
+    }
+
+    #[test]
+    fn test_mcp_tool_conversion() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File path"
+                }
+            }
+        });
+
+        let func = mcp_tool_to_function("filesystem", "read_file", "Read a file", &schema).unwrap();
+        assert_eq!(func.name, "mcp__filesystem__read_file");
+        assert_eq!(func.description, "Read a file");
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,88 @@
+//! Model Context Protocol (MCP) client implementation
+//!
+//! This module provides MCP client functionality, allowing aichat to connect
+//! to MCP servers and use their tools alongside local functions.
+//!
+//! # Architecture
+//!
+//! - `McpServerConfig`: Configuration for MCP servers (command, args, etc.)
+//! - `McpClient`: Wrapper around a single MCP server connection
+//! - `McpManager`: Manages multiple MCP server connections
+//! - Schema conversion utilities to translate MCP tools to FunctionDeclarations
+//!
+//! # Usage
+//!
+//! MCP servers are configured in the aichat config file:
+//!
+//! ```yaml
+//! mcp_servers:
+//!   - name: filesystem
+//!     command: npx
+//!     args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+//!     enabled: true
+//! ```
+//!
+//! Tools from MCP servers are automatically discovered and prefixed with
+//! `mcp__<server>__<tool>` to avoid name conflicts. Double underscores are
+//! used as sentinel markers around the server name to support server names
+//! that contain underscores.
+
+mod client;
+mod config;
+mod convert;
+
+pub use client::McpManager;
+pub use config::McpServerConfig;
+
+// Re-export for future use when implementing full MCP protocol
+#[allow(unused_imports)]
+use convert::mcp_tool_to_function;
+
+/// Check if a tool name is an MCP tool (starts with "mcp__")
+pub fn is_mcp_tool(name: &str) -> bool {
+    name.starts_with("mcp__")
+}
+
+/// Extract the server name from an MCP tool name
+///
+/// For example, "mcp__filesystem__read_file" -> Some("filesystem")
+/// The format is: mcp__<server_name>__<tool_name>
+pub fn extract_server_name(tool_name: &str) -> Option<String> {
+    let without_prefix = tool_name.strip_prefix("mcp__")?;
+    let end_of_server = without_prefix.find("__")?;
+    Some(without_prefix[..end_of_server].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_mcp_tool() {
+        assert!(is_mcp_tool("mcp__filesystem__read_file"));
+        assert!(is_mcp_tool("mcp__git__log"));
+        assert!(is_mcp_tool("mcp__my_server__tool_name"));
+        assert!(!is_mcp_tool("mcp_filesystem_read_file")); // old format
+        assert!(!is_mcp_tool("read_file"));
+        assert!(!is_mcp_tool("git_log"));
+    }
+
+    #[test]
+    fn test_extract_server_name() {
+        assert_eq!(
+            extract_server_name("mcp__filesystem__read_file"),
+            Some("filesystem".to_string())
+        );
+        assert_eq!(
+            extract_server_name("mcp__git__log"),
+            Some("git".to_string())
+        );
+        // Test server names with underscores
+        assert_eq!(
+            extract_server_name("mcp__my_server__tool_name"),
+            Some("my_server".to_string())
+        );
+        assert_eq!(extract_server_name("read_file"), None);
+        assert_eq!(extract_server_name("mcp_old_format"), None); // old format should fail
+    }
+}


### PR DESCRIPTION
This commit introduces initial support for MCP. It integrates the MCP server tools into the existing function declaration implementation. I still have a couple items to finish on this PR, but I wanted to put up a draft early to get some feedback. I read some of the backlog of issues around MCP, and see that there is some desire from users to have native MCP client support, so I put this PR together. Feel free to close if you don't feel like native MCP client support is something you want to see in aichat proper.

#### Architecture overview

The PR introduces a couple of new types: `McpClient` and `McpManager`. `McpClient` is a wrapper/owner type that owns the corresponding MCP server. This type implements the `rmcp` client traits necessary to call the RPC methods on its peer MCP server process.

`McpManager` is a collection manager owning each instance of `McpClient`. It exposes an API that allows introspecting the tools that are supported by each MCP server and passing tool calls down to the MCP server. As each tool is discovered, it gets translated into a `FunctionDeclaration` so that the MCP tool calling uses a similar logic to the native function calling.

The configuration data structure is updated to declare `mcp_servers` in a YAML array. The REPL has a few new commands to inspect and interact with MCP servers.

Tool calls can be configured to run automatically or via "human in the loop" prompting. To preserve existing function calling behavior, the default permission is "always", however tools can be set to "always", "ask" or "deny" by using simple glob-style pattern matching.

#### TODO

- [ ] Move MCP.md to the wiki and link to it from README.md instead. I just left MCP.md in place because it does contain documentation on how to use the MCP server design.
- [ ] There are some dead code warnings that need to be cleaned up

Fixes: #1346 