### PR TITLE
feat(models): update groq models

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -438,48 +438,103 @@
 #  - https://console.groq.com/docs/api-reference#chat
 - provider: groq
   models:
-    - name: openai/gpt-oss-120b
-      max_input_tokens: 131072
+    - name: allam-2-7b
+      max_input_tokens: 4096
+      max_output_tokens: 4096
       input_price: 0
       output_price: 0
-      supports_function_calling: true
-    - name: openai/gpt-oss-20b
-      max_input_tokens: 131072
+    - name: canopylabs/orpheus-arabic-saudi
+      max_input_tokens: 4000
+      max_output_tokens: 50000
       input_price: 0
       output_price: 0
-      supports_function_calling: true
-    - name: meta-llama/llama-4-maverick-17b-128e-instruct
-      max_input_tokens: 131072
+    - name: canopylabs/orpheus-v1-english
+      max_input_tokens: 4000
+      max_output_tokens: 50000
       input_price: 0
       output_price: 0
-      supports_vision: true
-      supports_function_calling: true
-    - name: meta-llama/llama-4-scout-17b-16e-instruct
+    - name: groq/compound
       max_input_tokens: 131072
+      max_output_tokens: 8192
       input_price: 0
       output_price: 0
-      supports_vision: true
+    - name: groq/compound-mini
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+      input_price: 0
+      output_price: 0
+    - name: llama-3.1-8b-instant
+      max_input_tokens: 131072
+      max_output_tokens: 131072
+      input_price: 0
+      output_price: 0
       supports_function_calling: true
     - name: llama-3.3-70b-versatile
       max_input_tokens: 131072
+      max_output_tokens: 32768
+      input_price: 0
+      output_price: 0
+      supports_function_calling: true
+    - name: meta-llama/llama-4-scout-17b-16e-instruct
+      max_input_tokens: 131072
+      max_output_tokens: 8192
+      input_price: 0
+      output_price: 0
+      supports_vision: true
+      supports_function_calling: true
+    - name: meta-llama/llama-prompt-guard-2-22m
+      max_input_tokens: 512
+      max_output_tokens: 512
+      input_price: 0
+      output_price: 0
+    - name: meta-llama/llama-prompt-guard-2-86m
+      max_input_tokens: 512
+      max_output_tokens: 512
+      input_price: 0
+      output_price: 0
+    - name: moonshotai/kimi-k2-instruct
+      max_input_tokens: 131072
+      max_output_tokens: 16384
       input_price: 0
       output_price: 0
       supports_function_calling: true
     - name: moonshotai/kimi-k2-instruct-0905
       max_input_tokens: 262144
+      max_output_tokens: 16384
+      input_price: 0
+      output_price: 0
+      supports_function_calling: true
+    - name: openai/gpt-oss-120b
+      max_input_tokens: 131072
+      max_output_tokens: 65536
+      input_price: 0
+      output_price: 0
+      supports_function_calling: true
+    - name: openai/gpt-oss-20b
+      max_input_tokens: 131072
+      max_output_tokens: 65536
+      input_price: 0
+      output_price: 0
+      supports_function_calling: true
+    - name: openai/gpt-oss-safeguard-20b
+      max_input_tokens: 131072
+      max_output_tokens: 65536
       input_price: 0
       output_price: 0
       supports_function_calling: true
     - name: qwen/qwen3-32b
       max_input_tokens: 131072
+      max_output_tokens: 40960
       input_price: 0
       output_price: 0
-    - name: groq/compound
-      max_input_tokens: 131072
+    - name: whisper-large-v3
+      max_input_tokens: 448
+      max_output_tokens: 448
       input_price: 0
       output_price: 0
-    - name: groq/compound-mini
-      max_input_tokens: 131072
+    - name: whisper-large-v3-turbo
+      max_input_tokens: 448
+      max_output_tokens: 448
       input_price: 0
       output_price: 0
 


### PR DESCRIPTION
I've updated [Groq's](https://groq.com) models according to latest data from its API.

Added models:
-  allam-2-7b
- canopylabs/orpheus-arabic-saudi
- canopylabs/orpheus-v1-english
- llama-3.1-8b-instant
- meta-llama/llama-prompt-guard-2-22m
- meta-llama/llama-prompt-guard-2-86m
- moonshotai/kimi-k2-instruct
- openai/gpt-oss-safeguard-20b
- whisper-large-v3
- whisper-large-v3-turbo

Removed [deprecated models](https://console.groq.com/docs/deprecations#deprecation-history):
- meta-llama/llama-4-maverick-17b-128e-instruct

Also models were sorted alphabetically.

## Data

```sh
curl https://api.groq.com/openai/v1/models -H "Authorization: Bearer $GROQ_API_KEY"
```
```json
{
  "object": "list",
  "data": [
    {
      "id": "llama-3.1-8b-instant",
      "object": "model",
      "created": 1693721698,
      "owned_by": "Meta",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 131072
    },
    {
      "id": "meta-llama/llama-4-scout-17b-16e-instruct",
      "object": "model",
      "created": 1743874824,
      "owned_by": "Meta",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 8192
    },
    {
      "id": "moonshotai/kimi-k2-instruct",
      "object": "model",
      "created": 1752435491,
      "owned_by": "Moonshot AI",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 16384
    },
    {
      "id": "meta-llama/llama-prompt-guard-2-86m",
      "object": "model",
      "created": 1748632165,
      "owned_by": "Meta",
      "active": true,
      "context_window": 512,
      "public_apps": null,
      "max_completion_tokens": 512
    },
    {
      "id": "groq/compound",
      "object": "model",
      "created": 1756949530,
      "owned_by": "Groq",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 8192
    },
    {
      "id": "llama-3.3-70b-versatile",
      "object": "model",
      "created": 1733447754,
      "owned_by": "Meta",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 32768
    },
    {
      "id": "openai/gpt-oss-20b",
      "object": "model",
      "created": 1754407957,
      "owned_by": "OpenAI",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 65536
    },
    {
      "id": "groq/compound-mini",
      "object": "model",
      "created": 1756949707,
      "owned_by": "Groq",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 8192
    },
    {
      "id": "canopylabs/orpheus-v1-english",
      "object": "model",
      "created": 1766186316,
      "owned_by": "Canopy Labs",
      "active": true,
      "context_window": 4000,
      "public_apps": null,
      "max_completion_tokens": 50000
    },
    {
      "id": "moonshotai/kimi-k2-instruct-0905",
      "object": "model",
      "created": 1757046093,
      "owned_by": "Moonshot AI",
      "active": true,
      "context_window": 262144,
      "public_apps": null,
      "max_completion_tokens": 16384
    },
    {
      "id": "whisper-large-v3",
      "object": "model",
      "created": 1693721698,
      "owned_by": "OpenAI",
      "active": true,
      "context_window": 448,
      "public_apps": null,
      "max_completion_tokens": 448
    },
    {
      "id": "openai/gpt-oss-120b",
      "object": "model",
      "created": 1754408224,
      "owned_by": "OpenAI",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 65536
    },
    {
      "id": "canopylabs/orpheus-arabic-saudi",
      "object": "model",
      "created": 1765926439,
      "owned_by": "Canopy Labs",
      "active": true,
      "context_window": 4000,
      "public_apps": null,
      "max_completion_tokens": 50000
    },
    {
      "id": "openai/gpt-oss-safeguard-20b",
      "object": "model",
      "created": 1761708789,
      "owned_by": "OpenAI",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 65536
    },
    {
      "id": "meta-llama/llama-prompt-guard-2-22m",
      "object": "model",
      "created": 1748632101,
      "owned_by": "Meta",
      "active": true,
      "context_window": 512,
      "public_apps": null,
      "max_completion_tokens": 512
    },
    {
      "id": "qwen/qwen3-32b",
      "object": "model",
      "created": 1748396646,
      "owned_by": "Alibaba Cloud",
      "active": true,
      "context_window": 131072,
      "public_apps": null,
      "max_completion_tokens": 40960
    },
    {
      "id": "allam-2-7b",
      "object": "model",
      "created": 1737672203,
      "owned_by": "SDAIA",
      "active": true,
      "context_window": 4096,
      "public_apps": null,
      "max_completion_tokens": 4096
    },
    {
      "id": "whisper-large-v3-turbo",
      "object": "model",
      "created": 1728413088,
      "owned_by": "OpenAI",
      "active": true,
      "context_window": 448,
      "public_apps": null,
      "max_completion_tokens": 448
    }
  ]
}
```