### PR TITLE
feat: add TLS configuration for custom endpoints

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -115,7 +115,7 @@ clients:
   #     accept_invalid_certs: false                   # Accept self-signed or invalid TLS certificates
   #     ca_cert: /path/to/ca.pem                      # Path to a custom CA certificate (PEM format)
   #     client_cert: /path/to/client-cert.pem         # Path to client certificate for mTLS (PEM format)
-  #     client_key: /path/to/client-key.pem           # Path to client private key for mTLS (PEM format)
+  #     client_key: /path/to/client-key.pem           # Path to client private key for mTLS (PEM format); omit if client_cert contains both
 
   # See https://platform.openai.com/docs/quickstart
   - type: openai

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -112,6 +112,10 @@ clients:
   #   extra:
   #     proxy: socks5://127.0.0.1:1080                # Set proxy
   #     connect_timeout: 10                           # Set timeout in seconds for connect to api
+  #     accept_invalid_certs: false                   # Accept self-signed or invalid TLS certificates
+  #     ca_cert: /path/to/ca.pem                      # Path to a custom CA certificate (PEM format)
+  #     client_cert: /path/to/client-cert.pem         # Path to client certificate for mTLS (PEM format)
+  #     client_key: /path/to/client-key.pem           # Path to client private key for mTLS (PEM format)
 
   # See https://platform.openai.com/docs/quickstart
   - type: openai

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -58,6 +58,29 @@ pub trait Client: Sync + Send {
         if let Some(user_agent) = self.global_config().read().user_agent.as_ref() {
             builder = builder.user_agent(user_agent);
         }
+        if let Some(true) = extra.and_then(|v| v.accept_invalid_certs) {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+        if let Some(ca_cert) = extra.and_then(|v| v.ca_cert.as_deref()) {
+            let cert_data = std::fs::read(ca_cert)
+                .with_context(|| format!("Failed to read CA certificate from '{ca_cert}'"))?;
+            let cert = reqwest::Certificate::from_pem(&cert_data)
+                .with_context(|| format!("Invalid CA certificate in '{ca_cert}'"))?;
+            builder = builder.add_root_certificate(cert);
+        }
+        if let Some(client_cert) = extra.and_then(|v| v.client_cert.as_deref()) {
+            let mut identity_data = std::fs::read(client_cert)
+                .with_context(|| format!("Failed to read client certificate from '{client_cert}'"))?;
+            if let Some(client_key) = extra.and_then(|v| v.client_key.as_deref()) {
+                let key_data = std::fs::read(client_key)
+                    .with_context(|| format!("Failed to read client key from '{client_key}'"))?;
+                identity_data.push(b'\n');
+                identity_data.extend_from_slice(&key_data);
+            }
+            let identity = reqwest::Identity::from_pem(&identity_data)
+                .with_context(|| format!("Invalid client certificate/key from '{client_cert}'"))?;
+            builder = builder.identity(identity);
+        }
         let client = builder
             .connect_timeout(Duration::from_secs(timeout))
             .build()
@@ -201,6 +224,10 @@ impl Default for ClientConfig {
 pub struct ExtraConfig {
     pub proxy: Option<String>,
     pub connect_timeout: Option<u64>,
+    pub accept_invalid_certs: Option<bool>,
+    pub ca_cert: Option<String>,
+    pub client_cert: Option<String>,
+    pub client_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -78,8 +78,10 @@ pub trait Client: Sync + Send {
                 identity_data.extend_from_slice(&key_data);
             }
             let identity = reqwest::Identity::from_pem(&identity_data)
-                .with_context(|| format!("Invalid client certificate/key from '{client_cert}'"))?;
+                .with_context(|| format!("Invalid client certificate/key from '{client_cert}'. If the cert and key are in separate files, ensure 'client_key' is also set."))?;
             builder = builder.identity(identity);
+        } else if extra.and_then(|v| v.client_key.as_deref()).is_some() {
+            warn!("'client_key' is set but 'client_cert' is missing; mTLS identity will not be configured");
         }
         let client = builder
             .connect_timeout(Duration::from_secs(timeout))


### PR DESCRIPTION
## Summary

- Add `ca_cert`, `client_cert`, `client_key`, and `accept_invalid_certs` fields to `ExtraConfig`
- Apply TLS settings in `build_client()` using reqwest's rustls backend
- Enables connecting to OpenAI-compatible endpoints behind corporate CAs or requiring mTLS authentication

## Configuration

```yaml
clients:
  - type: openai-compatible
    name: my-internal-llm
    api_base: https://llm.corp.internal/v1
    api_key: xxx
    extra:
      ca_cert: /path/to/ca.pem
      client_cert: /path/to/client-cert.pem
      client_key: /path/to/client-key.pem
      accept_invalid_certs: false
```

Related issues:

- https://github.com/sigoden/aichat/issues/1330
- https://github.com/sigoden/aichat/issues/1381
- https://github.com/sigoden/aichat/issues/1228
