### PR TITLE
Support claude code style hooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ reedline = "0.40.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.93", features = ["preserve_order"] }
 serde_yaml = "0.9.17"
-tokio = { version = "1.34.0", features = ["rt", "time", "macros", "signal", "rt-multi-thread"] }
+tokio = { version = "1.34.0", features = ["rt", "time", "macros", "signal", "rt-multi-thread", "io-util", "process"] }
 tokio-graceful = "0.2.2"
 tokio-stream = { version = "0.1.15", default-features = false, features = ["sync"] }
 crossterm = "0.28.1"

--- a/config.agent.example.yaml
+++ b/config.agent.example.yaml
@@ -15,4 +15,5 @@ variables:                       # Custom default values for the agent variables
 #   max_resume: 3                 # Agent-specific limit
 #   entries:
 #   - event: Stop                 # Fire after LLM responds
+#     type: claude-command         # Hook type (required)
 #     command: "/path/to/agent-hook.sh"

--- a/config.agent.example.yaml
+++ b/config.agent.example.yaml
@@ -9,3 +9,10 @@ agent_prelude: null              # Set a session to use when starting the agent.
 instructions: null               # Override the instructions for the agent, have no effect for dynamic instructions
 variables:                       # Custom default values for the agent variables
   <key>: <value>
+
+# ---- hooks ----
+# hooks:                          # Per-agent hooks (merged with global)
+#   max_auto_continue: 3          # Agent-specific limit
+#   entries:
+#   - event: Stop                 # Fire after LLM responds
+#     command: "/path/to/agent-hook.sh"

--- a/config.agent.example.yaml
+++ b/config.agent.example.yaml
@@ -12,7 +12,7 @@ variables:                       # Custom default values for the agent variables
 
 # ---- hooks ----
 # hooks:                          # Per-agent hooks (merged with global)
-#   max_auto_continue: 3          # Agent-specific limit
+#   max_resume: 3                 # Agent-specific limit
 #   entries:
 #   - event: Stop                 # Fire after LLM responds
 #     command: "/path/to/agent-hook.sh"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -327,5 +327,10 @@ clients:
 #   - event: PreToolUse               # Fire before tool execution
 #     matcher: "execute_command"      # Regex to match tool_name
 #     command: "echo 'blocked' >&2; exit 2"  # Exit 2 = block
+#   - event: PostToolUse              # Fire after tool execution
+#     matcher: "Write|Edit"          # Match file-editing tools
+#     command: "/path/to/run-tests.sh"
+#     async: true                     # Run in background without blocking
+#     timeout: 120                    # Longer timeout for async hooks
 #   - event: SessionStart             # Fire at session start
 #     command: "echo 'Session started'"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -334,6 +334,10 @@ clients:
 #     command: "/path/to/run-tests.sh"
 #     async: true                     # Run in background without blocking
 #     timeout: 120                    # Longer timeout for async hooks
+#   - event: Stop                     # Fire after LLM responds
+#     type: claude-command-persistent  # Long-running JSONL hook process
+#     command: "/path/to/persistent-hook.sh"
+#     timeout: 30                     # Timeout per event (default: 30)
 #   - event: SessionStart             # Fire at session start
 #     type: claude-command
 #     command: "echo 'Session started'"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -321,16 +321,19 @@ clients:
 #   max_resume: 5                     # Max resume turns (default: 5)
 #   entries:
 #   - event: Stop                     # Fire after LLM responds
+#     type: claude-command            # Hook type (required)
 #     command: "/path/to/hook.sh"     # Shell command to execute
 #     timeout: 30                     # Timeout in seconds (default: 30)
-#     protocol: claude-code           # Protocol (default: claude-code)
 #   - event: PreToolUse               # Fire before tool execution
+#     type: claude-command
 #     matcher: "execute_command"      # Regex to match tool_name
 #     command: "echo 'blocked' >&2; exit 2"  # Exit 2 = block
 #   - event: PostToolUse              # Fire after tool execution
+#     type: claude-command
 #     matcher: "Write|Edit"          # Match file-editing tools
 #     command: "/path/to/run-tests.sh"
 #     async: true                     # Run in background without blocking
 #     timeout: 120                    # Longer timeout for async hooks
 #   - event: SessionStart             # Fire at session start
+#     type: claude-command
 #     command: "echo 'Session started'"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -324,10 +324,10 @@ clients:
 #     type: claude-command            # Hook type (required)
 #     command: "/path/to/hook.sh"     # Shell command to execute
 #     timeout: 30                     # Timeout in seconds (default: 30)
-#   - event: PreToolUse               # Fire before tool execution
+#   - event: PreToolUse               # Block access to sensitive files
 #     type: claude-command
-#     matcher: "execute_command"      # Regex to match tool_name
-#     command: "echo 'blocked' >&2; exit 2"  # Exit 2 = block
+#     matcher: "fs_cat|fs_write|fs_patch|fs_rm|execute_command"
+#     command: "grep -q /etc/passwd && echo 'Blocked: sensitive file' >&2 && exit 2; true"
 #   - event: PostToolUse              # Fire after tool execution
 #     type: claude-command
 #     matcher: "Write|Edit"          # Match file-editing tools

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -318,7 +318,7 @@ clients:
 
 # ---- hooks ----
 # hooks:                              # Hook configuration (Claude Code compatible)
-#   max_auto_continue: 5              # Max auto-continue turns (default: 5)
+#   max_resume: 5                     # Max resume turns (default: 5)
 #   entries:
 #   - event: Stop                     # Fire after LLM responds
 #     command: "/path/to/hook.sh"     # Shell command to execute

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -315,3 +315,17 @@ clients:
     name: voyageai
     api_base: https://api.voyageai.com/v1
     api_key: xxx
+
+# ---- hooks ----
+# hooks:                              # Hook configuration (Claude Code compatible)
+#   max_auto_continue: 5              # Max auto-continue turns (default: 5)
+#   entries:
+#   - event: Stop                     # Fire after LLM responds
+#     command: "/path/to/hook.sh"     # Shell command to execute
+#     timeout: 30                     # Timeout in seconds (default: 30)
+#     protocol: claude-code           # Protocol (default: claude-code)
+#   - event: PreToolUse               # Fire before tool execution
+#     matcher: "execute_command"      # Regex to match tool_name
+#     command: "echo 'blocked' >&2; exit 2"  # Exit 2 = block
+#   - event: SessionStart             # Fire at session start
+#     command: "echo 'Session started'"

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -215,6 +215,10 @@ impl Agent {
         &self.name
     }
 
+    pub fn config(&self) -> &AgentConfig {
+        &self.config
+    }
+
     pub fn functions(&self) -> &Functions {
         &self.functions
     }
@@ -382,6 +386,9 @@ pub struct AgentConfig {
     pub instructions: Option<String>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub variables: AgentVariables,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hooks: Option<HooksConfig>,
 }
 
 impl AgentConfig {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2507,7 +2507,9 @@ pub async fn macro_execute(
     let config = Arc::new(RwLock::new(config));
     config.write().macro_flag = true;
     let mut async_manager = AsyncHookManager::new();
-    let persistent_manager = std::sync::Arc::new(tokio::sync::Mutex::new(crate::hooks::PersistentHookManager::new()));
+    let persistent_manager = std::sync::Arc::new(tokio::sync::Mutex::new(
+        crate::hooks::PersistentHookManager::new(),
+    ));
     let mut pending_async_context = None;
     for step in &macro_value.steps {
         let command = Macro::interpolate_command(step, &variables);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,7 +15,7 @@ use crate::client::{
     Model, ModelType, ProviderModels, OPENAI_COMPATIBLE_PROVIDERS,
 };
 use crate::function::{FunctionDeclaration, Functions, ToolResult};
-use crate::hooks::HooksConfig;
+use crate::hooks::{AsyncHookManager, HooksConfig};
 use crate::rag::Rag;
 use crate::render::{MarkdownRender, RenderOptions};
 use crate::repl::{run_repl_command, split_args_text};
@@ -2506,10 +2506,19 @@ pub async fn macro_execute(
     config.discontinuous_last_message();
     let config = Arc::new(RwLock::new(config));
     config.write().macro_flag = true;
+    let mut async_manager = AsyncHookManager::new();
+    let mut pending_async_context = None;
     for step in &macro_value.steps {
         let command = Macro::interpolate_command(step, &variables);
         println!(">> {}", multiline_text(&command));
-        run_repl_command(&config, abort_signal.clone(), &command).await?;
+        run_repl_command(
+            &config,
+            abort_signal.clone(),
+            &command,
+            &mut async_manager,
+            &mut pending_async_context,
+        )
+        .await?;
     }
     Ok(())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@ use crate::client::{
     Model, ModelType, ProviderModels, OPENAI_COMPATIBLE_PROVIDERS,
 };
 use crate::function::{FunctionDeclaration, Functions, ToolResult};
+use crate::hooks::HooksConfig;
 use crate::rag::Rag;
 use crate::render::{MarkdownRender, RenderOptions};
 use crate::repl::{run_repl_command, split_args_text};
@@ -148,6 +149,10 @@ pub struct Config {
 
     pub clients: Vec<ClientConfig>,
 
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hooks: Option<HooksConfig>,
+
     #[serde(skip)]
     pub macro_flag: bool,
     #[serde(skip)]
@@ -222,6 +227,8 @@ impl Default for Config {
             sync_models_url: None,
 
             clients: vec![],
+
+            hooks: None,
 
             macro_flag: false,
             info_flag: false,
@@ -542,6 +549,16 @@ impl Config {
         }
     }
 
+    pub fn resolved_hooks(&self) -> HooksConfig {
+        let global = self.hooks.clone().unwrap_or_default();
+        if let Some(agent) = &self.agent {
+            if let Some(agent_hooks) = &agent.config().hooks {
+                return HooksConfig::merge(&global, agent_hooks);
+            }
+        }
+        global
+    }
+
     pub fn info(&self) -> Result<String> {
         if let Some(agent) = &self.agent {
             let output = agent.export()?;
@@ -615,6 +632,9 @@ impl Config {
             ("functions_dir", display_path(&Self::functions_dir())),
             ("messages_file", display_path(&self.messages_file())),
         ];
+        if let Some(hooks) = &self.hooks {
+            items.push(("hooks", hooks.entries.len().to_string()));
+        }
         if let Ok((_, Some(log_path))) = Self::log_config(self.working_mode.is_serve()) {
             items.push(("log_path", display_path(&log_path)));
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2507,6 +2507,7 @@ pub async fn macro_execute(
     let config = Arc::new(RwLock::new(config));
     config.write().macro_flag = true;
     let mut async_manager = AsyncHookManager::new();
+    let persistent_manager = std::sync::Arc::new(tokio::sync::Mutex::new(crate::hooks::PersistentHookManager::new()));
     let mut pending_async_context = None;
     for step in &macro_value.steps {
         let command = Macro::interpolate_command(step, &variables);
@@ -2516,10 +2517,12 @@ pub async fn macro_execute(
             abort_signal.clone(),
             &command,
             &mut async_manager,
+            &persistent_manager,
             &mut pending_async_context,
         )
         .await?;
     }
+    persistent_manager.lock().await.shutdown();
     Ok(())
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::{Agent, Config, GlobalConfig},
+    hooks::{dispatch::dispatch_hooks, HookEvent, HookResultControl},
     utils::*,
 };
 
@@ -12,6 +13,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use tokio::runtime::Handle;
 
 #[cfg(windows)]
 const PATH_SEP: &str = ";";
@@ -27,15 +29,79 @@ pub fn eval_tool_calls(config: &GlobalConfig, mut calls: Vec<ToolCall>) -> Resul
     if calls.is_empty() {
         bail!("The request was aborted because an infinite loop of function calls was detected.")
     }
+
+    let hooks = config.read().resolved_hooks();
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let session_id = "cmd".to_string();
+
     let mut is_all_null = true;
     for call in calls {
-        let mut result = call.eval(config)?;
-        if result.is_null() {
-            result = json!("DONE");
-        } else {
+        let tool_input = call.arguments.clone();
+        let tool_use_id = call.id.clone().unwrap_or_default();
+
+        let pre_event = HookEvent::PreToolUse {
+            tool_name: call.name.clone(),
+            tool_input: tool_input.clone(),
+            tool_use_id: tool_use_id.clone(),
+        };
+        let pre_outcome = tokio::task::block_in_place(|| {
+            Handle::current().block_on(dispatch_hooks(
+                &pre_event,
+                &hooks.entries,
+                &session_id,
+                &cwd,
+            ))
+        });
+        if let HookResultControl::Block { reason } = pre_outcome.control {
+            let blocked_result = json!({"error": reason, "blocked_by_hook": true});
+            output.push(ToolResult::new(call, blocked_result));
             is_all_null = false;
+            continue;
         }
-        output.push(ToolResult::new(call, result));
+
+        match call.eval(config) {
+            Ok(mut result) => {
+                let post_event = HookEvent::PostToolUse {
+                    tool_name: call.name.clone(),
+                    tool_input: tool_input.clone(),
+                    tool_response: result.clone(),
+                    tool_use_id: tool_use_id.clone(),
+                };
+                let _ = tokio::task::block_in_place(|| {
+                    Handle::current().block_on(dispatch_hooks(
+                        &post_event,
+                        &hooks.entries,
+                        &session_id,
+                        &cwd,
+                    ))
+                });
+
+                if result.is_null() {
+                    result = json!("DONE");
+                } else {
+                    is_all_null = false;
+                }
+                output.push(ToolResult::new(call, result));
+            }
+            Err(err) => {
+                let fail_event = HookEvent::PostToolUseFailure {
+                    tool_name: call.name.clone(),
+                    tool_input: tool_input.clone(),
+                    tool_use_id: tool_use_id.clone(),
+                    error: err.to_string(),
+                };
+                let _ = tokio::task::block_in_place(|| {
+                    Handle::current().block_on(dispatch_hooks(
+                        &fail_event,
+                        &hooks.entries,
+                        &session_id,
+                        &cwd,
+                    ))
+                });
+
+                return Err(err);
+            }
+        }
     }
     if is_all_null {
         output = vec![];

--- a/src/hooks/async_manager.rs
+++ b/src/hooks/async_manager.rs
@@ -1,0 +1,121 @@
+use crate::hooks::{executor::execute_command_hook, HookPayload, HookResult};
+
+use tokio::sync::mpsc;
+
+pub struct AsyncHookManager {
+    sender: mpsc::UnboundedSender<HookResult>,
+    receiver: mpsc::UnboundedReceiver<HookResult>,
+}
+
+impl AsyncHookManager {
+    pub fn new() -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        Self { sender, receiver }
+    }
+
+    pub fn spawn_hook(&self, payload: HookPayload, command: String, timeout: Option<u64>) {
+        let sender = self.sender.clone();
+        tokio::spawn(async move {
+            let outcome = execute_command_hook(&payload, &command, timeout).await;
+            let _ = sender.send(outcome.result);
+        });
+    }
+
+    pub fn drain_pending(&mut self) -> Option<HookResult> {
+        let mut contexts = vec![];
+        let mut resume = false;
+
+        loop {
+            match self.receiver.try_recv() {
+                Ok(result) => {
+                    if let Some(ctx) = result.additional_context.filter(|s| !s.is_empty()) {
+                        contexts.push(ctx);
+                    }
+                    if let Some(msg) = result.system_message.filter(|s| !s.is_empty()) {
+                        contexts.push(msg);
+                    }
+                    resume |= result.resume.unwrap_or(false);
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => break,
+            }
+        }
+
+        if contexts.is_empty() && !resume {
+            None
+        } else {
+            Some(HookResult {
+                additional_context: (!contexts.is_empty()).then(|| contexts.join("\n")),
+                resume: resume.then_some(true),
+                ..HookResult::default()
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AsyncHookManager;
+    use crate::hooks::{HookEvent, HookPayload};
+    use serde_json::json;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::time::{sleep, Duration};
+
+    fn test_payload(cwd: &Path) -> HookPayload {
+        HookPayload {
+            session_id: "session-123".to_string(),
+            cwd: cwd.to_path_buf(),
+            resume_count: 0,
+            hook_event: HookEvent::PreToolUse {
+                tool_name: "shell".to_string(),
+                tool_input: json!({"command": "pwd"}),
+                tool_use_id: "call-1".to_string(),
+            },
+        }
+    }
+
+    fn temp_test_dir(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("aichat-async-hook-tests-{name}-{suffix}"));
+        fs::create_dir_all(&dir).expect("create temp test dir");
+        dir
+    }
+
+    #[cfg(unix)]
+    fn echo_command() -> &'static str {
+        "echo 'async hook complete'"
+    }
+
+    #[cfg(windows)]
+    fn echo_command() -> &'static str {
+        "echo async hook complete"
+    }
+
+    #[tokio::test]
+    async fn test_async_manager_spawn_and_drain() {
+        let cwd = temp_test_dir("spawn-and-drain");
+        let payload = test_payload(&cwd);
+        let mut manager = AsyncHookManager::new();
+
+        manager.spawn_hook(payload, echo_command().to_string(), Some(5));
+        sleep(Duration::from_millis(150)).await;
+
+        let drained = manager.drain_pending().expect("expected async hook result");
+        assert_eq!(
+            drained.additional_context.as_deref(),
+            Some("async hook complete")
+        );
+        assert!(drained.resume.is_none());
+    }
+
+    #[test]
+    fn test_async_manager_drain_empty() {
+        let mut manager = AsyncHookManager::new();
+        assert!(manager.drain_pending().is_none());
+    }
+}

--- a/src/hooks/async_manager.rs
+++ b/src/hooks/async_manager.rs
@@ -1,3 +1,4 @@
+use crate::config::Input;
 use crate::hooks::{executor::execute_command_hook, HookPayload, HookResult};
 
 use tokio::sync::mpsc;
@@ -51,6 +52,51 @@ impl AsyncHookManager {
             })
         }
     }
+}
+
+pub fn append_pending_context(pending_async_context: &mut Option<String>, context: String) {
+    if context.is_empty() {
+        return;
+    }
+
+    match pending_async_context {
+        Some(existing) if !existing.is_empty() => {
+            existing.push_str("\n\n");
+            existing.push_str(&context);
+        }
+        _ => *pending_async_context = Some(context),
+    }
+}
+
+pub fn drain_async_results(
+    async_manager: &mut AsyncHookManager,
+    pending_async_context: &mut Option<String>,
+) -> bool {
+    let mut resume = false;
+    if let Some(pending) = async_manager.drain_pending() {
+        if let Some(context) = pending.additional_context.filter(|value| !value.is_empty()) {
+            append_pending_context(pending_async_context, context);
+        }
+        resume = pending.resume.unwrap_or(false);
+    }
+    resume
+}
+
+pub fn inject_pending_async_context(input: &mut Input, pending_async_context: &mut Option<String>) {
+    let Some(context) = pending_async_context
+        .take()
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+
+    let input_text = input.text();
+    input.clear_patch();
+    input.set_text(if input_text.is_empty() {
+        context
+    } else {
+        format!("{context}\n\n{input_text}")
+    });
 }
 
 #[cfg(test)]

--- a/src/hooks/config.rs
+++ b/src/hooks/config.rs
@@ -39,7 +39,10 @@ pub struct HookConfig {
 impl HookConfig {
     /// Check if the hook type is supported
     pub fn is_supported_type(&self) -> bool {
-        self.hook_type == "claude-command"
+        matches!(
+            self.hook_type.as_str(),
+            "claude-command" | "claude-command-persistent"
+        )
     }
 }
 
@@ -251,6 +254,17 @@ entries:
             hook_type: "claude-command".to_string(),
         };
         assert!(hook2.is_supported_type());
+
+        let hook_persistent = HookConfig {
+            event: "Stop".to_string(),
+            matcher: None,
+            command: "test.sh".to_string(),
+            timeout: Some(30),
+            status_message: None,
+            async_hook: None,
+            hook_type: "claude-command-persistent".to_string(),
+        };
+        assert!(hook_persistent.is_supported_type());
 
         // Unknown type should be invalid
         let hook3 = HookConfig {

--- a/src/hooks/config.rs
+++ b/src/hooks/config.rs
@@ -46,9 +46,9 @@ impl HookConfig {
 /// Configuration for all hooks (global or per-agent)
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct HooksConfig {
-    /// Maximum number of auto-continue iterations
+    /// Maximum number of resume iterations
     #[serde(default)]
-    pub max_auto_continue: Option<u32>,
+    pub max_resume: Option<u32>,
 
     /// List of hook entries
     #[serde(default)]
@@ -61,7 +61,7 @@ impl HooksConfig {
     /// Rules:
     /// - Agent entries extend global entries (both lists are combined)
     /// - If agent and global have entries with the same `event` AND same `matcher`, agent takes priority (replaces)
-    /// - `max_auto_continue`: agent value overrides global if agent value is Some
+    /// - `max_resume`: agent value overrides global if agent value is Some
     pub fn merge(global: &HooksConfig, agent: &HooksConfig) -> HooksConfig {
         // Start with global entries
         let mut merged_entries = global.entries.clone();
@@ -81,11 +81,11 @@ impl HooksConfig {
             }
         }
 
-        // Determine max_auto_continue: agent overrides global if Some
-        let max_auto_continue = agent.max_auto_continue.or(global.max_auto_continue);
+        // Determine max_resume: agent overrides global if Some
+        let max_resume = agent.max_resume.or(global.max_resume);
 
         HooksConfig {
-            max_auto_continue,
+            max_resume,
             entries: merged_entries,
         }
     }
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn test_hooks_config_parse() {
         let yaml = r#"
-max_auto_continue: 3
+max_resume: 3
 entries:
   - event: Stop
     command: "/path/to/hook.sh"
@@ -108,7 +108,7 @@ entries:
 
         let config: HooksConfig = serde_yaml::from_str(yaml).expect("parse hooks config");
 
-        assert_eq!(config.max_auto_continue, Some(3));
+        assert_eq!(config.max_resume, Some(3));
         assert_eq!(config.entries.len(), 1);
 
         let entry = &config.entries[0];
@@ -123,7 +123,7 @@ entries:
     #[test]
     fn test_hooks_config_merge() {
         let global = HooksConfig {
-            max_auto_continue: Some(5),
+            max_resume: Some(5),
             entries: vec![
                 HookConfig {
                     event: "Stop".to_string(),
@@ -145,7 +145,7 @@ entries:
         };
 
         let agent = HooksConfig {
-            max_auto_continue: Some(3),
+            max_resume: Some(3),
             entries: vec![HookConfig {
                 event: "PreToolUse".to_string(),
                 matcher: Some("shell".to_string()),
@@ -158,8 +158,8 @@ entries:
 
         let merged = HooksConfig::merge(&global, &agent);
 
-        // Agent max_auto_continue should win
-        assert_eq!(merged.max_auto_continue, Some(3));
+        // Agent max_resume should win
+        assert_eq!(merged.max_resume, Some(3));
 
         // Should have 3 entries: 2 from global + 1 from agent
         assert_eq!(merged.entries.len(), 3);
@@ -174,7 +174,7 @@ entries:
     #[test]
     fn test_hooks_config_merge_conflict() {
         let global = HooksConfig {
-            max_auto_continue: Some(5),
+            max_resume: Some(5),
             entries: vec![HookConfig {
                 event: "PreToolUse".to_string(),
                 matcher: Some("shell".to_string()),
@@ -186,7 +186,7 @@ entries:
         };
 
         let agent = HooksConfig {
-            max_auto_continue: None,
+            max_resume: None,
             entries: vec![HookConfig {
                 event: "PreToolUse".to_string(),
                 matcher: Some("shell".to_string()),
@@ -199,8 +199,8 @@ entries:
 
         let merged = HooksConfig::merge(&global, &agent);
 
-        // Global max_auto_continue should be used (agent is None)
-        assert_eq!(merged.max_auto_continue, Some(5));
+        // Global max_resume should be used (agent is None)
+        assert_eq!(merged.max_resume, Some(5));
 
         // Should have only 1 entry (agent replaced global)
         assert_eq!(merged.entries.len(), 1);
@@ -215,7 +215,7 @@ entries:
     fn test_hooks_config_default() {
         let config = HooksConfig::default();
 
-        assert!(config.max_auto_continue.is_none());
+        assert!(config.max_resume.is_none());
         assert!(config.entries.is_empty());
     }
 

--- a/src/hooks/config.rs
+++ b/src/hooks/config.rs
@@ -1,0 +1,257 @@
+use serde::{Deserialize, Serialize};
+
+/// Default timeout for hook execution in seconds
+fn default_timeout() -> Option<u64> {
+    Some(30)
+}
+
+/// Configuration for a single hook entry
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HookConfig {
+    /// Hook event name (e.g., "PreToolUse", "Stop")
+    pub event: String,
+
+    /// Optional regex pattern to match against tool_name (for tool-bearing events)
+    #[serde(default)]
+    pub matcher: Option<String>,
+
+    /// Shell command to execute
+    pub command: String,
+
+    /// Timeout in seconds (default 30)
+    #[serde(default = "default_timeout")]
+    pub timeout: Option<u64>,
+
+    /// Optional status message to display
+    #[serde(default)]
+    pub status_message: Option<String>,
+
+    /// Protocol version (default "claude-code")
+    #[serde(default)]
+    pub protocol: Option<String>,
+}
+
+impl HookConfig {
+    /// Check if the protocol is valid
+    /// Returns true if protocol is None (defaults to "claude-code") or explicitly "claude-code"
+    /// Returns false for unknown protocols
+    pub fn is_valid_protocol(&self) -> bool {
+        match &self.protocol {
+            None => true, // Defaults to "claude-code"
+            Some(p) => p == "claude-code",
+        }
+    }
+}
+
+/// Configuration for all hooks (global or per-agent)
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct HooksConfig {
+    /// Maximum number of auto-continue iterations
+    #[serde(default)]
+    pub max_auto_continue: Option<u32>,
+
+    /// List of hook entries
+    #[serde(default)]
+    pub entries: Vec<HookConfig>,
+}
+
+impl HooksConfig {
+    /// Merge global and agent hooks
+    ///
+    /// Rules:
+    /// - Agent entries extend global entries (both lists are combined)
+    /// - If agent and global have entries with the same `event` AND same `matcher`, agent takes priority (replaces)
+    /// - `max_auto_continue`: agent value overrides global if agent value is Some
+    pub fn merge(global: &HooksConfig, agent: &HooksConfig) -> HooksConfig {
+        // Start with global entries
+        let mut merged_entries = global.entries.clone();
+
+        // Process agent entries
+        for agent_entry in &agent.entries {
+            // Check if there's a matching entry in global (same event and matcher)
+            if let Some(pos) = merged_entries
+                .iter()
+                .position(|e| e.event == agent_entry.event && e.matcher == agent_entry.matcher)
+            {
+                // Replace the global entry with the agent entry
+                merged_entries[pos] = agent_entry.clone();
+            } else {
+                // No conflict, add the agent entry
+                merged_entries.push(agent_entry.clone());
+            }
+        }
+
+        // Determine max_auto_continue: agent overrides global if Some
+        let max_auto_continue = agent.max_auto_continue.or(global.max_auto_continue);
+
+        HooksConfig {
+            max_auto_continue,
+            entries: merged_entries,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hooks_config_parse() {
+        let yaml = r#"
+max_auto_continue: 3
+entries:
+  - event: Stop
+    command: "/path/to/hook.sh"
+    timeout: 10
+    protocol: claude-code
+"#;
+
+        let config: HooksConfig = serde_yaml::from_str(yaml).expect("parse hooks config");
+
+        assert_eq!(config.max_auto_continue, Some(3));
+        assert_eq!(config.entries.len(), 1);
+
+        let entry = &config.entries[0];
+        assert_eq!(entry.event, "Stop");
+        assert_eq!(entry.command, "/path/to/hook.sh");
+        assert_eq!(entry.timeout, Some(10));
+        assert_eq!(entry.protocol, Some("claude-code".to_string()));
+        assert!(entry.matcher.is_none());
+        assert!(entry.status_message.is_none());
+    }
+
+    #[test]
+    fn test_hooks_config_merge() {
+        let global = HooksConfig {
+            max_auto_continue: Some(5),
+            entries: vec![
+                HookConfig {
+                    event: "Stop".to_string(),
+                    matcher: None,
+                    command: "global-stop.sh".to_string(),
+                    timeout: Some(30),
+                    status_message: None,
+                    protocol: None,
+                },
+                HookConfig {
+                    event: "SessionStart".to_string(),
+                    matcher: None,
+                    command: "global-start.sh".to_string(),
+                    timeout: Some(30),
+                    status_message: None,
+                    protocol: None,
+                },
+            ],
+        };
+
+        let agent = HooksConfig {
+            max_auto_continue: Some(3),
+            entries: vec![HookConfig {
+                event: "PreToolUse".to_string(),
+                matcher: Some("shell".to_string()),
+                command: "agent-tool.sh".to_string(),
+                timeout: Some(15),
+                status_message: None,
+                protocol: None,
+            }],
+        };
+
+        let merged = HooksConfig::merge(&global, &agent);
+
+        // Agent max_auto_continue should win
+        assert_eq!(merged.max_auto_continue, Some(3));
+
+        // Should have 3 entries: 2 from global + 1 from agent
+        assert_eq!(merged.entries.len(), 3);
+
+        // Check that all events are present
+        let events: Vec<&str> = merged.entries.iter().map(|e| e.event.as_str()).collect();
+        assert!(events.contains(&"Stop"));
+        assert!(events.contains(&"SessionStart"));
+        assert!(events.contains(&"PreToolUse"));
+    }
+
+    #[test]
+    fn test_hooks_config_merge_conflict() {
+        let global = HooksConfig {
+            max_auto_continue: Some(5),
+            entries: vec![HookConfig {
+                event: "PreToolUse".to_string(),
+                matcher: Some("shell".to_string()),
+                command: "global-shell.sh".to_string(),
+                timeout: Some(30),
+                status_message: None,
+                protocol: None,
+            }],
+        };
+
+        let agent = HooksConfig {
+            max_auto_continue: None,
+            entries: vec![HookConfig {
+                event: "PreToolUse".to_string(),
+                matcher: Some("shell".to_string()),
+                command: "agent-shell.sh".to_string(),
+                timeout: Some(10),
+                status_message: Some("Agent override".to_string()),
+                protocol: Some("claude-code".to_string()),
+            }],
+        };
+
+        let merged = HooksConfig::merge(&global, &agent);
+
+        // Global max_auto_continue should be used (agent is None)
+        assert_eq!(merged.max_auto_continue, Some(5));
+
+        // Should have only 1 entry (agent replaced global)
+        assert_eq!(merged.entries.len(), 1);
+
+        let entry = &merged.entries[0];
+        assert_eq!(entry.command, "agent-shell.sh");
+        assert_eq!(entry.timeout, Some(10));
+        assert_eq!(entry.status_message, Some("Agent override".to_string()));
+    }
+
+    #[test]
+    fn test_hooks_config_default() {
+        let config = HooksConfig::default();
+
+        assert!(config.max_auto_continue.is_none());
+        assert!(config.entries.is_empty());
+    }
+
+    #[test]
+    fn test_valid_protocol() {
+        // None should be valid (defaults to "claude-code")
+        let hook1 = HookConfig {
+            event: "Stop".to_string(),
+            matcher: None,
+            command: "test.sh".to_string(),
+            timeout: Some(30),
+            status_message: None,
+            protocol: None,
+        };
+        assert!(hook1.is_valid_protocol());
+
+        // "claude-code" should be valid
+        let hook2 = HookConfig {
+            event: "Stop".to_string(),
+            matcher: None,
+            command: "test.sh".to_string(),
+            timeout: Some(30),
+            status_message: None,
+            protocol: Some("claude-code".to_string()),
+        };
+        assert!(hook2.is_valid_protocol());
+
+        // Unknown protocol should be invalid
+        let hook3 = HookConfig {
+            event: "Stop".to_string(),
+            matcher: None,
+            command: "test.sh".to_string(),
+            timeout: Some(30),
+            status_message: None,
+            protocol: Some("future-v2".to_string()),
+        };
+        assert!(!hook3.is_valid_protocol());
+    }
+}

--- a/src/hooks/config.rs
+++ b/src/hooks/config.rs
@@ -26,6 +26,9 @@ pub struct HookConfig {
     #[serde(default)]
     pub status_message: Option<String>,
 
+    #[serde(default, rename = "async")]
+    pub async_hook: Option<bool>,
+
     /// Protocol version (default "claude-code")
     #[serde(default)]
     pub protocol: Option<String>,
@@ -102,6 +105,7 @@ max_resume: 3
 entries:
   - event: Stop
     command: "/path/to/hook.sh"
+    async: true
     timeout: 10
     protocol: claude-code
 "#;
@@ -118,6 +122,7 @@ entries:
         assert_eq!(entry.protocol, Some("claude-code".to_string()));
         assert!(entry.matcher.is_none());
         assert!(entry.status_message.is_none());
+        assert_eq!(entry.async_hook, Some(true));
     }
 
     #[test]
@@ -131,6 +136,7 @@ entries:
                     command: "global-stop.sh".to_string(),
                     timeout: Some(30),
                     status_message: None,
+                    async_hook: None,
                     protocol: None,
                 },
                 HookConfig {
@@ -139,6 +145,7 @@ entries:
                     command: "global-start.sh".to_string(),
                     timeout: Some(30),
                     status_message: None,
+                    async_hook: None,
                     protocol: None,
                 },
             ],
@@ -152,6 +159,7 @@ entries:
                 command: "agent-tool.sh".to_string(),
                 timeout: Some(15),
                 status_message: None,
+                async_hook: None,
                 protocol: None,
             }],
         };
@@ -181,6 +189,7 @@ entries:
                 command: "global-shell.sh".to_string(),
                 timeout: Some(30),
                 status_message: None,
+                async_hook: None,
                 protocol: None,
             }],
         };
@@ -193,6 +202,7 @@ entries:
                 command: "agent-shell.sh".to_string(),
                 timeout: Some(10),
                 status_message: Some("Agent override".to_string()),
+                async_hook: None,
                 protocol: Some("claude-code".to_string()),
             }],
         };
@@ -228,6 +238,7 @@ entries:
             command: "test.sh".to_string(),
             timeout: Some(30),
             status_message: None,
+            async_hook: None,
             protocol: None,
         };
         assert!(hook1.is_valid_protocol());
@@ -239,6 +250,7 @@ entries:
             command: "test.sh".to_string(),
             timeout: Some(30),
             status_message: None,
+            async_hook: None,
             protocol: Some("claude-code".to_string()),
         };
         assert!(hook2.is_valid_protocol());
@@ -250,6 +262,7 @@ entries:
             command: "test.sh".to_string(),
             timeout: Some(30),
             status_message: None,
+            async_hook: None,
             protocol: Some("future-v2".to_string()),
         };
         assert!(!hook3.is_valid_protocol());

--- a/src/hooks/config.rs
+++ b/src/hooks/config.rs
@@ -29,20 +29,17 @@ pub struct HookConfig {
     #[serde(default, rename = "async")]
     pub async_hook: Option<bool>,
 
-    /// Protocol version (default "claude-code")
-    #[serde(default)]
-    pub protocol: Option<String>,
+    /// Hook type. Determines the execution protocol.
+    /// Supported: "claude-command" (subprocess with stdin/stdout JSON).
+    /// Unknown types are silently skipped.
+    #[serde(rename = "type")]
+    pub hook_type: String,
 }
 
 impl HookConfig {
-    /// Check if the protocol is valid
-    /// Returns true if protocol is None (defaults to "claude-code") or explicitly "claude-code"
-    /// Returns false for unknown protocols
-    pub fn is_valid_protocol(&self) -> bool {
-        match &self.protocol {
-            None => true, // Defaults to "claude-code"
-            Some(p) => p == "claude-code",
-        }
+    /// Check if the hook type is supported
+    pub fn is_supported_type(&self) -> bool {
+        self.hook_type == "claude-command"
     }
 }
 
@@ -107,7 +104,7 @@ entries:
     command: "/path/to/hook.sh"
     async: true
     timeout: 10
-    protocol: claude-code
+    type: claude-command
 "#;
 
         let config: HooksConfig = serde_yaml::from_str(yaml).expect("parse hooks config");
@@ -119,7 +116,7 @@ entries:
         assert_eq!(entry.event, "Stop");
         assert_eq!(entry.command, "/path/to/hook.sh");
         assert_eq!(entry.timeout, Some(10));
-        assert_eq!(entry.protocol, Some("claude-code".to_string()));
+        assert_eq!(entry.hook_type, "claude-command");
         assert!(entry.matcher.is_none());
         assert!(entry.status_message.is_none());
         assert_eq!(entry.async_hook, Some(true));
@@ -137,7 +134,7 @@ entries:
                     timeout: Some(30),
                     status_message: None,
                     async_hook: None,
-                    protocol: None,
+                    hook_type: "claude-command".to_string(),
                 },
                 HookConfig {
                     event: "SessionStart".to_string(),
@@ -146,7 +143,7 @@ entries:
                     timeout: Some(30),
                     status_message: None,
                     async_hook: None,
-                    protocol: None,
+                    hook_type: "claude-command".to_string(),
                 },
             ],
         };
@@ -160,7 +157,7 @@ entries:
                 timeout: Some(15),
                 status_message: None,
                 async_hook: None,
-                protocol: None,
+                hook_type: "claude-command".to_string(),
             }],
         };
 
@@ -190,7 +187,7 @@ entries:
                 timeout: Some(30),
                 status_message: None,
                 async_hook: None,
-                protocol: None,
+                hook_type: "claude-command".to_string(),
             }],
         };
 
@@ -203,7 +200,7 @@ entries:
                 timeout: Some(10),
                 status_message: Some("Agent override".to_string()),
                 async_hook: None,
-                protocol: Some("claude-code".to_string()),
+                hook_type: "claude-command".to_string(),
             }],
         };
 
@@ -230,8 +227,8 @@ entries:
     }
 
     #[test]
-    fn test_valid_protocol() {
-        // None should be valid (defaults to "claude-code")
+    fn test_supported_type() {
+        // None should be valid (defaults to "claude-command")
         let hook1 = HookConfig {
             event: "Stop".to_string(),
             matcher: None,
@@ -239,11 +236,11 @@ entries:
             timeout: Some(30),
             status_message: None,
             async_hook: None,
-            protocol: None,
+            hook_type: "claude-command".to_string(),
         };
-        assert!(hook1.is_valid_protocol());
+        assert!(hook1.is_supported_type());
 
-        // "claude-code" should be valid
+        // "claude-command" should be valid
         let hook2 = HookConfig {
             event: "Stop".to_string(),
             matcher: None,
@@ -251,11 +248,11 @@ entries:
             timeout: Some(30),
             status_message: None,
             async_hook: None,
-            protocol: Some("claude-code".to_string()),
+            hook_type: "claude-command".to_string(),
         };
-        assert!(hook2.is_valid_protocol());
+        assert!(hook2.is_supported_type());
 
-        // Unknown protocol should be invalid
+        // Unknown type should be invalid
         let hook3 = HookConfig {
             event: "Stop".to_string(),
             matcher: None,
@@ -263,8 +260,8 @@ entries:
             timeout: Some(30),
             status_message: None,
             async_hook: None,
-            protocol: Some("future-v2".to_string()),
+            hook_type: "future-v2".to_string(),
         };
-        assert!(!hook3.is_valid_protocol());
+        assert!(!hook3.is_supported_type());
     }
 }

--- a/src/hooks/dispatch.rs
+++ b/src/hooks/dispatch.rs
@@ -23,7 +23,8 @@ pub async fn dispatch_hooks_with_manager(
     cwd: &Path,
     async_manager: Option<&AsyncHookManager>,
 ) -> HookOutcome {
-    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, 0, async_manager, None).await
+    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, 0, async_manager, None)
+        .await
 }
 
 pub async fn dispatch_hooks_with_managers(
@@ -34,7 +35,16 @@ pub async fn dispatch_hooks_with_managers(
     async_manager: Option<&AsyncHookManager>,
     persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
 ) -> HookOutcome {
-    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, 0, async_manager, persistent_manager).await
+    dispatch_hooks_with_count_and_manager(
+        event,
+        hooks,
+        session_id,
+        cwd,
+        0,
+        async_manager,
+        persistent_manager,
+    )
+    .await
 }
 
 pub async fn dispatch_hooks_with_count(
@@ -45,7 +55,16 @@ pub async fn dispatch_hooks_with_count(
     resume_count: u32,
     persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
 ) -> HookOutcome {
-    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, resume_count, None, persistent_manager).await
+    dispatch_hooks_with_count_and_manager(
+        event,
+        hooks,
+        session_id,
+        cwd,
+        resume_count,
+        None,
+        persistent_manager,
+    )
+    .await
 }
 
 pub async fn dispatch_hooks_with_count_and_manager(
@@ -96,7 +115,11 @@ pub async fn dispatch_hooks_with_count_and_manager(
 
         if hook.hook_type == "claude-command-persistent" {
             if let Some(pm) = persistent_manager {
-                let outcome = pm.lock().await.send_event(&hook.command, &payload, hook.timeout).await;
+                let outcome = pm
+                    .lock()
+                    .await
+                    .send_event(&hook.command, &payload, hook.timeout)
+                    .await;
                 let HookOutcome { control, result } = outcome;
 
                 match control {
@@ -107,7 +130,9 @@ pub async fn dispatch_hooks_with_count_and_manager(
                         };
                     }
                     HookResultControl::Continue => {
-                        if let Some(context) = result.additional_context.filter(|value| !value.is_empty()) {
+                        if let Some(context) =
+                            result.additional_context.filter(|value| !value.is_empty())
+                        {
                             additional_contexts.push(context);
                         }
                         if let Some(msg) = result.system_message.filter(|value| !value.is_empty()) {
@@ -274,9 +299,15 @@ mod tests {
             format!("python -c \"import sys, pathlib; pathlib.Path(r'{}').write_text(sys.stdin.read())\"", marker.display()),
         )];
 
-        let outcome =
-            dispatch_hooks_with_count(&pre_tool_use_event("shell"), &hooks, "session-3", &cwd, 4, None)
-                .await;
+        let outcome = dispatch_hooks_with_count(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-3",
+            &cwd,
+            4,
+            None,
+        )
+        .await;
 
         assert!(matches!(outcome.control, HookResultControl::Continue));
         let payload = fs::read_to_string(&marker).expect("read payload marker");

--- a/src/hooks/dispatch.rs
+++ b/src/hooks/dispatch.rs
@@ -1,0 +1,172 @@
+use crate::hooks::{
+    executor::execute_command_hook, CompiledMatcher, HookConfig, HookEvent, HookOutcome,
+    HookPayload, HookResult, HookResultControl,
+};
+
+use std::path::Path;
+
+pub async fn dispatch_hooks(
+    event: &HookEvent,
+    hooks: &[HookConfig],
+    session_id: &str,
+    cwd: &Path,
+) -> HookOutcome {
+    let payload = HookPayload {
+        session_id: session_id.to_string(),
+        cwd: cwd.to_path_buf(),
+        hook_event: event.clone(),
+    };
+
+    let mut additional_contexts = vec![];
+    let mut auto_continue = false;
+
+    for hook in hooks {
+        if hook.event != event.event_name() || !hook.is_valid_protocol() {
+            continue;
+        }
+
+        let matcher = match CompiledMatcher::compile(&hook.matcher) {
+            Ok(matcher) => matcher,
+            Err(err) => {
+                warn!(
+                    "Skipping hook `{}` for event `{}` because matcher compilation failed: {err}",
+                    hook.command, hook.event
+                );
+                continue;
+            }
+        };
+
+        if !matcher.matches(event) {
+            continue;
+        }
+
+        let outcome = execute_command_hook(&payload, &hook.command, hook.timeout).await;
+        let HookOutcome { control, result } = outcome;
+
+        match control {
+            HookResultControl::Block { reason } => {
+                return HookOutcome {
+                    control: HookResultControl::Block { reason },
+                    result,
+                };
+            }
+            HookResultControl::Continue => {
+                if let Some(context) = result.additional_context.filter(|value| !value.is_empty()) {
+                    additional_contexts.push(context);
+                }
+                auto_continue |= result.auto_continue.unwrap_or(false);
+            }
+        }
+    }
+
+    HookOutcome {
+        control: HookResultControl::Continue,
+        result: HookResult {
+            additional_context: (!additional_contexts.is_empty())
+                .then(|| additional_contexts.join("\n")),
+            auto_continue: auto_continue.then_some(true),
+            ..HookResult::default()
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dispatch_hooks;
+    use crate::hooks::{HookConfig, HookEvent, HookResultControl};
+    use serde_json::json;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_test_dir(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("aichat-dispatch-tests-{name}-{suffix}"));
+        fs::create_dir_all(&dir).expect("create temp dispatch dir");
+        dir
+    }
+
+    fn pre_tool_use_event(tool_name: &str) -> HookEvent {
+        HookEvent::PreToolUse {
+            tool_name: tool_name.to_string(),
+            tool_input: json!({"command": "pwd"}),
+            tool_use_id: "call-1".to_string(),
+        }
+    }
+
+    fn hook_config(event: &str, command: String) -> HookConfig {
+        HookConfig {
+            event: event.to_string(),
+            matcher: None,
+            command,
+            timeout: Some(5),
+            status_message: None,
+            protocol: None,
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_line_command(path: &Path, line: &str) -> String {
+        format!("printf '%s\\n' '{line}' >> '{}'", path.display())
+    }
+
+    #[cfg(windows)]
+    fn write_line_command(path: &Path, line: &str) -> String {
+        format!("echo {line}>>{}", path.display())
+    }
+
+    #[cfg(unix)]
+    fn block_command(path: &Path) -> String {
+        format!(
+            "printf '%s\\n' 'blocked' > '{}' && echo 'blocked' >&2 && exit 2",
+            path.display()
+        )
+    }
+
+    #[cfg(windows)]
+    fn block_command(path: &Path) -> String {
+        format!(
+            "echo blocked>{} && echo blocked 1>&2 && exit 2",
+            path.display()
+        )
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_filters_by_event() {
+        let cwd = temp_test_dir("filter-by-event");
+        let marker = cwd.join("hook-runs.txt");
+        let hooks = vec![
+            hook_config("PreToolUse", write_line_command(&marker, "pre-tool")),
+            hook_config("SessionStart", write_line_command(&marker, "session-start")),
+        ];
+
+        let outcome = dispatch_hooks(&pre_tool_use_event("shell"), &hooks, "session-1", &cwd).await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        let contents = fs::read_to_string(&marker).expect("read marker file");
+        assert_eq!(contents.trim(), "pre-tool");
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_block_short_circuit() {
+        let cwd = temp_test_dir("block-short-circuit");
+        let blocked_marker = cwd.join("blocked.txt");
+        let second_marker = cwd.join("second.txt");
+        let hooks = vec![
+            hook_config("PreToolUse", block_command(&blocked_marker)),
+            hook_config("PreToolUse", write_line_command(&second_marker, "second")),
+        ];
+
+        let outcome = dispatch_hooks(&pre_tool_use_event("shell"), &hooks, "session-2", &cwd).await;
+
+        match outcome.control {
+            HookResultControl::Block { reason } => assert_eq!(reason, "blocked"),
+            HookResultControl::Continue => panic!("expected blocked hook outcome"),
+        }
+        assert!(blocked_marker.exists());
+        assert!(!second_marker.exists());
+    }
+}

--- a/src/hooks/dispatch.rs
+++ b/src/hooks/dispatch.rs
@@ -1,6 +1,6 @@
 use crate::hooks::{
-    executor::execute_command_hook, CompiledMatcher, HookConfig, HookEvent, HookOutcome,
-    HookPayload, HookResult, HookResultControl,
+    executor::execute_command_hook, AsyncHookManager, CompiledMatcher, HookConfig, HookEvent,
+    HookOutcome, HookPayload, HookResult, HookResultControl,
 };
 
 use std::path::Path;
@@ -14,12 +14,33 @@ pub async fn dispatch_hooks(
     dispatch_hooks_with_count(event, hooks, session_id, cwd, 0).await
 }
 
+pub async fn dispatch_hooks_with_manager(
+    event: &HookEvent,
+    hooks: &[HookConfig],
+    session_id: &str,
+    cwd: &Path,
+    async_manager: Option<&AsyncHookManager>,
+) -> HookOutcome {
+    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, 0, async_manager).await
+}
+
 pub async fn dispatch_hooks_with_count(
     event: &HookEvent,
     hooks: &[HookConfig],
     session_id: &str,
     cwd: &Path,
     resume_count: u32,
+) -> HookOutcome {
+    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, resume_count, None).await
+}
+
+pub async fn dispatch_hooks_with_count_and_manager(
+    event: &HookEvent,
+    hooks: &[HookConfig],
+    session_id: &str,
+    cwd: &Path,
+    resume_count: u32,
+    async_manager: Option<&AsyncHookManager>,
 ) -> HookOutcome {
     let payload = HookPayload {
         session_id: session_id.to_string(),
@@ -48,6 +69,13 @@ pub async fn dispatch_hooks_with_count(
         };
 
         if !matcher.matches(event) {
+            continue;
+        }
+
+        if hook.async_hook == Some(true) {
+            if let Some(manager) = async_manager {
+                manager.spawn_hook(payload.clone(), hook.command.clone(), hook.timeout);
+            }
             continue;
         }
 
@@ -86,11 +114,12 @@ pub async fn dispatch_hooks_with_count(
 
 #[cfg(test)]
 mod tests {
-    use super::{dispatch_hooks, dispatch_hooks_with_count};
-    use crate::hooks::{HookConfig, HookEvent, HookResultControl};
+    use super::{dispatch_hooks, dispatch_hooks_with_count, dispatch_hooks_with_count_and_manager};
+    use crate::hooks::{AsyncHookManager, HookConfig, HookEvent, HookResultControl};
     use serde_json::json;
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_test_dir(name: &str) -> PathBuf {
@@ -118,8 +147,19 @@ mod tests {
             command,
             timeout: Some(5),
             status_message: None,
+            async_hook: None,
             protocol: None,
         }
+    }
+
+    #[cfg(unix)]
+    fn sleep_command(seconds: u64) -> String {
+        format!("sleep {seconds}")
+    }
+
+    #[cfg(windows)]
+    fn sleep_command(seconds: u64) -> String {
+        format!("powershell -Command \"Start-Sleep -Seconds {seconds}\"")
     }
 
     #[cfg(unix)]
@@ -205,5 +245,32 @@ mod tests {
         assert!(matches!(outcome.control, HookResultControl::Continue));
         let payload = fs::read_to_string(&marker).expect("read payload marker");
         assert!(payload.contains("\"resume_count\":4"));
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_async_hook_does_not_block() {
+        let cwd = temp_test_dir("async-no-block");
+        let hooks = vec![HookConfig {
+            async_hook: Some(true),
+            command: sleep_command(5),
+            ..hook_config("PreToolUse", sleep_command(5))
+        }];
+        let manager = AsyncHookManager::new();
+        let start = tokio::time::Instant::now();
+
+        let outcome = dispatch_hooks_with_count_and_manager(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-async",
+            &cwd,
+            0,
+            Some(&manager),
+        )
+        .await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert!(start.elapsed() < Duration::from_secs(1));
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
     }
 }

--- a/src/hooks/dispatch.rs
+++ b/src/hooks/dispatch.rs
@@ -53,7 +53,7 @@ pub async fn dispatch_hooks_with_count_and_manager(
     let mut resume = false;
 
     for hook in hooks {
-        if hook.event != event.event_name() || !hook.is_valid_protocol() {
+        if hook.event != event.event_name() || !hook.is_supported_type() {
             continue;
         }
 
@@ -148,7 +148,7 @@ mod tests {
             timeout: Some(5),
             status_message: None,
             async_hook: None,
-            protocol: None,
+            hook_type: "claude-command".to_string(),
         }
     }
 

--- a/src/hooks/dispatch.rs
+++ b/src/hooks/dispatch.rs
@@ -19,17 +19,17 @@ pub async fn dispatch_hooks_with_count(
     hooks: &[HookConfig],
     session_id: &str,
     cwd: &Path,
-    auto_continue_count: u32,
+    resume_count: u32,
 ) -> HookOutcome {
     let payload = HookPayload {
         session_id: session_id.to_string(),
         cwd: cwd.to_path_buf(),
-        auto_continue_count,
+        resume_count,
         hook_event: event.clone(),
     };
 
     let mut additional_contexts = vec![];
-    let mut auto_continue = false;
+    let mut resume = false;
 
     for hook in hooks {
         if hook.event != event.event_name() || !hook.is_valid_protocol() {
@@ -65,7 +65,10 @@ pub async fn dispatch_hooks_with_count(
                 if let Some(context) = result.additional_context.filter(|value| !value.is_empty()) {
                     additional_contexts.push(context);
                 }
-                auto_continue |= result.auto_continue.unwrap_or(false);
+                if let Some(msg) = result.system_message.filter(|value| !value.is_empty()) {
+                    additional_contexts.push(msg);
+                }
+                resume |= result.resume.unwrap_or(false);
             }
         }
     }
@@ -75,7 +78,7 @@ pub async fn dispatch_hooks_with_count(
         result: HookResult {
             additional_context: (!additional_contexts.is_empty())
                 .then(|| additional_contexts.join("\n")),
-            auto_continue: auto_continue.then_some(true),
+            resume: resume.then_some(true),
             ..HookResult::default()
         },
     }
@@ -182,8 +185,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dispatch_includes_auto_continue_count_in_payload() {
-        let cwd = temp_test_dir("auto-continue-count");
+    async fn test_dispatch_includes_resume_count_in_payload() {
+        let cwd = temp_test_dir("resume-count");
         let marker = cwd.join("payload.json");
         let hooks = vec![hook_config(
             "PreToolUse",
@@ -201,6 +204,6 @@ mod tests {
 
         assert!(matches!(outcome.control, HookResultControl::Continue));
         let payload = fs::read_to_string(&marker).expect("read payload marker");
-        assert!(payload.contains("\"auto_continue_count\":4"));
+        assert!(payload.contains("\"resume_count\":4"));
     }
 }

--- a/src/hooks/dispatch.rs
+++ b/src/hooks/dispatch.rs
@@ -1,9 +1,11 @@
 use crate::hooks::{
     executor::execute_command_hook, AsyncHookManager, CompiledMatcher, HookConfig, HookEvent,
-    HookOutcome, HookPayload, HookResult, HookResultControl,
+    HookOutcome, HookPayload, HookResult, HookResultControl, PersistentHookManager,
 };
 
 use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
 
 pub async fn dispatch_hooks(
     event: &HookEvent,
@@ -11,7 +13,7 @@ pub async fn dispatch_hooks(
     session_id: &str,
     cwd: &Path,
 ) -> HookOutcome {
-    dispatch_hooks_with_count(event, hooks, session_id, cwd, 0).await
+    dispatch_hooks_with_count(event, hooks, session_id, cwd, 0, None).await
 }
 
 pub async fn dispatch_hooks_with_manager(
@@ -21,7 +23,18 @@ pub async fn dispatch_hooks_with_manager(
     cwd: &Path,
     async_manager: Option<&AsyncHookManager>,
 ) -> HookOutcome {
-    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, 0, async_manager).await
+    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, 0, async_manager, None).await
+}
+
+pub async fn dispatch_hooks_with_managers(
+    event: &HookEvent,
+    hooks: &[HookConfig],
+    session_id: &str,
+    cwd: &Path,
+    async_manager: Option<&AsyncHookManager>,
+    persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
+) -> HookOutcome {
+    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, 0, async_manager, persistent_manager).await
 }
 
 pub async fn dispatch_hooks_with_count(
@@ -30,8 +43,9 @@ pub async fn dispatch_hooks_with_count(
     session_id: &str,
     cwd: &Path,
     resume_count: u32,
+    persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
 ) -> HookOutcome {
-    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, resume_count, None).await
+    dispatch_hooks_with_count_and_manager(event, hooks, session_id, cwd, resume_count, None, persistent_manager).await
 }
 
 pub async fn dispatch_hooks_with_count_and_manager(
@@ -41,6 +55,7 @@ pub async fn dispatch_hooks_with_count_and_manager(
     cwd: &Path,
     resume_count: u32,
     async_manager: Option<&AsyncHookManager>,
+    persistent_manager: Option<&Arc<TokioMutex<PersistentHookManager>>>,
 ) -> HookOutcome {
     let payload = HookPayload {
         session_id: session_id.to_string(),
@@ -75,6 +90,32 @@ pub async fn dispatch_hooks_with_count_and_manager(
         if hook.async_hook == Some(true) {
             if let Some(manager) = async_manager {
                 manager.spawn_hook(payload.clone(), hook.command.clone(), hook.timeout);
+            }
+            continue;
+        }
+
+        if hook.hook_type == "claude-command-persistent" {
+            if let Some(pm) = persistent_manager {
+                let outcome = pm.lock().await.send_event(&hook.command, &payload, hook.timeout).await;
+                let HookOutcome { control, result } = outcome;
+
+                match control {
+                    HookResultControl::Block { reason } => {
+                        return HookOutcome {
+                            control: HookResultControl::Block { reason },
+                            result,
+                        };
+                    }
+                    HookResultControl::Continue => {
+                        if let Some(context) = result.additional_context.filter(|value| !value.is_empty()) {
+                            additional_contexts.push(context);
+                        }
+                        if let Some(msg) = result.system_message.filter(|value| !value.is_empty()) {
+                            additional_contexts.push(msg);
+                        }
+                        resume |= result.resume.unwrap_or(false);
+                    }
+                }
             }
             continue;
         }
@@ -233,14 +274,9 @@ mod tests {
             format!("python -c \"import sys, pathlib; pathlib.Path(r'{}').write_text(sys.stdin.read())\"", marker.display()),
         )];
 
-        let outcome = dispatch_hooks_with_count(
-            &pre_tool_use_event("shell"),
-            &hooks,
-            "session-3",
-            &cwd,
-            4,
-        )
-        .await;
+        let outcome =
+            dispatch_hooks_with_count(&pre_tool_use_event("shell"), &hooks, "session-3", &cwd, 4, None)
+                .await;
 
         assert!(matches!(outcome.control, HookResultControl::Continue));
         let payload = fs::read_to_string(&marker).expect("read payload marker");
@@ -265,6 +301,7 @@ mod tests {
             &cwd,
             0,
             Some(&manager),
+            None,
         )
         .await;
 

--- a/src/hooks/dispatch.rs
+++ b/src/hooks/dispatch.rs
@@ -11,9 +11,20 @@ pub async fn dispatch_hooks(
     session_id: &str,
     cwd: &Path,
 ) -> HookOutcome {
+    dispatch_hooks_with_count(event, hooks, session_id, cwd, 0).await
+}
+
+pub async fn dispatch_hooks_with_count(
+    event: &HookEvent,
+    hooks: &[HookConfig],
+    session_id: &str,
+    cwd: &Path,
+    auto_continue_count: u32,
+) -> HookOutcome {
     let payload = HookPayload {
         session_id: session_id.to_string(),
         cwd: cwd.to_path_buf(),
+        auto_continue_count,
         hook_event: event.clone(),
     };
 
@@ -72,7 +83,7 @@ pub async fn dispatch_hooks(
 
 #[cfg(test)]
 mod tests {
-    use super::dispatch_hooks;
+    use super::{dispatch_hooks, dispatch_hooks_with_count};
     use crate::hooks::{HookConfig, HookEvent, HookResultControl};
     use serde_json::json;
     use std::fs;
@@ -168,5 +179,28 @@ mod tests {
         }
         assert!(blocked_marker.exists());
         assert!(!second_marker.exists());
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_includes_auto_continue_count_in_payload() {
+        let cwd = temp_test_dir("auto-continue-count");
+        let marker = cwd.join("payload.json");
+        let hooks = vec![hook_config(
+            "PreToolUse",
+            format!("python -c \"import sys, pathlib; pathlib.Path(r'{}').write_text(sys.stdin.read())\"", marker.display()),
+        )];
+
+        let outcome = dispatch_hooks_with_count(
+            &pre_tool_use_event("shell"),
+            &hooks,
+            "session-3",
+            &cwd,
+            4,
+        )
+        .await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        let payload = fs::read_to_string(&marker).expect("read payload marker");
+        assert!(payload.contains("\"auto_continue_count\":4"));
     }
 }

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -1,8 +1,10 @@
 use crate::hooks::{HookOutcome, HookPayload, HookResult, HookResultControl};
 
-use std::io::{ErrorKind, Read};
-use std::process::{Child, Command, Output, Stdio};
-use std::time::{Duration, Instant};
+use std::io::ErrorKind;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
 
 pub async fn execute_command_hook(
     payload: &HookPayload,
@@ -26,6 +28,7 @@ pub async fn execute_command_hook(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn()
     {
         Ok(child) => child,
@@ -44,17 +47,29 @@ pub async fn execute_command_hook(
     };
 
     if let Some(mut stdin) = child.stdin.take() {
-        if let Err(err) = std::io::Write::write_all(&mut stdin, payload_json.as_bytes()) {
+        if let Err(err) = stdin.write_all(payload_json.as_bytes()).await {
             if err.kind() != ErrorKind::BrokenPipe {
                 warn!("Failed to write hook payload to `{command}` stdin: {err}");
                 return continue_with_default();
             }
         }
+        drop(stdin);
     }
 
-    let output = match wait_for_output(child, timeout_secs, command).await {
-        Some(output) => output,
-        None => return continue_with_default(),
+    let timeout = Duration::from_secs(timeout_secs.unwrap_or(30));
+    let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(err)) => {
+            warn!("Hook command `{command}` failed: {err}");
+            return continue_with_default();
+        }
+        Err(_) => {
+            warn!(
+                "Hook command `{command}` timed out after {}s",
+                timeout.as_secs()
+            );
+            return continue_with_default();
+        }
     };
 
     let elapsed = started_at.elapsed().as_millis();
@@ -120,65 +135,6 @@ fn continue_with_default() -> HookOutcome {
         control: HookResultControl::Continue,
         result: HookResult::default(),
     }
-}
-
-async fn wait_for_output(
-    mut child: Child,
-    timeout_secs: Option<u64>,
-    command: &str,
-) -> Option<Output> {
-    let timeout = timeout_secs.map(Duration::from_secs);
-    let started_at = Instant::now();
-
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => match collect_output(&mut child, status) {
-                Ok(output) => return Some(output),
-                Err(err) => {
-                    warn!("Failed reading output from hook command `{command}`: {err}");
-                    return None;
-                }
-            },
-            Ok(None) => {
-                if let Some(timeout) = timeout {
-                    if started_at.elapsed() >= timeout {
-                        warn!(
-                            "Hook command `{command}` timed out after {}s",
-                            timeout.as_secs()
-                        );
-                        if let Err(err) = child.kill() {
-                            warn!("Failed to kill timed out hook command `{command}`: {err}");
-                        }
-                        let _ = child.wait();
-                        return None;
-                    }
-                }
-                tokio::time::sleep(Duration::from_millis(25)).await;
-            }
-            Err(err) => {
-                warn!("Failed waiting for hook command `{command}`: {err}");
-                return None;
-            }
-        }
-    }
-}
-
-fn collect_output(child: &mut Child, status: std::process::ExitStatus) -> std::io::Result<Output> {
-    let mut stdout = vec![];
-    if let Some(mut handle) = child.stdout.take() {
-        handle.read_to_end(&mut stdout)?;
-    }
-
-    let mut stderr = vec![];
-    if let Some(mut handle) = child.stderr.take() {
-        handle.read_to_end(&mut stderr)?;
-    }
-
-    Ok(Output {
-        status,
-        stdout,
-        stderr,
-    })
 }
 
 #[cfg(unix)]

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -208,7 +208,7 @@ mod tests {
         HookPayload {
             session_id: "session-123".to_string(),
             cwd: cwd.to_path_buf(),
-            auto_continue_count: 0,
+            resume_count: 0,
             hook_event: HookEvent::PreToolUse {
                 tool_name: "shell".to_string(),
                 tool_input: json!({"command": "pwd"}),
@@ -286,7 +286,7 @@ mod tests {
 
         assert!(matches!(outcome.control, HookResultControl::Continue));
         assert!(outcome.result.additional_context.is_none());
-        assert!(outcome.result.auto_continue.is_none());
+        assert!(outcome.result.resume.is_none());
         assert!(outcome.result.updated_input.is_none());
     }
 

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -1,0 +1,332 @@
+use crate::hooks::{HookOutcome, HookPayload, HookResult, HookResultControl};
+
+use std::io::{ErrorKind, Read};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+pub async fn execute_command_hook(
+    payload: &HookPayload,
+    command: &str,
+    timeout_secs: Option<u64>,
+) -> HookOutcome {
+    let shell = default_shell();
+    let shell_arg = default_shell_arg();
+
+    let mut child = match Command::new(&shell)
+        .arg(shell_arg)
+        .arg(command)
+        .current_dir(&payload.cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) => {
+            warn!("Failed to spawn hook command `{command}`: {err}");
+            return continue_with_default();
+        }
+    };
+
+    let payload_json = match serde_json::to_string(payload) {
+        Ok(payload_json) => payload_json,
+        Err(err) => {
+            warn!("Failed to serialize hook payload for `{command}`: {err}");
+            return continue_with_default();
+        }
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(err) = std::io::Write::write_all(&mut stdin, payload_json.as_bytes()) {
+            if err.kind() != ErrorKind::BrokenPipe {
+                warn!("Failed to write hook payload to `{command}` stdin: {err}");
+                return continue_with_default();
+            }
+        }
+    }
+
+    let output = match wait_for_output(child, timeout_secs, command).await {
+        Some(output) => output,
+        None => return continue_with_default(),
+    };
+
+    match output.status.code() {
+        Some(0) => parse_success_output(&output.stdout),
+        Some(2) => HookOutcome {
+            control: HookResultControl::Block {
+                reason: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            },
+            result: HookResult::default(),
+        },
+        Some(code) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            if stderr.is_empty() {
+                warn!("Hook command `{command}` exited with status {code}");
+            } else {
+                warn!("Hook command `{command}` exited with status {code}: {stderr}");
+            }
+            continue_with_default()
+        }
+        None => {
+            warn!("Hook command `{command}` terminated without an exit code");
+            continue_with_default()
+        }
+    }
+}
+
+fn parse_success_output(stdout: &[u8]) -> HookOutcome {
+    if stdout.is_empty() {
+        return continue_with_default();
+    }
+
+    match serde_json::from_slice::<HookResult>(stdout) {
+        Ok(result) => HookOutcome {
+            control: HookResultControl::Continue,
+            result,
+        },
+        Err(_) => {
+            let text = String::from_utf8_lossy(stdout).trim().to_string();
+            if text.is_empty() {
+                continue_with_default()
+            } else {
+                HookOutcome {
+                    control: HookResultControl::Continue,
+                    result: HookResult {
+                        additional_context: Some(text),
+                        ..HookResult::default()
+                    },
+                }
+            }
+        }
+    }
+}
+
+fn continue_with_default() -> HookOutcome {
+    HookOutcome {
+        control: HookResultControl::Continue,
+        result: HookResult::default(),
+    }
+}
+
+async fn wait_for_output(
+    mut child: Child,
+    timeout_secs: Option<u64>,
+    command: &str,
+) -> Option<Output> {
+    let timeout = timeout_secs.map(Duration::from_secs);
+    let started_at = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => match collect_output(&mut child, status) {
+                Ok(output) => return Some(output),
+                Err(err) => {
+                    warn!("Failed reading output from hook command `{command}`: {err}");
+                    return None;
+                }
+            },
+            Ok(None) => {
+                if let Some(timeout) = timeout {
+                    if started_at.elapsed() >= timeout {
+                        warn!(
+                            "Hook command `{command}` timed out after {}s",
+                            timeout.as_secs()
+                        );
+                        if let Err(err) = child.kill() {
+                            warn!("Failed to kill timed out hook command `{command}`: {err}");
+                        }
+                        let _ = child.wait();
+                        return None;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(err) => {
+                warn!("Failed waiting for hook command `{command}`: {err}");
+                return None;
+            }
+        }
+    }
+}
+
+fn collect_output(child: &mut Child, status: std::process::ExitStatus) -> std::io::Result<Output> {
+    let mut stdout = vec![];
+    if let Some(mut handle) = child.stdout.take() {
+        handle.read_to_end(&mut stdout)?;
+    }
+
+    let mut stderr = vec![];
+    if let Some(mut handle) = child.stderr.take() {
+        handle.read_to_end(&mut stderr)?;
+    }
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+#[cfg(unix)]
+fn default_shell() -> String {
+    std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string())
+}
+
+#[cfg(windows)]
+fn default_shell() -> String {
+    "cmd".to_string()
+}
+
+#[cfg(unix)]
+fn default_shell_arg() -> &'static str {
+    "-c"
+}
+
+#[cfg(windows)]
+fn default_shell_arg() -> &'static str {
+    "/C"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::execute_command_hook;
+    use crate::hooks::{HookEvent, HookPayload, HookResultControl};
+    use serde_json::json;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn test_payload(cwd: &Path) -> HookPayload {
+        HookPayload {
+            session_id: "session-123".to_string(),
+            cwd: cwd.to_path_buf(),
+            hook_event: HookEvent::PreToolUse {
+                tool_name: "shell".to_string(),
+                tool_input: json!({"command": "pwd"}),
+                tool_use_id: "call-1".to_string(),
+            },
+        }
+    }
+
+    fn temp_test_dir(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("aichat-hook-tests-{name}-{suffix}"));
+        fs::create_dir_all(&dir).expect("create temp test dir");
+        dir
+    }
+
+    #[cfg(unix)]
+    fn success_json_command() -> &'static str {
+        "echo '{}'"
+    }
+
+    #[cfg(windows)]
+    fn success_json_command() -> &'static str {
+        "echo {}"
+    }
+
+    #[cfg(unix)]
+    fn plain_text_command() -> &'static str {
+        "echo 'hello world'"
+    }
+
+    #[cfg(windows)]
+    fn plain_text_command() -> &'static str {
+        "echo hello world"
+    }
+
+    #[cfg(unix)]
+    fn exit_2_command() -> &'static str {
+        "echo 'blocked' >&2; exit 2"
+    }
+
+    #[cfg(windows)]
+    fn exit_2_command() -> &'static str {
+        "echo blocked 1>&2 && exit 2"
+    }
+
+    #[cfg(unix)]
+    fn timeout_command() -> &'static str {
+        "sleep 60"
+    }
+
+    #[cfg(windows)]
+    fn timeout_command() -> &'static str {
+        "powershell -Command \"Start-Sleep -Seconds 60\""
+    }
+
+    #[cfg(unix)]
+    fn command_not_found() -> &'static str {
+        "/nonexistent/hook"
+    }
+
+    #[cfg(windows)]
+    fn command_not_found() -> &'static str {
+        "C:\\nonexistent\\hook.exe"
+    }
+
+    #[tokio::test]
+    async fn test_executor_echo_hook() {
+        let cwd = temp_test_dir("echo-hook");
+        let payload = test_payload(&cwd);
+
+        let outcome = execute_command_hook(&payload, success_json_command(), Some(5)).await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert!(outcome.result.additional_context.is_none());
+        assert!(outcome.result.auto_continue.is_none());
+        assert!(outcome.result.updated_input.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_executor_plain_text() {
+        let cwd = temp_test_dir("plain-text");
+        let payload = test_payload(&cwd);
+
+        let outcome = execute_command_hook(&payload, plain_text_command(), Some(5)).await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert_eq!(
+            outcome.result.additional_context.as_deref(),
+            Some("hello world")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_executor_exit_2() {
+        let cwd = temp_test_dir("exit-2");
+        let payload = test_payload(&cwd);
+
+        let outcome = execute_command_hook(&payload, exit_2_command(), Some(5)).await;
+
+        match outcome.control {
+            HookResultControl::Block { reason } => assert_eq!(reason, "blocked"),
+            HookResultControl::Continue => panic!("expected blocked hook outcome"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_executor_timeout() {
+        let cwd = temp_test_dir("timeout");
+        let payload = test_payload(&cwd);
+        let start = tokio::time::Instant::now();
+
+        let outcome = execute_command_hook(&payload, timeout_command(), Some(1)).await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert!(start.elapsed() < Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn test_executor_command_not_found() {
+        let cwd = temp_test_dir("not-found");
+        let payload = test_payload(&cwd);
+
+        let outcome = execute_command_hook(&payload, command_not_found(), Some(5)).await;
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+    }
+}

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -10,9 +10,12 @@ pub async fn execute_command_hook(
     timeout_secs: Option<u64>,
 ) -> HookOutcome {
     let event_name = payload.hook_event.event_name();
-    debug!("Dispatching hook for event '{}': command='{}'", event_name, command);
+    debug!(
+        "Dispatching hook for event '{}': command='{}'",
+        event_name, command
+    );
     let started_at = std::time::Instant::now();
-    
+
     let shell = default_shell();
     let shell_arg = default_shell_arg();
 
@@ -56,7 +59,10 @@ pub async fn execute_command_hook(
 
     let elapsed = started_at.elapsed().as_millis();
     let exit_code = output.status.code().unwrap_or(-1);
-    debug!("Hook for '{}' completed: exit_code={}, duration={}ms", event_name, exit_code, elapsed);
+    debug!(
+        "Hook for '{}' completed: exit_code={}, duration={}ms",
+        event_name, exit_code, elapsed
+    );
 
     match output.status.code() {
         Some(0) => parse_success_output(&output.stdout),
@@ -176,22 +182,22 @@ fn collect_output(child: &mut Child, status: std::process::ExitStatus) -> std::i
 }
 
 #[cfg(unix)]
-fn default_shell() -> String {
+pub(crate) fn default_shell() -> String {
     std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string())
 }
 
 #[cfg(windows)]
-fn default_shell() -> String {
+pub(crate) fn default_shell() -> String {
     "cmd".to_string()
 }
 
 #[cfg(unix)]
-fn default_shell_arg() -> &'static str {
+pub(crate) fn default_shell_arg() -> &'static str {
     "-c"
 }
 
 #[cfg(windows)]
-fn default_shell_arg() -> &'static str {
+pub(crate) fn default_shell_arg() -> &'static str {
     "/C"
 }
 

--- a/src/hooks/executor.rs
+++ b/src/hooks/executor.rs
@@ -9,6 +9,10 @@ pub async fn execute_command_hook(
     command: &str,
     timeout_secs: Option<u64>,
 ) -> HookOutcome {
+    let event_name = payload.hook_event.event_name();
+    debug!("Dispatching hook for event '{}': command='{}'", event_name, command);
+    let started_at = std::time::Instant::now();
+    
     let shell = default_shell();
     let shell_arg = default_shell_arg();
 
@@ -49,6 +53,10 @@ pub async fn execute_command_hook(
         Some(output) => output,
         None => return continue_with_default(),
     };
+
+    let elapsed = started_at.elapsed().as_millis();
+    let exit_code = output.status.code().unwrap_or(-1);
+    debug!("Hook for '{}' completed: exit_code={}, duration={}ms", event_name, exit_code, elapsed);
 
     match output.status.code() {
         Some(0) => parse_success_output(&output.stdout),
@@ -200,6 +208,7 @@ mod tests {
         HookPayload {
             session_id: "session-123".to_string(),
             cwd: cwd.to_path_buf(),
+            auto_continue_count: 0,
             hook_event: HookEvent::PreToolUse {
                 tool_name: "shell".to_string(),
                 tool_input: json!({"command": "pwd"}),

--- a/src/hooks/matcher.rs
+++ b/src/hooks/matcher.rs
@@ -1,0 +1,81 @@
+use crate::hooks::HookEvent;
+
+use anyhow::{Context, Result};
+
+pub struct CompiledMatcher {
+    regex: Option<fancy_regex::Regex>,
+}
+
+impl CompiledMatcher {
+    pub fn compile(pattern: &Option<String>) -> Result<Self> {
+        let regex = pattern
+            .as_ref()
+            .map(|pattern| {
+                fancy_regex::Regex::new(pattern)
+                    .with_context(|| format!("failed to compile hook matcher regex: {pattern}"))
+            })
+            .transpose()?;
+
+        Ok(Self { regex })
+    }
+
+    pub fn matches(&self, event: &HookEvent) -> bool {
+        match &self.regex {
+            None => true,
+            Some(regex) => event
+                .matcher_text()
+                .and_then(|text| regex.is_match(text).ok())
+                .unwrap_or(false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CompiledMatcher;
+    use crate::hooks::HookEvent;
+    use serde_json::json;
+
+    #[test]
+    fn test_matcher_no_pattern() {
+        let matcher = CompiledMatcher::compile(&None).expect("compile empty matcher");
+
+        assert!(matcher.matches(&HookEvent::SessionStart {
+            source: "cli".to_string(),
+            model: "claude".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_matcher_matches_tool_name() {
+        let matcher =
+            CompiledMatcher::compile(&Some("execute_command".to_string())).expect("compile regex");
+
+        assert!(matcher.matches(&HookEvent::PreToolUse {
+            tool_name: "execute_command".to_string(),
+            tool_input: json!({"command": "pwd"}),
+            tool_use_id: "call-1".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_matcher_no_match() {
+        let matcher = CompiledMatcher::compile(&Some("shell".to_string())).expect("compile regex");
+
+        assert!(!matcher.matches(&HookEvent::PreToolUse {
+            tool_name: "web_search".to_string(),
+            tool_input: json!({"query": "rust"}),
+            tool_use_id: "call-1".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_matcher_non_tool_event() {
+        let matcher = CompiledMatcher::compile(&Some("shell".to_string())).expect("compile regex");
+
+        assert!(!matcher.matches(&HookEvent::SessionStart {
+            source: "cli".to_string(),
+            model: "claude".to_string(),
+        }));
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -8,6 +8,8 @@
 //! - Exit code 0: stdout parsed as JSON (HookResult) or plain text (additional_context)
 //! - Exit code 2: block the operation (stderr = reason)
 //! - Other exit codes: non-blocking warning
+//! - Hooks marked with `async: true` run in the background and can only append context
+//!   or request a follow-up turn; they never block or deny the active operation
 //!
 //! ## Supported Events
 //! SessionStart, SessionEnd, UserPromptSubmit, Stop, StopFailure,
@@ -16,19 +18,30 @@
 //! ## Resume
 //! Stop hooks can return {"resume": true, "additionalContext": "..."} to
 //! trigger another LLM turn. max_resume prevents infinite loops.
+//! Async hook results are drained before each LLM turn. Results without
+//! `resume: true` are queued until the next user-initiated turn, while results
+//! with `resume: true` can trigger an immediate follow-up turn when the session
+//! loop checks for completed async work.
 //!
 //! Compatible with Claude Code, Cursor, GitHub Copilot, and Gemini CLI.
 
+pub mod async_manager;
 pub mod config;
 pub mod dispatch;
 pub mod executor;
 pub mod matcher;
 pub mod types;
 
+pub use async_manager::AsyncHookManager;
 #[allow(unused_imports)]
 pub use config::{HookConfig, HooksConfig};
 #[allow(unused_imports)]
-pub use dispatch::{dispatch_hooks, dispatch_hooks_with_count};
+pub use dispatch::{
+    dispatch_hooks,
+    dispatch_hooks_with_count,
+    dispatch_hooks_with_manager,
+    dispatch_hooks_with_count_and_manager,
+};
 #[allow(unused_imports)]
 pub use executor::execute_command_hook;
 pub use matcher::CompiledMatcher;

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -23,7 +23,9 @@
 //! with `resume: true` can trigger an immediate follow-up turn when the session
 //! loop checks for completed async work.
 //!
-//! Compatible with Claude Code, Cursor, GitHub Copilot, and Gemini CLI.
+//! Protocol follows the Claude Code hooks convention (subprocess, JSON stdin/stdout,
+//! exit codes for control flow). Other coding CLIs (Gemini CLI, Cursor, etc.) use
+//! similar but not identical protocols.
 
 pub mod async_manager;
 pub mod config;
@@ -33,7 +35,10 @@ pub mod matcher;
 pub mod persistent;
 pub mod types;
 
-pub use async_manager::AsyncHookManager;
+#[allow(unused_imports)]
+pub use async_manager::{
+    append_pending_context, drain_async_results, inject_pending_async_context, AsyncHookManager,
+};
 #[allow(unused_imports)]
 pub use config::{HookConfig, HooksConfig};
 #[allow(unused_imports)]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -13,9 +13,9 @@
 //! SessionStart, SessionEnd, UserPromptSubmit, Stop, StopFailure,
 //! PreToolUse, PostToolUse, PostToolUseFailure, InstructionsLoaded, CwdChanged
 //!
-//! ## Auto-Continue
-//! Stop hooks can return {"auto_continue": true, "additional_context": "..."} to
-//! trigger another LLM turn. max_auto_continue prevents infinite loops.
+//! ## Resume
+//! Stop hooks can return {"resume": true, "additionalContext": "..."} to
+//! trigger another LLM turn. max_resume prevents infinite loops.
 //!
 //! Compatible with Claude Code, Cursor, GitHub Copilot, and Gemini CLI.
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,3 +1,24 @@
+//! # Hooks System
+//!
+//! Claude Code-compatible hooks for aichat. External scripts can observe and
+//! influence the LLM conversation lifecycle via subprocess hooks.
+//!
+//! ## Protocol
+//! - Hooks receive JSON on stdin (HookPayload with session_id, cwd, hook_event_name, etc.)
+//! - Exit code 0: stdout parsed as JSON (HookResult) or plain text (additional_context)
+//! - Exit code 2: block the operation (stderr = reason)
+//! - Other exit codes: non-blocking warning
+//!
+//! ## Supported Events
+//! SessionStart, SessionEnd, UserPromptSubmit, Stop, StopFailure,
+//! PreToolUse, PostToolUse, PostToolUseFailure, InstructionsLoaded, CwdChanged
+//!
+//! ## Auto-Continue
+//! Stop hooks can return {"auto_continue": true, "additional_context": "..."} to
+//! trigger another LLM turn. max_auto_continue prevents infinite loops.
+//!
+//! Compatible with Claude Code, Cursor, GitHub Copilot, and Gemini CLI.
+
 pub mod config;
 pub mod dispatch;
 pub mod executor;
@@ -7,7 +28,7 @@ pub mod types;
 #[allow(unused_imports)]
 pub use config::{HookConfig, HooksConfig};
 #[allow(unused_imports)]
-pub use dispatch::dispatch_hooks;
+pub use dispatch::{dispatch_hooks, dispatch_hooks_with_count};
 #[allow(unused_imports)]
 pub use executor::execute_command_hook;
 pub use matcher::CompiledMatcher;

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -30,6 +30,7 @@ pub mod config;
 pub mod dispatch;
 pub mod executor;
 pub mod matcher;
+pub mod persistent;
 pub mod types;
 
 pub use async_manager::AsyncHookManager;
@@ -37,12 +38,12 @@ pub use async_manager::AsyncHookManager;
 pub use config::{HookConfig, HooksConfig};
 #[allow(unused_imports)]
 pub use dispatch::{
-    dispatch_hooks,
-    dispatch_hooks_with_count,
-    dispatch_hooks_with_manager,
-    dispatch_hooks_with_count_and_manager,
+    dispatch_hooks, dispatch_hooks_with_count, dispatch_hooks_with_count_and_manager,
+    dispatch_hooks_with_manager, dispatch_hooks_with_managers,
 };
 #[allow(unused_imports)]
 pub use executor::execute_command_hook;
 pub use matcher::CompiledMatcher;
+#[allow(unused_imports)]
+pub use persistent::PersistentHookManager;
 pub use types::*;

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,0 +1,14 @@
+pub mod config;
+pub mod dispatch;
+pub mod executor;
+pub mod matcher;
+pub mod types;
+
+#[allow(unused_imports)]
+pub use config::{HookConfig, HooksConfig};
+#[allow(unused_imports)]
+pub use dispatch::dispatch_hooks;
+#[allow(unused_imports)]
+pub use executor::execute_command_hook;
+pub use matcher::CompiledMatcher;
+pub use types::*;

--- a/src/hooks/persistent.rs
+++ b/src/hooks/persistent.rs
@@ -1,0 +1,372 @@
+#![allow(dead_code)]
+
+use crate::hooks::{HookOutcome, HookPayload, HookResult, HookResultControl};
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{oneshot, Mutex};
+
+static EVENT_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Serialize)]
+struct JsonlRequest<'a> {
+    id: String,
+    #[serde(flatten)]
+    payload: &'a HookPayload,
+}
+
+#[derive(Deserialize)]
+struct JsonlResponse {
+    id: String,
+    #[serde(flatten)]
+    result: HookResult,
+}
+
+pub struct PersistentHookProcess {
+    _child: Child,
+    stdin: ChildStdin,
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<HookResult>>>>,
+    _reader_task: tokio::task::JoinHandle<()>,
+    _stderr_task: tokio::task::JoinHandle<()>,
+}
+
+pub struct PersistentHookManager {
+    processes: HashMap<String, PersistentHookProcess>,
+}
+
+impl PersistentHookManager {
+    pub fn new() -> Self {
+        Self {
+            processes: HashMap::new(),
+        }
+    }
+
+    pub async fn send_event(
+        &mut self,
+        command: &str,
+        payload: &HookPayload,
+        timeout_secs: Option<u64>,
+    ) -> HookOutcome {
+        if !self.processes.contains_key(command) {
+            match PersistentHookProcess::spawn(command) {
+                Ok(process) => {
+                    self.processes.insert(command.to_string(), process);
+                }
+                Err(err) => {
+                    warn!("Failed to spawn persistent hook `{command}`: {err}");
+                    return continue_with_default();
+                }
+            }
+        }
+
+        let process = self
+            .processes
+            .get_mut(command)
+            .expect("persistent hook process inserted before use");
+
+        match process.send_event(payload, timeout_secs).await {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                warn!("Persistent hook `{command}` failed: {err}, removing process");
+                self.processes.remove(command);
+                continue_with_default()
+            }
+        }
+    }
+
+    pub fn shutdown(&mut self) {
+        self.processes.clear();
+    }
+}
+
+impl Default for PersistentHookManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PersistentHookProcess {
+    fn spawn(command: &str) -> Result<Self> {
+        let shell = super::executor::default_shell();
+        let shell_arg = super::executor::default_shell_arg();
+
+        let mut child = Command::new(&shell)
+            .arg(shell_arg)
+            .arg(command)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("missing stdin pipe"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("missing stdout pipe"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("missing stderr pipe"))?;
+
+        let pending: Arc<Mutex<HashMap<String, oneshot::Sender<HookResult>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        let reader_pending = Arc::clone(&pending);
+        let reader_task = tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => match serde_json::from_str::<JsonlResponse>(&line) {
+                        Ok(response) => {
+                            let mut map = reader_pending.lock().await;
+                            if let Some(sender) = map.remove(&response.id) {
+                                let _ = sender.send(response.result);
+                            } else {
+                                warn!(
+                                    "Persistent hook returned response for unknown event id `{}`",
+                                    response.id
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            warn!("Failed to parse persistent hook response: {err}");
+                        }
+                    },
+                    Ok(None) => break,
+                    Err(err) => {
+                        warn!("Failed reading persistent hook stdout: {err}");
+                        break;
+                    }
+                }
+            }
+
+            reader_pending.lock().await.clear();
+        });
+
+        let stderr_task = tokio::spawn(async move {
+            let reader = BufReader::new(stderr);
+            let mut lines = reader.lines();
+
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        let line = line.trim();
+                        if !line.is_empty() {
+                            warn!("Persistent hook stderr: {line}");
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        warn!("Failed reading persistent hook stderr: {err}");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            _child: child,
+            stdin,
+            pending,
+            _reader_task: reader_task,
+            _stderr_task: stderr_task,
+        })
+    }
+
+    async fn send_event(
+        &mut self,
+        payload: &HookPayload,
+        timeout_secs: Option<u64>,
+    ) -> Result<HookOutcome> {
+        let id = format!("evt-{}", EVENT_COUNTER.fetch_add(1, Ordering::Relaxed));
+        let request = JsonlRequest {
+            id: id.clone(),
+            payload,
+        };
+
+        let mut line = serde_json::to_string(&request)?;
+        line.push('\n');
+
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id.clone(), tx);
+
+        if let Err(err) = self.stdin.write_all(line.as_bytes()).await {
+            self.pending.lock().await.remove(&id);
+            return Err(err.into());
+        }
+
+        if let Err(err) = self.stdin.flush().await {
+            self.pending.lock().await.remove(&id);
+            return Err(err.into());
+        }
+
+        let timeout = Duration::from_secs(timeout_secs.unwrap_or(30));
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(result)) => Ok(HookOutcome {
+                control: HookResultControl::Continue,
+                result,
+            }),
+            Ok(Err(_)) => {
+                self.pending.lock().await.remove(&id);
+                bail!("persistent hook process exited unexpectedly")
+            }
+            Err(_) => {
+                self.pending.lock().await.remove(&id);
+                warn!("Persistent hook timed out for event `{id}`");
+                Ok(continue_with_default())
+            }
+        }
+    }
+}
+
+fn continue_with_default() -> HookOutcome {
+    HookOutcome {
+        control: HookResultControl::Continue,
+        result: HookResult::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PersistentHookManager, PersistentHookProcess};
+    use crate::hooks::{HookEvent, HookPayload, HookResultControl};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn test_payload(cwd: &Path) -> HookPayload {
+        HookPayload {
+            session_id: "session-123".to_string(),
+            cwd: cwd.to_path_buf(),
+            resume_count: 0,
+            hook_event: HookEvent::Stop {
+                stop_hook_active: false,
+                last_assistant_message: Some("done".to_string()),
+            },
+        }
+    }
+
+    fn temp_test_dir(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("unix epoch")
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("aichat-persistent-hook-tests-{name}-{suffix}"));
+        fs::create_dir_all(&dir).expect("create temp test dir");
+        dir
+    }
+
+    #[cfg(unix)]
+    fn extract_id_snippet() -> &'static str {
+        r#"id=${line#*\"id\":\"}; id=${id%%\"*}"#
+    }
+
+    #[cfg(unix)]
+    fn respond_command(marker: Option<&Path>, additional_context: &str) -> String {
+        let startup = marker
+            .map(|path| format!("printf '%s\\n' 'spawned' >> '{}' ; ", path.display()))
+            .unwrap_or_default();
+
+        format!(
+            "{startup}while IFS= read -r line; do {}; printf '{{\"id\":\"%s\",\"additionalContext\":\"{}\"}}\\n' \"$id\"; done",
+            extract_id_snippet(),
+            additional_context.replace('"', "\\\"")
+        )
+    }
+
+    #[cfg(windows)]
+    fn respond_command(marker: Option<&Path>, additional_context: &str) -> String {
+        let startup = marker
+            .map(|path| format!("Add-Content -Path '{}' -Value 'spawned'; ", path.display()))
+            .unwrap_or_default();
+
+        format!(
+            "powershell -Command \"{}while (($line = [Console]::In.ReadLine()) -ne $null) {{ if ($line -match '\\\"id\\\":\\\"([^\\\"]+)\\\"') {{ $id = $Matches[1]; [Console]::Out.WriteLine('{{\\\"id\\\":\\\"' + $id + '\\\",\\\"additionalContext\\\":\\\"{}\\\"}}') }} }}\"",
+            startup,
+            additional_context.replace('"', "`\"")
+        )
+    }
+
+    #[cfg(unix)]
+    fn timeout_command() -> String {
+        "while IFS= read -r _line; do sleep 60; done".to_string()
+    }
+
+    #[cfg(windows)]
+    fn timeout_command() -> String {
+        "powershell -Command \"while (($line = [Console]::In.ReadLine()) -ne $null) { Start-Sleep -Seconds 60 }\"".to_string()
+    }
+
+    #[tokio::test]
+    async fn test_persistent_process_send_and_receive() {
+        let cwd = temp_test_dir("send-and-receive");
+        let payload = test_payload(&cwd);
+        let mut process =
+            PersistentHookProcess::spawn(&respond_command(None, "persistent response"))
+                .expect("spawn persistent hook");
+
+        let outcome = process
+            .send_event(&payload, Some(5))
+            .await
+            .expect("send event");
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert_eq!(
+            outcome.result.additional_context.as_deref(),
+            Some("persistent response")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_persistent_manager_reuses_process() {
+        let cwd = temp_test_dir("reuse-process");
+        let marker = cwd.join("persistent-spawns.txt");
+        let payload = test_payload(&cwd);
+        let command = respond_command(Some(&marker), "persistent response");
+        let mut manager = PersistentHookManager::new();
+
+        let first = manager.send_event(&command, &payload, Some(5)).await;
+        let second = manager.send_event(&command, &payload, Some(5)).await;
+
+        assert!(matches!(first.control, HookResultControl::Continue));
+        assert!(matches!(second.control, HookResultControl::Continue));
+
+        let contents = fs::read_to_string(&marker).expect("read spawn marker");
+        assert_eq!(contents.lines().count(), 1);
+
+        manager.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_persistent_process_timeout() {
+        let cwd = temp_test_dir("timeout");
+        let payload = test_payload(&cwd);
+        let mut process =
+            PersistentHookProcess::spawn(&timeout_command()).expect("spawn timeout hook");
+        let start = tokio::time::Instant::now();
+
+        let outcome = process
+            .send_event(&payload, Some(1))
+            .await
+            .expect("timeout should continue");
+
+        assert!(matches!(outcome.control, HookResultControl::Continue));
+        assert_eq!(outcome.result.additional_context, None);
+        assert!(start.elapsed() < Duration::from_secs(2));
+    }
+}

--- a/src/hooks/types.rs
+++ b/src/hooks/types.rs
@@ -1,0 +1,225 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HookPayload {
+    pub session_id: String,
+    pub cwd: PathBuf,
+    #[serde(flatten)]
+    pub hook_event: HookEvent,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "hook_event_name", rename_all = "PascalCase")]
+pub enum HookEvent {
+    SessionStart {
+        source: String,
+        model: String,
+    },
+    SessionEnd {
+        reason: String,
+    },
+    UserPromptSubmit {
+        prompt: String,
+    },
+    Stop {
+        stop_hook_active: bool,
+        last_assistant_message: Option<String>,
+    },
+    StopFailure {
+        error: String,
+        error_type: String,
+    },
+    PreToolUse {
+        tool_name: String,
+        tool_input: Value,
+        tool_use_id: String,
+    },
+    PostToolUse {
+        tool_name: String,
+        tool_input: Value,
+        tool_response: Value,
+        tool_use_id: String,
+    },
+    PostToolUseFailure {
+        tool_name: String,
+        tool_input: Value,
+        tool_use_id: String,
+        error: String,
+    },
+    InstructionsLoaded {},
+    CwdChanged {},
+}
+
+impl HookEvent {
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::SessionStart { .. } => "SessionStart",
+            Self::SessionEnd { .. } => "SessionEnd",
+            Self::UserPromptSubmit { .. } => "UserPromptSubmit",
+            Self::Stop { .. } => "Stop",
+            Self::StopFailure { .. } => "StopFailure",
+            Self::PreToolUse { .. } => "PreToolUse",
+            Self::PostToolUse { .. } => "PostToolUse",
+            Self::PostToolUseFailure { .. } => "PostToolUseFailure",
+            Self::InstructionsLoaded { .. } => "InstructionsLoaded",
+            Self::CwdChanged { .. } => "CwdChanged",
+        }
+    }
+
+    pub fn matcher_text(&self) -> Option<&str> {
+        match self {
+            Self::PreToolUse { tool_name, .. }
+            | Self::PostToolUse { tool_name, .. }
+            | Self::PostToolUseFailure { tool_name, .. } => Some(tool_name),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookResultControl {
+    Continue,
+    Block { reason: String },
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct HookResult {
+    #[serde(default)]
+    pub additional_context: Option<String>,
+    #[serde(default)]
+    pub auto_continue: Option<bool>,
+    #[serde(default)]
+    pub updated_input: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HookOutcome {
+    pub control: HookResultControl,
+    pub result: HookResult,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HookEvent, HookPayload, HookResult};
+    use serde_json::{json, Value};
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_hook_payload_serialization() {
+        let payload = HookPayload {
+            session_id: "session-123".to_string(),
+            cwd: PathBuf::from("/tmp/project"),
+            hook_event: HookEvent::PreToolUse {
+                tool_name: "shell".to_string(),
+                tool_input: json!({"command": "echo hi"}),
+                tool_use_id: "call-1".to_string(),
+            },
+        };
+
+        let value = serde_json::to_value(payload).expect("serialize hook payload");
+        assert_eq!(
+            value["hook_event_name"],
+            Value::String("PreToolUse".to_string())
+        );
+        assert_eq!(value["tool_name"], Value::String("shell".to_string()));
+        assert_eq!(value["tool_input"], json!({"command": "echo hi"}));
+        assert_eq!(
+            value["session_id"],
+            Value::String("session-123".to_string())
+        );
+        assert_eq!(value["cwd"], Value::String("/tmp/project".to_string()));
+    }
+
+    #[test]
+    fn test_hook_result_deserialization() {
+        let result: HookResult =
+            serde_json::from_str(r#"{"auto_continue":true,"additional_context":"keep going"}"#)
+                .expect("deserialize hook result");
+
+        assert_eq!(result.auto_continue, Some(true));
+        assert_eq!(result.additional_context.as_deref(), Some("keep going"));
+        assert!(result.updated_input.is_none());
+    }
+
+    #[test]
+    fn test_hook_result_empty_json() {
+        let result: HookResult = serde_json::from_str("{}").expect("deserialize empty hook result");
+
+        assert!(result.additional_context.is_none());
+        assert!(result.auto_continue.is_none());
+        assert!(result.updated_input.is_none());
+    }
+
+    #[test]
+    fn test_event_name() {
+        let events = vec![
+            (
+                HookEvent::SessionStart {
+                    source: "cli".to_string(),
+                    model: "claude".to_string(),
+                },
+                "SessionStart",
+            ),
+            (
+                HookEvent::SessionEnd {
+                    reason: "complete".to_string(),
+                },
+                "SessionEnd",
+            ),
+            (
+                HookEvent::UserPromptSubmit {
+                    prompt: "hello".to_string(),
+                },
+                "UserPromptSubmit",
+            ),
+            (
+                HookEvent::Stop {
+                    stop_hook_active: true,
+                    last_assistant_message: Some("done".to_string()),
+                },
+                "Stop",
+            ),
+            (
+                HookEvent::StopFailure {
+                    error: "boom".to_string(),
+                    error_type: "runtime".to_string(),
+                },
+                "StopFailure",
+            ),
+            (
+                HookEvent::PreToolUse {
+                    tool_name: "shell".to_string(),
+                    tool_input: json!({}),
+                    tool_use_id: "call-1".to_string(),
+                },
+                "PreToolUse",
+            ),
+            (
+                HookEvent::PostToolUse {
+                    tool_name: "shell".to_string(),
+                    tool_input: json!({}),
+                    tool_response: json!({"ok": true}),
+                    tool_use_id: "call-2".to_string(),
+                },
+                "PostToolUse",
+            ),
+            (
+                HookEvent::PostToolUseFailure {
+                    tool_name: "shell".to_string(),
+                    tool_input: json!({}),
+                    tool_use_id: "call-3".to_string(),
+                    error: "failed".to_string(),
+                },
+                "PostToolUseFailure",
+            ),
+            (HookEvent::InstructionsLoaded {}, "InstructionsLoaded"),
+            (HookEvent::CwdChanged {}, "CwdChanged"),
+        ];
+
+        for (event, expected_name) in events {
+            assert_eq!(event.event_name(), expected_name);
+        }
+    }
+}

--- a/src/hooks/types.rs
+++ b/src/hooks/types.rs
@@ -7,7 +7,7 @@ pub struct HookPayload {
     pub session_id: String,
     pub cwd: PathBuf,
     #[serde(default)]
-    pub auto_continue_count: u32,
+    pub resume_count: u32,
     #[serde(flatten)]
     pub hook_event: HookEvent,
 }
@@ -87,13 +87,16 @@ pub enum HookResultControl {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HookResult {
     #[serde(default)]
     pub additional_context: Option<String>,
     #[serde(default)]
-    pub auto_continue: Option<bool>,
+    pub resume: Option<bool>,
     #[serde(default)]
     pub updated_input: Option<Value>,
+    #[serde(default)]
+    pub system_message: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -113,7 +116,7 @@ mod tests {
         let payload = HookPayload {
             session_id: "session-123".to_string(),
             cwd: PathBuf::from("/tmp/project"),
-            auto_continue_count: 2,
+            resume_count: 2,
             hook_event: HookEvent::PreToolUse {
                 tool_name: "shell".to_string(),
                 tool_input: json!({"command": "echo hi"}),
@@ -133,16 +136,16 @@ mod tests {
             Value::String("session-123".to_string())
         );
         assert_eq!(value["cwd"], Value::String("/tmp/project".to_string()));
-        assert_eq!(value["auto_continue_count"], Value::from(2));
+        assert_eq!(value["resume_count"], Value::from(2));
     }
 
     #[test]
     fn test_hook_result_deserialization() {
         let result: HookResult =
-            serde_json::from_str(r#"{"auto_continue":true,"additional_context":"keep going"}"#)
+            serde_json::from_str(r#"{"resume":true,"additionalContext":"keep going"}"#)
                 .expect("deserialize hook result");
 
-        assert_eq!(result.auto_continue, Some(true));
+        assert_eq!(result.resume, Some(true));
         assert_eq!(result.additional_context.as_deref(), Some("keep going"));
         assert!(result.updated_input.is_none());
     }
@@ -152,7 +155,7 @@ mod tests {
         let result: HookResult = serde_json::from_str("{}").expect("deserialize empty hook result");
 
         assert!(result.additional_context.is_none());
-        assert!(result.auto_continue.is_none());
+        assert!(result.resume.is_none());
         assert!(result.updated_input.is_none());
     }
 

--- a/src/hooks/types.rs
+++ b/src/hooks/types.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 pub struct HookPayload {
     pub session_id: String,
     pub cwd: PathBuf,
+    #[serde(default)]
+    pub auto_continue_count: u32,
     #[serde(flatten)]
     pub hook_event: HookEvent,
 }
@@ -111,6 +113,7 @@ mod tests {
         let payload = HookPayload {
             session_id: "session-123".to_string(),
             cwd: PathBuf::from("/tmp/project"),
+            auto_continue_count: 2,
             hook_event: HookEvent::PreToolUse {
                 tool_name: "shell".to_string(),
                 tool_input: json!({"command": "echo hi"}),
@@ -130,6 +133,7 @@ mod tests {
             Value::String("session-123".to_string())
         );
         assert_eq!(value["cwd"], Value::String("/tmp/project".to_string()));
+        assert_eq!(value["auto_continue_count"], Value::from(2));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use crate::config::{
     ensure_parent_exists, list_agents, load_env_file, macro_execute, Config, GlobalConfig, Input,
     WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE, SHELL_ROLE, TEMP_SESSION_NAME,
 };
+use crate::hooks::{dispatch_hooks, HookEvent, HookResultControl};
 use crate::render::render_error;
 use crate::repl::Repl;
 use crate::utils::*;
@@ -30,7 +31,7 @@ use clap::Parser;
 use inquire::Text;
 use parking_lot::RwLock;
 use simplelog::{format_description, ConfigBuilder, LevelFilter, SimpleLogger, WriteLogger};
-use std::{env, process, sync::Arc};
+use std::{env, path::PathBuf, process, sync::Arc, time::Duration};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -182,15 +183,58 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         false => {
             let mut input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
             input.use_embeddings(abort_signal.clone()).await?;
-            start_directive(&config, input, cli.code, abort_signal).await
+            dispatch_session_start(&config, "cmd").await;
+            let result = start_directive(&config, input, cli.code, abort_signal).await;
+            exit_session_with_hook(&config).await?;
+            result
         }
         true => {
             if !*IS_STDOUT_TERMINAL {
                 bail!("No TTY for REPL")
             }
-            start_interactive(&config).await
+            let result = start_interactive(&config).await;
+            exit_session_with_hook(&config).await?;
+            result
         }
     }
+}
+
+fn hook_dispatch_context(config: &GlobalConfig) -> (crate::hooks::HooksConfig, String, PathBuf) {
+    let config = config.read();
+    (
+        config.resolved_hooks(),
+        config
+            .session
+            .as_ref()
+            .map(|session| session.name())
+            .unwrap_or("default")
+            .to_string(),
+        env::current_dir().unwrap_or_default(),
+    )
+}
+
+async fn dispatch_session_start(config: &GlobalConfig, source: &str) {
+    let (hooks, session_id, cwd) = hook_dispatch_context(config);
+    let model_id = config.read().current_model().id().to_string();
+    let event = HookEvent::SessionStart {
+        source: source.to_string(),
+        model: model_id,
+    };
+    let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+}
+
+async fn exit_session_with_hook(config: &GlobalConfig) -> Result<()> {
+    let (hooks, session_id, cwd) = hook_dispatch_context(config);
+    config.write().exit_session()?;
+    let event = HookEvent::SessionEnd {
+        reason: "session_exit".to_string(),
+    };
+    let _ = tokio::time::timeout(
+        Duration::from_secs(5),
+        dispatch_hooks(&event, &hooks.entries, &session_id, &cwd),
+    )
+    .await;
+    Ok(())
 }
 
 #[async_recursion::async_recursion]
@@ -203,6 +247,15 @@ async fn start_directive(
     let client = input.create_client()?;
     let extract_code = !*IS_STDOUT_TERMINAL && code_mode;
     config.write().before_chat_completion(&input)?;
+    let (hooks, session_id, cwd) = hook_dispatch_context(config);
+    let input_text = input.text();
+    let event = HookEvent::UserPromptSubmit {
+        prompt: input_text.clone(),
+    };
+    let outcome = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+    if let HookResultControl::Block { reason } = outcome.control {
+        bail!("{reason}");
+    }
     let (output, tool_results) = if !input.stream() || extract_code {
         call_chat_completions(
             &input,
@@ -218,6 +271,26 @@ async fn start_directive(
     config
         .write()
         .after_chat_completion(&input, &output, &tool_results)?;
+    let stop_outcome = if tool_results.is_empty() {
+        let event = HookEvent::Stop {
+            stop_hook_active: true,
+            last_assistant_message: Some(output.clone()),
+        };
+        let stop_outcome = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+        if let Some(additional_context) = stop_outcome
+            .result
+            .additional_context
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            debug!(
+                "Captured Stop hook additional context for later auto-continue in CMD: {additional_context}"
+            );
+        }
+        Some(stop_outcome)
+    } else {
+        None
+    };
 
     if !tool_results.is_empty() {
         start_directive(
@@ -229,11 +302,12 @@ async fn start_directive(
         .await?;
     }
 
-    config.write().exit_session()?;
+    let _ = stop_outcome;
     Ok(())
 }
 
 async fn start_interactive(config: &GlobalConfig) -> Result<()> {
+    dispatch_session_start(config, "repl").await;
     let mut repl: Repl = Repl::init(config)?;
     repl.run().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,9 @@ use crate::config::{
     WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE, SHELL_ROLE, TEMP_SESSION_NAME,
 };
 use crate::hooks::{
-    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers,
-    AsyncHookManager, PersistentHookManager, HookEvent, HookResultControl,
+    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers, drain_async_results,
+    inject_pending_async_context, AsyncHookManager, HookEvent, HookResultControl,
+    PersistentHookManager,
 };
 use crate::render::render_error;
 use crate::repl::Repl;
@@ -186,7 +187,8 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         false => {
             let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
             let mut async_manager = AsyncHookManager::new();
-            let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
+            let persistent_manager =
+                Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
             let mut pending_async_context = None;
             dispatch_session_start(&config, "cmd", &async_manager, &persistent_manager).await;
             let result = start_directive(
@@ -210,51 +212,6 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
             start_interactive(&config).await
         }
     }
-}
-
-fn append_pending_context(pending_async_context: &mut Option<String>, context: String) {
-    if context.is_empty() {
-        return;
-    }
-
-    match pending_async_context {
-        Some(existing) if !existing.is_empty() => {
-            existing.push_str("\n\n");
-            existing.push_str(&context);
-        }
-        _ => *pending_async_context = Some(context),
-    }
-}
-
-fn drain_async_results(
-    async_manager: &mut AsyncHookManager,
-    pending_async_context: &mut Option<String>,
-) -> bool {
-    let mut resume = false;
-    if let Some(pending) = async_manager.drain_pending() {
-        if let Some(context) = pending.additional_context.filter(|value| !value.is_empty()) {
-            append_pending_context(pending_async_context, context);
-        }
-        resume = pending.resume.unwrap_or(false);
-    }
-    resume
-}
-
-fn inject_pending_async_context(input: &mut Input, pending_async_context: &mut Option<String>) {
-    let Some(context) = pending_async_context
-        .take()
-        .filter(|value| !value.is_empty())
-    else {
-        return;
-    };
-
-    let input_text = input.text();
-    input.clear_patch();
-    input.set_text(if input_text.is_empty() {
-        context
-    } else {
-        format!("{context}\n\n{input_text}")
-    });
 }
 
 fn hook_dispatch_context(config: &GlobalConfig) -> (crate::hooks::HooksConfig, String, PathBuf) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod client;
 mod config;
 mod function;
+mod hooks;
 mod rag;
 mod render;
 mod repl;

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,7 @@ async fn start_directive_inner(
     mut input: Input,
     code_mode: bool,
     abort_signal: AbortSignal,
-    auto_continue_count: u32,
+    resume_count: u32,
     with_embeddings: bool,
 ) -> Result<()> {
     if with_embeddings {
@@ -271,7 +271,7 @@ async fn start_directive_inner(
         &hooks.entries,
         &session_id,
         &cwd,
-        auto_continue_count,
+        resume_count,
     )
     .await;
     if let HookResultControl::Block { reason } = outcome.control {
@@ -324,7 +324,7 @@ async fn start_directive_inner(
             &hooks.entries,
             &session_id,
             &cwd,
-            auto_continue_count,
+            resume_count,
         )
         .await;
         if let Some(additional_context) = stop_outcome
@@ -348,16 +348,16 @@ async fn start_directive_inner(
             input.merge_tool_results(output, tool_results),
             code_mode,
             abort_signal,
-            auto_continue_count,
+            resume_count,
             false,
         )
         .await;
     }
 
     if let Some(stop_outcome) = stop_outcome {
-        let max_auto_continue = hooks.max_auto_continue.unwrap_or(5);
-        if stop_outcome.result.auto_continue.unwrap_or(false)
-            && auto_continue_count < max_auto_continue
+        let max_resume = hooks.max_resume.unwrap_or(5);
+        if stop_outcome.result.resume.unwrap_or(false)
+            && resume_count < max_resume
         {
             if abort_signal.aborted() {
                 return Ok(());
@@ -374,7 +374,7 @@ async fn start_directive_inner(
                 new_input,
                 code_mode,
                 abort_signal,
-                auto_continue_count + 1,
+                resume_count + 1,
                 true,
             )
             .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use crate::config::{
     ensure_parent_exists, list_agents, load_env_file, macro_execute, Config, GlobalConfig, Input,
     WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE, SHELL_ROLE, TEMP_SESSION_NAME,
 };
-use crate::hooks::{dispatch_hooks, HookEvent, HookResultControl};
+use crate::hooks::{dispatch_hooks, dispatch_hooks_with_count, HookEvent, HookResultControl};
 use crate::render::render_error;
 use crate::repl::Repl;
 use crate::utils::*;
@@ -181,8 +181,7 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
     config.write().apply_prelude()?;
     match is_repl {
         false => {
-            let mut input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
-            input.use_embeddings(abort_signal.clone()).await?;
+            let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
             dispatch_session_start(&config, "cmd").await;
             let result = start_directive(&config, input, cli.code, abort_signal).await;
             exit_session_with_hook(&config).await?;
@@ -244,6 +243,21 @@ async fn start_directive(
     code_mode: bool,
     abort_signal: AbortSignal,
 ) -> Result<()> {
+    start_directive_inner(config, input, code_mode, abort_signal, 0, true).await
+}
+
+#[async_recursion::async_recursion]
+async fn start_directive_inner(
+    config: &GlobalConfig,
+    mut input: Input,
+    code_mode: bool,
+    abort_signal: AbortSignal,
+    auto_continue_count: u32,
+    with_embeddings: bool,
+) -> Result<()> {
+    if with_embeddings {
+        input.use_embeddings(abort_signal.clone()).await?;
+    }
     let client = input.create_client()?;
     let extract_code = !*IS_STDOUT_TERMINAL && code_mode;
     config.write().before_chat_completion(&input)?;
@@ -252,21 +266,50 @@ async fn start_directive(
     let event = HookEvent::UserPromptSubmit {
         prompt: input_text.clone(),
     };
-    let outcome = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+    let outcome = dispatch_hooks_with_count(
+        &event,
+        &hooks.entries,
+        &session_id,
+        &cwd,
+        auto_continue_count,
+    )
+    .await;
     if let HookResultControl::Block { reason } = outcome.control {
         bail!("{reason}");
     }
     let (output, tool_results) = if !input.stream() || extract_code {
-        call_chat_completions(
+        match call_chat_completions(
             &input,
             true,
             extract_code,
             client.as_ref(),
             abort_signal.clone(),
         )
-        .await?
+        .await
+        {
+            Ok(result) => result,
+            Err(err) => {
+                let event = HookEvent::StopFailure {
+                    error: err.to_string(),
+                    error_type: "api_error".to_string(),
+                };
+                let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+                return Err(err);
+            }
+        }
     } else {
-        call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await?
+        match call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await
+        {
+            Ok(result) => result,
+            Err(err) => {
+                let event = HookEvent::StopFailure {
+                    error: err.to_string(),
+                    error_type: "api_error".to_string(),
+                };
+                let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+                return Err(err);
+            }
+        }
     };
     config
         .write()
@@ -276,7 +319,14 @@ async fn start_directive(
             stop_hook_active: true,
             last_assistant_message: Some(output.clone()),
         };
-        let stop_outcome = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+        let stop_outcome = dispatch_hooks_with_count(
+            &event,
+            &hooks.entries,
+            &session_id,
+            &cwd,
+            auto_continue_count,
+        )
+        .await;
         if let Some(additional_context) = stop_outcome
             .result
             .additional_context
@@ -293,16 +343,44 @@ async fn start_directive(
     };
 
     if !tool_results.is_empty() {
-        start_directive(
+        return start_directive_inner(
             config,
             input.merge_tool_results(output, tool_results),
             code_mode,
             abort_signal,
+            auto_continue_count,
+            false,
         )
-        .await?;
+        .await;
     }
 
-    let _ = stop_outcome;
+    if let Some(stop_outcome) = stop_outcome {
+        let max_auto_continue = hooks.max_auto_continue.unwrap_or(5);
+        if stop_outcome.result.auto_continue.unwrap_or(false)
+            && auto_continue_count < max_auto_continue
+        {
+            if abort_signal.aborted() {
+                return Ok(());
+            }
+
+            let context = stop_outcome
+                .result
+                .additional_context
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "Continue working on pending tasks.".to_string());
+            let new_input = Input::from_str(config, &context, None);
+            return start_directive_inner(
+                config,
+                new_input,
+                code_mode,
+                abort_signal,
+                auto_continue_count + 1,
+                true,
+            )
+            .await;
+        }
+    }
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ use crate::config::{
     WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE, SHELL_ROLE, TEMP_SESSION_NAME,
 };
 use crate::hooks::{
-    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_manager, AsyncHookManager,
-    HookEvent, HookResultControl,
+    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers,
+    AsyncHookManager, PersistentHookManager, HookEvent, HookResultControl,
 };
 use crate::render::render_error;
 use crate::repl::Repl;
@@ -186,18 +186,21 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         false => {
             let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
             let mut async_manager = AsyncHookManager::new();
+            let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
             let mut pending_async_context = None;
-            dispatch_session_start(&config, "cmd", &async_manager).await;
+            dispatch_session_start(&config, "cmd", &async_manager, &persistent_manager).await;
             let result = start_directive(
                 &config,
                 input,
                 cli.code,
                 abort_signal,
                 &mut async_manager,
+                &persistent_manager,
                 &mut pending_async_context,
             )
             .await;
-            exit_session_with_hook(&config, &async_manager).await?;
+            exit_session_with_hook(&config, &async_manager, &persistent_manager).await?;
+            persistent_manager.lock().await.shutdown();
             result
         }
         true => {
@@ -238,7 +241,10 @@ fn drain_async_results(
 }
 
 fn inject_pending_async_context(input: &mut Input, pending_async_context: &mut Option<String>) {
-    let Some(context) = pending_async_context.take().filter(|value| !value.is_empty()) else {
+    let Some(context) = pending_async_context
+        .take()
+        .filter(|value| !value.is_empty())
+    else {
         return;
     };
 
@@ -269,6 +275,7 @@ async fn dispatch_session_start(
     config: &GlobalConfig,
     source: &str,
     async_manager: &AsyncHookManager,
+    persistent_manager: &Arc<tokio::sync::Mutex<PersistentHookManager>>,
 ) {
     let (hooks, session_id, cwd) = hook_dispatch_context(config);
     let model_id = config.read().current_model().id().to_string();
@@ -276,12 +283,22 @@ async fn dispatch_session_start(
         source: source.to_string(),
         model: model_id,
     };
-    let _ =
-        dispatch_hooks_with_manager(&event, &hooks.entries, &session_id, &cwd, Some(async_manager))
-            .await;
+    let _ = dispatch_hooks_with_managers(
+        &event,
+        &hooks.entries,
+        &session_id,
+        &cwd,
+        Some(async_manager),
+        Some(persistent_manager),
+    )
+    .await;
 }
 
-async fn exit_session_with_hook(config: &GlobalConfig, async_manager: &AsyncHookManager) -> Result<()> {
+async fn exit_session_with_hook(
+    config: &GlobalConfig,
+    async_manager: &AsyncHookManager,
+    persistent_manager: &Arc<tokio::sync::Mutex<PersistentHookManager>>,
+) -> Result<()> {
     let (hooks, session_id, cwd) = hook_dispatch_context(config);
     config.write().exit_session()?;
     let event = HookEvent::SessionEnd {
@@ -289,7 +306,14 @@ async fn exit_session_with_hook(config: &GlobalConfig, async_manager: &AsyncHook
     };
     let _ = tokio::time::timeout(
         Duration::from_secs(5),
-        dispatch_hooks_with_manager(&event, &hooks.entries, &session_id, &cwd, Some(async_manager)),
+        dispatch_hooks_with_managers(
+            &event,
+            &hooks.entries,
+            &session_id,
+            &cwd,
+            Some(async_manager),
+            Some(persistent_manager),
+        ),
     )
     .await;
     Ok(())
@@ -302,6 +326,7 @@ async fn start_directive(
     code_mode: bool,
     abort_signal: AbortSignal,
     async_manager: &mut AsyncHookManager,
+    persistent_manager: &Arc<tokio::sync::Mutex<PersistentHookManager>>,
     pending_async_context: &mut Option<String>,
 ) -> Result<()> {
     start_directive_inner(
@@ -310,6 +335,7 @@ async fn start_directive(
         code_mode,
         abort_signal,
         async_manager,
+        persistent_manager,
         pending_async_context,
         0,
         true,
@@ -324,6 +350,7 @@ async fn start_directive_inner(
     code_mode: bool,
     abort_signal: AbortSignal,
     async_manager: &mut AsyncHookManager,
+    persistent_manager: &Arc<tokio::sync::Mutex<PersistentHookManager>>,
     pending_async_context: &mut Option<String>,
     resume_count: u32,
     with_embeddings: bool,
@@ -348,6 +375,7 @@ async fn start_directive_inner(
         &cwd,
         resume_count,
         Some(async_manager),
+        Some(persistent_manager),
     )
     .await;
     if let HookResultControl::Block { reason } = outcome.control {
@@ -369,32 +397,33 @@ async fn start_directive_inner(
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                let _ = dispatch_hooks_with_manager(
+                let _ = dispatch_hooks_with_managers(
                     &event,
                     &hooks.entries,
                     &session_id,
                     &cwd,
                     Some(async_manager),
+                    Some(persistent_manager),
                 )
                 .await;
                 return Err(err);
             }
         }
     } else {
-        match call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await
-        {
+        match call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await {
             Ok(result) => result,
             Err(err) => {
                 let event = HookEvent::StopFailure {
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                let _ = dispatch_hooks_with_manager(
+                let _ = dispatch_hooks_with_managers(
                     &event,
                     &hooks.entries,
                     &session_id,
                     &cwd,
                     Some(async_manager),
+                    Some(persistent_manager),
                 )
                 .await;
                 return Err(err);
@@ -416,6 +445,7 @@ async fn start_directive_inner(
             &cwd,
             resume_count,
             Some(async_manager),
+            Some(persistent_manager),
         )
         .await;
         if let Some(additional_context) = stop_outcome
@@ -440,6 +470,7 @@ async fn start_directive_inner(
             code_mode,
             abort_signal,
             async_manager,
+            persistent_manager,
             pending_async_context,
             resume_count,
             false,
@@ -449,9 +480,7 @@ async fn start_directive_inner(
 
     if let Some(stop_outcome) = stop_outcome {
         let max_resume = hooks.max_resume.unwrap_or(5);
-        if stop_outcome.result.resume.unwrap_or(false)
-            && resume_count < max_resume
-        {
+        if stop_outcome.result.resume.unwrap_or(false) && resume_count < max_resume {
             if abort_signal.aborted() {
                 return Ok(());
             }
@@ -468,6 +497,7 @@ async fn start_directive_inner(
                 code_mode,
                 abort_signal,
                 async_manager,
+                persistent_manager,
                 pending_async_context,
                 resume_count + 1,
                 true,
@@ -493,6 +523,7 @@ async fn start_directive_inner(
             code_mode,
             abort_signal,
             async_manager,
+            persistent_manager,
             pending_async_context,
             resume_count + 1,
             true,
@@ -505,10 +536,12 @@ async fn start_directive_inner(
 
 async fn start_interactive(config: &GlobalConfig) -> Result<()> {
     let async_manager = AsyncHookManager::new();
-    dispatch_session_start(config, "repl", &async_manager).await;
-    let mut repl: Repl = Repl::init(config, async_manager)?;
+    let persistent_manager = Arc::new(tokio::sync::Mutex::new(PersistentHookManager::new()));
+    dispatch_session_start(config, "repl", &async_manager, &persistent_manager).await;
+    let mut repl: Repl = Repl::init(config, async_manager, persistent_manager.clone())?;
     let result = repl.run().await;
-    exit_session_with_hook(config, repl.async_manager()).await?;
+    exit_session_with_hook(config, repl.async_manager(), &persistent_manager).await?;
+    persistent_manager.lock().await.shutdown();
     result
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,10 @@ use crate::config::{
     ensure_parent_exists, list_agents, load_env_file, macro_execute, Config, GlobalConfig, Input,
     WorkingMode, CODE_ROLE, EXPLAIN_SHELL_ROLE, SHELL_ROLE, TEMP_SESSION_NAME,
 };
-use crate::hooks::{dispatch_hooks, dispatch_hooks_with_count, HookEvent, HookResultControl};
+use crate::hooks::{
+    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_manager, AsyncHookManager,
+    HookEvent, HookResultControl,
+};
 use crate::render::render_error;
 use crate::repl::Repl;
 use crate::utils::*;
@@ -182,20 +185,70 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
     match is_repl {
         false => {
             let input = create_input(&config, text, &cli.file, abort_signal.clone()).await?;
-            dispatch_session_start(&config, "cmd").await;
-            let result = start_directive(&config, input, cli.code, abort_signal).await;
-            exit_session_with_hook(&config).await?;
+            let mut async_manager = AsyncHookManager::new();
+            let mut pending_async_context = None;
+            dispatch_session_start(&config, "cmd", &async_manager).await;
+            let result = start_directive(
+                &config,
+                input,
+                cli.code,
+                abort_signal,
+                &mut async_manager,
+                &mut pending_async_context,
+            )
+            .await;
+            exit_session_with_hook(&config, &async_manager).await?;
             result
         }
         true => {
             if !*IS_STDOUT_TERMINAL {
                 bail!("No TTY for REPL")
             }
-            let result = start_interactive(&config).await;
-            exit_session_with_hook(&config).await?;
-            result
+            start_interactive(&config).await
         }
     }
+}
+
+fn append_pending_context(pending_async_context: &mut Option<String>, context: String) {
+    if context.is_empty() {
+        return;
+    }
+
+    match pending_async_context {
+        Some(existing) if !existing.is_empty() => {
+            existing.push_str("\n\n");
+            existing.push_str(&context);
+        }
+        _ => *pending_async_context = Some(context),
+    }
+}
+
+fn drain_async_results(
+    async_manager: &mut AsyncHookManager,
+    pending_async_context: &mut Option<String>,
+) -> bool {
+    let mut resume = false;
+    if let Some(pending) = async_manager.drain_pending() {
+        if let Some(context) = pending.additional_context.filter(|value| !value.is_empty()) {
+            append_pending_context(pending_async_context, context);
+        }
+        resume = pending.resume.unwrap_or(false);
+    }
+    resume
+}
+
+fn inject_pending_async_context(input: &mut Input, pending_async_context: &mut Option<String>) {
+    let Some(context) = pending_async_context.take().filter(|value| !value.is_empty()) else {
+        return;
+    };
+
+    let input_text = input.text();
+    input.clear_patch();
+    input.set_text(if input_text.is_empty() {
+        context
+    } else {
+        format!("{context}\n\n{input_text}")
+    });
 }
 
 fn hook_dispatch_context(config: &GlobalConfig) -> (crate::hooks::HooksConfig, String, PathBuf) {
@@ -212,17 +265,23 @@ fn hook_dispatch_context(config: &GlobalConfig) -> (crate::hooks::HooksConfig, S
     )
 }
 
-async fn dispatch_session_start(config: &GlobalConfig, source: &str) {
+async fn dispatch_session_start(
+    config: &GlobalConfig,
+    source: &str,
+    async_manager: &AsyncHookManager,
+) {
     let (hooks, session_id, cwd) = hook_dispatch_context(config);
     let model_id = config.read().current_model().id().to_string();
     let event = HookEvent::SessionStart {
         source: source.to_string(),
         model: model_id,
     };
-    let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+    let _ =
+        dispatch_hooks_with_manager(&event, &hooks.entries, &session_id, &cwd, Some(async_manager))
+            .await;
 }
 
-async fn exit_session_with_hook(config: &GlobalConfig) -> Result<()> {
+async fn exit_session_with_hook(config: &GlobalConfig, async_manager: &AsyncHookManager) -> Result<()> {
     let (hooks, session_id, cwd) = hook_dispatch_context(config);
     config.write().exit_session()?;
     let event = HookEvent::SessionEnd {
@@ -230,7 +289,7 @@ async fn exit_session_with_hook(config: &GlobalConfig) -> Result<()> {
     };
     let _ = tokio::time::timeout(
         Duration::from_secs(5),
-        dispatch_hooks(&event, &hooks.entries, &session_id, &cwd),
+        dispatch_hooks_with_manager(&event, &hooks.entries, &session_id, &cwd, Some(async_manager)),
     )
     .await;
     Ok(())
@@ -242,8 +301,20 @@ async fn start_directive(
     input: Input,
     code_mode: bool,
     abort_signal: AbortSignal,
+    async_manager: &mut AsyncHookManager,
+    pending_async_context: &mut Option<String>,
 ) -> Result<()> {
-    start_directive_inner(config, input, code_mode, abort_signal, 0, true).await
+    start_directive_inner(
+        config,
+        input,
+        code_mode,
+        abort_signal,
+        async_manager,
+        pending_async_context,
+        0,
+        true,
+    )
+    .await
 }
 
 #[async_recursion::async_recursion]
@@ -252,12 +323,16 @@ async fn start_directive_inner(
     mut input: Input,
     code_mode: bool,
     abort_signal: AbortSignal,
+    async_manager: &mut AsyncHookManager,
+    pending_async_context: &mut Option<String>,
     resume_count: u32,
     with_embeddings: bool,
 ) -> Result<()> {
     if with_embeddings {
         input.use_embeddings(abort_signal.clone()).await?;
     }
+    drain_async_results(async_manager, pending_async_context);
+    inject_pending_async_context(&mut input, pending_async_context);
     let client = input.create_client()?;
     let extract_code = !*IS_STDOUT_TERMINAL && code_mode;
     config.write().before_chat_completion(&input)?;
@@ -266,12 +341,13 @@ async fn start_directive_inner(
     let event = HookEvent::UserPromptSubmit {
         prompt: input_text.clone(),
     };
-    let outcome = dispatch_hooks_with_count(
+    let outcome = dispatch_hooks_with_count_and_manager(
         &event,
         &hooks.entries,
         &session_id,
         &cwd,
         resume_count,
+        Some(async_manager),
     )
     .await;
     if let HookResultControl::Block { reason } = outcome.control {
@@ -293,7 +369,14 @@ async fn start_directive_inner(
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+                let _ = dispatch_hooks_with_manager(
+                    &event,
+                    &hooks.entries,
+                    &session_id,
+                    &cwd,
+                    Some(async_manager),
+                )
+                .await;
                 return Err(err);
             }
         }
@@ -306,7 +389,14 @@ async fn start_directive_inner(
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+                let _ = dispatch_hooks_with_manager(
+                    &event,
+                    &hooks.entries,
+                    &session_id,
+                    &cwd,
+                    Some(async_manager),
+                )
+                .await;
                 return Err(err);
             }
         }
@@ -319,12 +409,13 @@ async fn start_directive_inner(
             stop_hook_active: true,
             last_assistant_message: Some(output.clone()),
         };
-        let stop_outcome = dispatch_hooks_with_count(
+        let stop_outcome = dispatch_hooks_with_count_and_manager(
             &event,
             &hooks.entries,
             &session_id,
             &cwd,
             resume_count,
+            Some(async_manager),
         )
         .await;
         if let Some(additional_context) = stop_outcome
@@ -348,6 +439,8 @@ async fn start_directive_inner(
             input.merge_tool_results(output, tool_results),
             code_mode,
             abort_signal,
+            async_manager,
+            pending_async_context,
             resume_count,
             false,
         )
@@ -374,6 +467,8 @@ async fn start_directive_inner(
                 new_input,
                 code_mode,
                 abort_signal,
+                async_manager,
+                pending_async_context,
                 resume_count + 1,
                 true,
             )
@@ -381,13 +476,40 @@ async fn start_directive_inner(
         }
     }
 
+    let max_resume = hooks.max_resume.unwrap_or(5);
+    if drain_async_results(async_manager, pending_async_context) && resume_count < max_resume {
+        if abort_signal.aborted() {
+            return Ok(());
+        }
+
+        let context = pending_async_context
+            .take()
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "Continue working on pending tasks.".to_string());
+        let new_input = Input::from_str(config, &context, None);
+        return start_directive_inner(
+            config,
+            new_input,
+            code_mode,
+            abort_signal,
+            async_manager,
+            pending_async_context,
+            resume_count + 1,
+            true,
+        )
+        .await;
+    }
+
     Ok(())
 }
 
 async fn start_interactive(config: &GlobalConfig) -> Result<()> {
-    dispatch_session_start(config, "repl").await;
-    let mut repl: Repl = Repl::init(config)?;
-    repl.run().await
+    let async_manager = AsyncHookManager::new();
+    dispatch_session_start(config, "repl", &async_manager).await;
+    let mut repl: Repl = Repl::init(config, async_manager)?;
+    let result = repl.run().await;
+    exit_session_with_hook(config, repl.async_manager()).await?;
+    result
 }
 
 #[async_recursion::async_recursion]

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -11,7 +11,10 @@ use crate::config::{
     macro_execute, AgentVariables, AssertState, Config, GlobalConfig, Input, LastMessage,
     StateFlags,
 };
-use crate::hooks::{dispatch_hooks, dispatch_hooks_with_count, HookEvent, HookResultControl};
+use crate::hooks::{
+    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_manager, AsyncHookManager,
+    HookEvent, HookResultControl,
+};
 use crate::render::render_error;
 use crate::utils::{
     abortable_run_with_spinner, create_abort_signal, dimmed_text, set_text, temp_file, AbortSignal,
@@ -196,10 +199,12 @@ pub struct Repl {
     editor: Reedline,
     prompt: ReplPrompt,
     abort_signal: AbortSignal,
+    async_manager: AsyncHookManager,
+    pending_async_context: Option<String>,
 }
 
 impl Repl {
-    pub fn init(config: &GlobalConfig) -> Result<Self> {
+    pub fn init(config: &GlobalConfig, async_manager: AsyncHookManager) -> Result<Self> {
         let editor = Self::create_editor(config)?;
 
         let prompt = ReplPrompt::new(config);
@@ -210,7 +215,13 @@ impl Repl {
             editor,
             prompt,
             abort_signal,
+            async_manager,
+            pending_async_context: None,
         })
+    }
+
+    pub fn async_manager(&self) -> &AsyncHookManager {
+        &self.async_manager
     }
 
     pub async fn run(&mut self) -> Result<()> {
@@ -230,11 +241,22 @@ Type ".help" for additional help.
             if self.abort_signal.aborted_ctrld() {
                 break;
             }
+            if self.process_pending_async_resume().await? {
+                continue;
+            }
             let sig = self.editor.read_line(&self.prompt);
             match sig {
                 Ok(Signal::Success(line)) => {
                     self.abort_signal.reset();
-                    match run_repl_command(&self.config, self.abort_signal.clone(), &line).await {
+                    match run_repl_command(
+                        &self.config,
+                        self.abort_signal.clone(),
+                        &line,
+                        &mut self.async_manager,
+                        &mut self.pending_async_context,
+                    )
+                    .await
+                    {
                         Ok(exit) => {
                             if exit {
                                 break;
@@ -259,6 +281,42 @@ Type ".help" for additional help.
         }
         self.config.write().exit_session()?;
         Ok(())
+    }
+
+    async fn process_pending_async_resume(&mut self) -> Result<bool> {
+        let (should_resume, max_resume) = {
+            let config = self.config.read();
+            let hooks = config.resolved_hooks();
+            (drain_async_results(
+                &mut self.async_manager,
+                &mut self.pending_async_context,
+            ), hooks.max_resume.unwrap_or(5))
+        };
+        if !should_resume {
+            return Ok(false);
+        }
+
+        if self.abort_signal.aborted() {
+            return Ok(true);
+        }
+
+        let context = self
+            .pending_async_context
+            .take()
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "Continue working on pending tasks.".to_string());
+        let input = Input::from_str(&self.config, &context, None);
+        ask(
+            &self.config,
+            self.abort_signal.clone(),
+            input,
+            true,
+            &mut self.async_manager,
+            &mut self.pending_async_context,
+            max_resume,
+        )
+        .await?;
+        Ok(true)
     }
 
     fn create_editor(config: &GlobalConfig) -> Result<Reedline> {
@@ -337,6 +395,48 @@ Type ".help" for additional help.
     }
 }
 
+fn append_pending_context(pending_async_context: &mut Option<String>, context: String) {
+    if context.is_empty() {
+        return;
+    }
+
+    match pending_async_context {
+        Some(existing) if !existing.is_empty() => {
+            existing.push_str("\n\n");
+            existing.push_str(&context);
+        }
+        _ => *pending_async_context = Some(context),
+    }
+}
+
+fn drain_async_results(
+    async_manager: &mut AsyncHookManager,
+    pending_async_context: &mut Option<String>,
+) -> bool {
+    let mut resume = false;
+    if let Some(pending) = async_manager.drain_pending() {
+        if let Some(context) = pending.additional_context.filter(|value| !value.is_empty()) {
+            append_pending_context(pending_async_context, context);
+        }
+        resume = pending.resume.unwrap_or(false);
+    }
+    resume
+}
+
+fn inject_pending_async_context(input: &mut Input, pending_async_context: &mut Option<String>) {
+    let Some(context) = pending_async_context.take().filter(|value| !value.is_empty()) else {
+        return;
+    };
+
+    let input_text = input.text();
+    input.clear_patch();
+    input.set_text(if input_text.is_empty() {
+        context
+    } else {
+        format!("{context}\n\n{input_text}")
+    });
+}
+
 #[derive(Debug, Clone)]
 pub struct ReplCommand {
     name: &'static str,
@@ -376,7 +476,10 @@ pub async fn run_repl_command(
     config: &GlobalConfig,
     abort_signal: AbortSignal,
     mut line: &str,
+    async_manager: &mut AsyncHookManager,
+    pending_async_context: &mut Option<String>,
 ) -> Result<bool> {
+    let max_resume = config.read().resolved_hooks().max_resume.unwrap_or(5);
     if let Ok(Some(captures)) = MULTILINE_RE.captures(line) {
         if let Some(text_match) = captures.get(1) {
             line = text_match.as_str();
@@ -427,7 +530,16 @@ pub async fn run_repl_command(
                     Some((name, text)) => {
                         let role = config.read().retrieve_role(name.trim())?;
                         let input = Input::from_str(config, text, Some(role));
-                        ask(config, abort_signal.clone(), input, false).await?;
+                        ask(
+                            config,
+                            abort_signal.clone(),
+                            input,
+                            false,
+                            async_manager,
+                            pending_async_context,
+                            max_resume,
+                        )
+                        .await?;
                     }
                     None => {
                         let name = args;
@@ -493,7 +605,16 @@ pub async fn run_repl_command(
                         Some(text) => {
                             println!("{}", dimmed_text(&format!(">> {text}")));
                             let input = Input::from_str(config, &text, None);
-                            ask(config, abort_signal.clone(), input, true).await?;
+                            ask(
+                                config,
+                                abort_signal.clone(),
+                                input,
+                                true,
+                                async_manager,
+                                pending_async_context,
+                                max_resume,
+                            )
+                            .await?;
                         }
                         None => {
                             bail!("Invalid starter value");
@@ -601,7 +722,16 @@ pub async fn run_repl_command(
                         abort_signal.clone(),
                     )
                     .await?;
-                    ask(config, abort_signal.clone(), input, true).await?;
+                    ask(
+                        config,
+                        abort_signal.clone(),
+                        input,
+                        true,
+                        async_manager,
+                        pending_async_context,
+                        max_resume,
+                    )
+                    .await?;
                 }
                 None => println!(
                     r#"Usage: .file <file|dir|url|cmd|loader:resource|%%>... [-- <text>...]
@@ -629,7 +759,16 @@ pub async fn run_repl_command(
                     None => bail!("Unable to continue the response"),
                 };
                 input.set_continue_output(&output);
-                ask(config, abort_signal.clone(), input, true).await?;
+                ask(
+                    config,
+                    abort_signal.clone(),
+                    input,
+                    true,
+                    async_manager,
+                    pending_async_context,
+                    max_resume,
+                )
+                .await?;
             }
             ".regenerate" => {
                 let LastMessage { mut input, .. } = match config
@@ -643,7 +782,16 @@ pub async fn run_repl_command(
                     None => bail!("Unable to regenerate the response"),
                 };
                 input.set_regenerate();
-                ask(config, abort_signal.clone(), input, true).await?;
+                ask(
+                    config,
+                    abort_signal.clone(),
+                    input,
+                    true,
+                    async_manager,
+                    pending_async_context,
+                    max_resume,
+                )
+                .await?;
             }
             ".set" => match args {
                 Some(args) => {
@@ -721,7 +869,9 @@ pub async fn run_repl_command(
             let event = HookEvent::UserPromptSubmit {
                 prompt: line.to_string(),
             };
-            let outcome = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+            let outcome =
+                dispatch_hooks_with_manager(&event, &hooks.entries, &session_id, &cwd, Some(async_manager))
+                    .await;
             match outcome.control {
                 HookResultControl::Block { reason } => {
                     render_error(anyhow!(reason));
@@ -734,7 +884,16 @@ pub async fn run_repl_command(
                         _ => line.to_string(),
                     };
                     let input = Input::from_str(config, &input_text, None);
-                    ask(config, abort_signal.clone(), input, true).await?;
+                    ask(
+                        config,
+                        abort_signal.clone(),
+                        input,
+                        true,
+                        async_manager,
+                        pending_async_context,
+                        hooks.max_resume.unwrap_or(5),
+                    )
+                    .await?;
                 }
             }
         }
@@ -753,8 +912,21 @@ async fn ask(
     abort_signal: AbortSignal,
     input: Input,
     with_embeddings: bool,
+    async_manager: &mut AsyncHookManager,
+    pending_async_context: &mut Option<String>,
+    max_resume: u32,
 ) -> Result<()> {
-    ask_inner(config, abort_signal, input, with_embeddings, 0).await
+    ask_inner(
+        config,
+        abort_signal,
+        input,
+        with_embeddings,
+        async_manager,
+        pending_async_context,
+        0,
+        max_resume,
+    )
+    .await
 }
 
 #[async_recursion::async_recursion]
@@ -763,7 +935,10 @@ async fn ask_inner(
     abort_signal: AbortSignal,
     mut input: Input,
     with_embeddings: bool,
+    async_manager: &mut AsyncHookManager,
+    pending_async_context: &mut Option<String>,
     resume_count: u32,
+    max_resume: u32,
 ) -> Result<()> {
     if input.is_empty() {
         return Ok(());
@@ -774,6 +949,9 @@ async fn ask_inner(
     while config.read().is_compressing_session() {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
+
+    drain_async_results(async_manager, pending_async_context);
+    inject_pending_async_context(&mut input, pending_async_context);
 
     let client = input.create_client()?;
     config.write().before_chat_completion(&input)?;
@@ -799,7 +977,14 @@ async fn ask_inner(
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+                let _ = dispatch_hooks_with_manager(
+                    &event,
+                    &hooks.entries,
+                    &session_id,
+                    &cwd,
+                    Some(async_manager),
+                )
+                .await;
                 return Err(err);
             }
         }
@@ -812,7 +997,14 @@ async fn ask_inner(
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+                let _ = dispatch_hooks_with_manager(
+                    &event,
+                    &hooks.entries,
+                    &session_id,
+                    &cwd,
+                    Some(async_manager),
+                )
+                .await;
                 return Err(err);
             }
         }
@@ -825,12 +1017,13 @@ async fn ask_inner(
             stop_hook_active: true,
             last_assistant_message: Some(output.clone()),
         };
-        let stop_outcome = dispatch_hooks_with_count(
+        let stop_outcome = dispatch_hooks_with_count_and_manager(
             &event,
             &hooks.entries,
             &session_id,
             &cwd,
             resume_count,
+            Some(async_manager),
         )
         .await;
         if let Some(additional_context) = stop_outcome
@@ -853,23 +1046,14 @@ async fn ask_inner(
             abort_signal,
             input.merge_tool_results(output, tool_results),
             false,
+            async_manager,
+            pending_async_context,
             resume_count,
+            max_resume,
         )
         .await
     } else {
         if let Some(stop_outcome) = stop_outcome {
-            let (hooks, _, _) = {
-                let config = config.read();
-                let hooks = config.resolved_hooks();
-                let session_id = config
-                    .session
-                    .as_ref()
-                    .map(|session| session.name())
-                    .unwrap_or("default")
-                    .to_string();
-                (hooks, session_id, env::current_dir().unwrap_or_default())
-            };
-            let max_resume = hooks.max_resume.unwrap_or(5);
             if stop_outcome.result.resume.unwrap_or(false)
                 && resume_count < max_resume
             {
@@ -888,11 +1072,38 @@ async fn ask_inner(
                     abort_signal,
                     new_input,
                     true,
+                    async_manager,
+                    pending_async_context,
                     resume_count + 1,
+                    max_resume,
                 )
                 .await;
             }
         }
+
+        if drain_async_results(async_manager, pending_async_context) && resume_count < max_resume {
+            if abort_signal.aborted() {
+                return Ok(());
+            }
+
+            let context = pending_async_context
+                .take()
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "Continue working on pending tasks.".to_string());
+            let new_input = Input::from_str(config, &context, None);
+            return ask_inner(
+                config,
+                abort_signal,
+                new_input,
+                true,
+                async_manager,
+                pending_async_context,
+                resume_count + 1,
+                max_resume,
+            )
+            .await;
+        }
+
         Config::maybe_autoname_session(config.clone());
         Config::maybe_compress_session(config.clone());
         Ok(())

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -763,7 +763,7 @@ async fn ask_inner(
     abort_signal: AbortSignal,
     mut input: Input,
     with_embeddings: bool,
-    auto_continue_count: u32,
+    resume_count: u32,
 ) -> Result<()> {
     if input.is_empty() {
         return Ok(());
@@ -830,7 +830,7 @@ async fn ask_inner(
             &hooks.entries,
             &session_id,
             &cwd,
-            auto_continue_count,
+            resume_count,
         )
         .await;
         if let Some(additional_context) = stop_outcome
@@ -853,7 +853,7 @@ async fn ask_inner(
             abort_signal,
             input.merge_tool_results(output, tool_results),
             false,
-            auto_continue_count,
+            resume_count,
         )
         .await
     } else {
@@ -869,9 +869,9 @@ async fn ask_inner(
                     .to_string();
                 (hooks, session_id, env::current_dir().unwrap_or_default())
             };
-            let max_auto_continue = hooks.max_auto_continue.unwrap_or(5);
-            if stop_outcome.result.auto_continue.unwrap_or(false)
-                && auto_continue_count < max_auto_continue
+            let max_resume = hooks.max_resume.unwrap_or(5);
+            if stop_outcome.result.resume.unwrap_or(false)
+                && resume_count < max_resume
             {
                 if abort_signal.aborted() {
                     return Ok(());
@@ -888,7 +888,7 @@ async fn ask_inner(
                     abort_signal,
                     new_input,
                     true,
-                    auto_continue_count + 1,
+                    resume_count + 1,
                 )
                 .await;
             }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -11,12 +11,13 @@ use crate::config::{
     macro_execute, AgentVariables, AssertState, Config, GlobalConfig, Input, LastMessage,
     StateFlags,
 };
+use crate::hooks::{dispatch_hooks, HookEvent, HookResultControl};
 use crate::render::render_error;
 use crate::utils::{
     abortable_run_with_spinner, create_abort_signal, dimmed_text, set_text, temp_file, AbortSignal,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use crossterm::cursor::SetCursorStyle;
 use fancy_regex::Regex;
 use reedline::CursorConfig;
@@ -704,8 +705,38 @@ pub async fn run_repl_command(
             _ => unknown_command()?,
         },
         None => {
-            let input = Input::from_str(config, line, None);
-            ask(config, abort_signal.clone(), input, true).await?;
+            let (hooks, session_id) = {
+                let config = config.read();
+                (
+                    config.resolved_hooks(),
+                    config
+                        .session
+                        .as_ref()
+                        .map(|session| session.name())
+                        .unwrap_or("default")
+                        .to_string(),
+                )
+            };
+            let cwd = env::current_dir().unwrap_or_default();
+            let event = HookEvent::UserPromptSubmit {
+                prompt: line.to_string(),
+            };
+            let outcome = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+            match outcome.control {
+                HookResultControl::Block { reason } => {
+                    render_error(anyhow!(reason));
+                }
+                HookResultControl::Continue => {
+                    let input_text = match outcome.result.additional_context {
+                        Some(additional_context) if !additional_context.is_empty() => {
+                            format!("{line}\n\n{additional_context}")
+                        }
+                        _ => line.to_string(),
+                    };
+                    let input = Input::from_str(config, &input_text, None);
+                    ask(config, abort_signal.clone(), input, true).await?;
+                }
+            }
         }
     }
 
@@ -743,6 +774,39 @@ async fn ask(
     config
         .write()
         .after_chat_completion(&input, &output, &tool_results)?;
+    let stop_outcome = if tool_results.is_empty() {
+        let (hooks, session_id) = {
+            let config = config.read();
+            (
+                config.resolved_hooks(),
+                config
+                    .session
+                    .as_ref()
+                    .map(|session| session.name())
+                    .unwrap_or("default")
+                    .to_string(),
+            )
+        };
+        let cwd = env::current_dir().unwrap_or_default();
+        let event = HookEvent::Stop {
+            stop_hook_active: true,
+            last_assistant_message: Some(output.clone()),
+        };
+        let stop_outcome = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+        if let Some(additional_context) = stop_outcome
+            .result
+            .additional_context
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            debug!(
+                "Captured Stop hook additional context for later auto-continue in REPL: {additional_context}"
+            );
+        }
+        Some(stop_outcome)
+    } else {
+        None
+    };
     if !tool_results.is_empty() {
         ask(
             config,
@@ -752,6 +816,7 @@ async fn ask(
         )
         .await
     } else {
+        let _ = stop_outcome;
         Config::maybe_autoname_session(config.clone());
         Config::maybe_compress_session(config.clone());
         Ok(())

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -11,7 +11,7 @@ use crate::config::{
     macro_execute, AgentVariables, AssertState, Config, GlobalConfig, Input, LastMessage,
     StateFlags,
 };
-use crate::hooks::{dispatch_hooks, HookEvent, HookResultControl};
+use crate::hooks::{dispatch_hooks, dispatch_hooks_with_count, HookEvent, HookResultControl};
 use crate::render::render_error;
 use crate::utils::{
     abortable_run_with_spinner, create_abort_signal, dimmed_text, set_text, temp_file, AbortSignal,
@@ -751,8 +751,19 @@ pub async fn run_repl_command(
 async fn ask(
     config: &GlobalConfig,
     abort_signal: AbortSignal,
+    input: Input,
+    with_embeddings: bool,
+) -> Result<()> {
+    ask_inner(config, abort_signal, input, with_embeddings, 0).await
+}
+
+#[async_recursion::async_recursion]
+async fn ask_inner(
+    config: &GlobalConfig,
+    abort_signal: AbortSignal,
     mut input: Input,
     with_embeddings: bool,
+    auto_continue_count: u32,
 ) -> Result<()> {
     if input.is_empty() {
         return Ok(());
@@ -766,33 +777,62 @@ async fn ask(
 
     let client = input.create_client()?;
     config.write().before_chat_completion(&input)?;
+    let (hooks, session_id, cwd) = {
+        let config = config.read();
+        (
+            config.resolved_hooks(),
+            config
+                .session
+                .as_ref()
+                .map(|session| session.name())
+                .unwrap_or("default")
+                .to_string(),
+            env::current_dir().unwrap_or_default(),
+        )
+    };
     let (output, tool_results) = if input.stream() {
-        call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await?
+        match call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await
+        {
+            Ok(result) => result,
+            Err(err) => {
+                let event = HookEvent::StopFailure {
+                    error: err.to_string(),
+                    error_type: "api_error".to_string(),
+                };
+                let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+                return Err(err);
+            }
+        }
     } else {
-        call_chat_completions(&input, true, false, client.as_ref(), abort_signal.clone()).await?
+        match call_chat_completions(&input, true, false, client.as_ref(), abort_signal.clone()).await
+        {
+            Ok(result) => result,
+            Err(err) => {
+                let event = HookEvent::StopFailure {
+                    error: err.to_string(),
+                    error_type: "api_error".to_string(),
+                };
+                let _ = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+                return Err(err);
+            }
+        }
     };
     config
         .write()
         .after_chat_completion(&input, &output, &tool_results)?;
     let stop_outcome = if tool_results.is_empty() {
-        let (hooks, session_id) = {
-            let config = config.read();
-            (
-                config.resolved_hooks(),
-                config
-                    .session
-                    .as_ref()
-                    .map(|session| session.name())
-                    .unwrap_or("default")
-                    .to_string(),
-            )
-        };
-        let cwd = env::current_dir().unwrap_or_default();
         let event = HookEvent::Stop {
             stop_hook_active: true,
             last_assistant_message: Some(output.clone()),
         };
-        let stop_outcome = dispatch_hooks(&event, &hooks.entries, &session_id, &cwd).await;
+        let stop_outcome = dispatch_hooks_with_count(
+            &event,
+            &hooks.entries,
+            &session_id,
+            &cwd,
+            auto_continue_count,
+        )
+        .await;
         if let Some(additional_context) = stop_outcome
             .result
             .additional_context
@@ -808,15 +848,51 @@ async fn ask(
         None
     };
     if !tool_results.is_empty() {
-        ask(
+        ask_inner(
             config,
             abort_signal,
             input.merge_tool_results(output, tool_results),
             false,
+            auto_continue_count,
         )
         .await
     } else {
-        let _ = stop_outcome;
+        if let Some(stop_outcome) = stop_outcome {
+            let (hooks, _, _) = {
+                let config = config.read();
+                let hooks = config.resolved_hooks();
+                let session_id = config
+                    .session
+                    .as_ref()
+                    .map(|session| session.name())
+                    .unwrap_or("default")
+                    .to_string();
+                (hooks, session_id, env::current_dir().unwrap_or_default())
+            };
+            let max_auto_continue = hooks.max_auto_continue.unwrap_or(5);
+            if stop_outcome.result.auto_continue.unwrap_or(false)
+                && auto_continue_count < max_auto_continue
+            {
+                if abort_signal.aborted() {
+                    return Ok(());
+                }
+
+                let context = stop_outcome
+                    .result
+                    .additional_context
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or_else(|| "Continue working on pending tasks.".to_string());
+                let new_input = Input::from_str(config, &context, None);
+                return ask_inner(
+                    config,
+                    abort_signal,
+                    new_input,
+                    true,
+                    auto_continue_count + 1,
+                )
+                .await;
+            }
+        }
         Config::maybe_autoname_session(config.clone());
         Config::maybe_compress_session(config.clone());
         Ok(())

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -12,8 +12,9 @@ use crate::config::{
     StateFlags,
 };
 use crate::hooks::{
-    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers,
-    AsyncHookManager, PersistentHookManager, HookEvent, HookResultControl,
+    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers, drain_async_results,
+    inject_pending_async_context, AsyncHookManager, HookEvent, HookResultControl,
+    PersistentHookManager,
 };
 use crate::render::render_error;
 use crate::utils::{
@@ -403,51 +404,6 @@ Type ".help" for additional help.
     }
 }
 
-fn append_pending_context(pending_async_context: &mut Option<String>, context: String) {
-    if context.is_empty() {
-        return;
-    }
-
-    match pending_async_context {
-        Some(existing) if !existing.is_empty() => {
-            existing.push_str("\n\n");
-            existing.push_str(&context);
-        }
-        _ => *pending_async_context = Some(context),
-    }
-}
-
-fn drain_async_results(
-    async_manager: &mut AsyncHookManager,
-    pending_async_context: &mut Option<String>,
-) -> bool {
-    let mut resume = false;
-    if let Some(pending) = async_manager.drain_pending() {
-        if let Some(context) = pending.additional_context.filter(|value| !value.is_empty()) {
-            append_pending_context(pending_async_context, context);
-        }
-        resume = pending.resume.unwrap_or(false);
-    }
-    resume
-}
-
-fn inject_pending_async_context(input: &mut Input, pending_async_context: &mut Option<String>) {
-    let Some(context) = pending_async_context
-        .take()
-        .filter(|value| !value.is_empty())
-    else {
-        return;
-    };
-
-    let input_text = input.text();
-    input.clear_patch();
-    input.set_text(if input_text.is_empty() {
-        context
-    } else {
-        format!("{context}\n\n{input_text}")
-    });
-}
-
 #[derive(Debug, Clone)]
 pub struct ReplCommand {
     name: &'static str,
@@ -542,17 +498,17 @@ pub async fn run_repl_command(
                     Some((name, text)) => {
                         let role = config.read().retrieve_role(name.trim())?;
                         let input = Input::from_str(config, text, Some(role));
-                         ask(
-                             config,
-                             abort_signal.clone(),
-                             input,
-                             false,
-                             async_manager,
-                             persistent_manager,
-                             pending_async_context,
-                             max_resume,
-                         )
-                         .await?;
+                        ask(
+                            config,
+                            abort_signal.clone(),
+                            input,
+                            false,
+                            async_manager,
+                            persistent_manager,
+                            pending_async_context,
+                            max_resume,
+                        )
+                        .await?;
                     }
                     None => {
                         let name = args;
@@ -617,18 +573,18 @@ pub async fn run_repl_command(
                     match text {
                         Some(text) => {
                             println!("{}", dimmed_text(&format!(">> {text}")));
-                             let input = Input::from_str(config, &text, None);
-                             ask(
-                                 config,
-                                 abort_signal.clone(),
-                                 input,
-                                 true,
-                                 async_manager,
-                                 persistent_manager,
-                                 pending_async_context,
-                                 max_resume,
-                             )
-                             .await?;
+                            let input = Input::from_str(config, &text, None);
+                            ask(
+                                config,
+                                abort_signal.clone(),
+                                input,
+                                true,
+                                async_manager,
+                                persistent_manager,
+                                pending_async_context,
+                                max_resume,
+                            )
+                            .await?;
                         }
                         None => {
                             bail!("Invalid starter value");
@@ -907,17 +863,17 @@ pub async fn run_repl_command(
                         _ => line.to_string(),
                     };
                     let input = Input::from_str(config, &input_text, None);
-                     ask(
-                         config,
-                         abort_signal.clone(),
-                         input,
-                         true,
-                         async_manager,
-                         persistent_manager,
-                         pending_async_context,
-                         hooks.max_resume.unwrap_or(5),
-                     )
-                     .await?;
+                    ask(
+                        config,
+                        abort_signal.clone(),
+                        input,
+                        true,
+                        async_manager,
+                        persistent_manager,
+                        pending_async_context,
+                        hooks.max_resume.unwrap_or(5),
+                    )
+                    .await?;
                 }
             }
         }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -12,8 +12,8 @@ use crate::config::{
     StateFlags,
 };
 use crate::hooks::{
-    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_manager, AsyncHookManager,
-    HookEvent, HookResultControl,
+    dispatch_hooks_with_count_and_manager, dispatch_hooks_with_managers,
+    AsyncHookManager, PersistentHookManager, HookEvent, HookResultControl,
 };
 use crate::render::render_error;
 use crate::utils::{
@@ -200,11 +200,16 @@ pub struct Repl {
     prompt: ReplPrompt,
     abort_signal: AbortSignal,
     async_manager: AsyncHookManager,
+    persistent_manager: std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
     pending_async_context: Option<String>,
 }
 
 impl Repl {
-    pub fn init(config: &GlobalConfig, async_manager: AsyncHookManager) -> Result<Self> {
+    pub fn init(
+        config: &GlobalConfig,
+        async_manager: AsyncHookManager,
+        persistent_manager: std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
+    ) -> Result<Self> {
         let editor = Self::create_editor(config)?;
 
         let prompt = ReplPrompt::new(config);
@@ -216,6 +221,7 @@ impl Repl {
             prompt,
             abort_signal,
             async_manager,
+            persistent_manager,
             pending_async_context: None,
         })
     }
@@ -253,6 +259,7 @@ Type ".help" for additional help.
                         self.abort_signal.clone(),
                         &line,
                         &mut self.async_manager,
+                        &self.persistent_manager,
                         &mut self.pending_async_context,
                     )
                     .await
@@ -287,10 +294,10 @@ Type ".help" for additional help.
         let (should_resume, max_resume) = {
             let config = self.config.read();
             let hooks = config.resolved_hooks();
-            (drain_async_results(
-                &mut self.async_manager,
-                &mut self.pending_async_context,
-            ), hooks.max_resume.unwrap_or(5))
+            (
+                drain_async_results(&mut self.async_manager, &mut self.pending_async_context),
+                hooks.max_resume.unwrap_or(5),
+            )
         };
         if !should_resume {
             return Ok(false);
@@ -312,6 +319,7 @@ Type ".help" for additional help.
             input,
             true,
             &mut self.async_manager,
+            &self.persistent_manager,
             &mut self.pending_async_context,
             max_resume,
         )
@@ -424,7 +432,10 @@ fn drain_async_results(
 }
 
 fn inject_pending_async_context(input: &mut Input, pending_async_context: &mut Option<String>) {
-    let Some(context) = pending_async_context.take().filter(|value| !value.is_empty()) else {
+    let Some(context) = pending_async_context
+        .take()
+        .filter(|value| !value.is_empty())
+    else {
         return;
     };
 
@@ -477,6 +488,7 @@ pub async fn run_repl_command(
     abort_signal: AbortSignal,
     mut line: &str,
     async_manager: &mut AsyncHookManager,
+    persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
     pending_async_context: &mut Option<String>,
 ) -> Result<bool> {
     let max_resume = config.read().resolved_hooks().max_resume.unwrap_or(5);
@@ -530,16 +542,17 @@ pub async fn run_repl_command(
                     Some((name, text)) => {
                         let role = config.read().retrieve_role(name.trim())?;
                         let input = Input::from_str(config, text, Some(role));
-                        ask(
-                            config,
-                            abort_signal.clone(),
-                            input,
-                            false,
-                            async_manager,
-                            pending_async_context,
-                            max_resume,
-                        )
-                        .await?;
+                         ask(
+                             config,
+                             abort_signal.clone(),
+                             input,
+                             false,
+                             async_manager,
+                             persistent_manager,
+                             pending_async_context,
+                             max_resume,
+                         )
+                         .await?;
                     }
                     None => {
                         let name = args;
@@ -604,17 +617,18 @@ pub async fn run_repl_command(
                     match text {
                         Some(text) => {
                             println!("{}", dimmed_text(&format!(">> {text}")));
-                            let input = Input::from_str(config, &text, None);
-                            ask(
-                                config,
-                                abort_signal.clone(),
-                                input,
-                                true,
-                                async_manager,
-                                pending_async_context,
-                                max_resume,
-                            )
-                            .await?;
+                             let input = Input::from_str(config, &text, None);
+                             ask(
+                                 config,
+                                 abort_signal.clone(),
+                                 input,
+                                 true,
+                                 async_manager,
+                                 persistent_manager,
+                                 pending_async_context,
+                                 max_resume,
+                             )
+                             .await?;
                         }
                         None => {
                             bail!("Invalid starter value");
@@ -728,6 +742,7 @@ pub async fn run_repl_command(
                         input,
                         true,
                         async_manager,
+                        persistent_manager,
                         pending_async_context,
                         max_resume,
                     )
@@ -765,6 +780,7 @@ pub async fn run_repl_command(
                     input,
                     true,
                     async_manager,
+                    persistent_manager,
                     pending_async_context,
                     max_resume,
                 )
@@ -788,6 +804,7 @@ pub async fn run_repl_command(
                     input,
                     true,
                     async_manager,
+                    persistent_manager,
                     pending_async_context,
                     max_resume,
                 )
@@ -869,9 +886,15 @@ pub async fn run_repl_command(
             let event = HookEvent::UserPromptSubmit {
                 prompt: line.to_string(),
             };
-            let outcome =
-                dispatch_hooks_with_manager(&event, &hooks.entries, &session_id, &cwd, Some(async_manager))
-                    .await;
+            let outcome = dispatch_hooks_with_managers(
+                &event,
+                &hooks.entries,
+                &session_id,
+                &cwd,
+                Some(async_manager),
+                Some(persistent_manager),
+            )
+            .await;
             match outcome.control {
                 HookResultControl::Block { reason } => {
                     render_error(anyhow!(reason));
@@ -884,16 +907,17 @@ pub async fn run_repl_command(
                         _ => line.to_string(),
                     };
                     let input = Input::from_str(config, &input_text, None);
-                    ask(
-                        config,
-                        abort_signal.clone(),
-                        input,
-                        true,
-                        async_manager,
-                        pending_async_context,
-                        hooks.max_resume.unwrap_or(5),
-                    )
-                    .await?;
+                     ask(
+                         config,
+                         abort_signal.clone(),
+                         input,
+                         true,
+                         async_manager,
+                         persistent_manager,
+                         pending_async_context,
+                         hooks.max_resume.unwrap_or(5),
+                     )
+                     .await?;
                 }
             }
         }
@@ -913,6 +937,7 @@ async fn ask(
     input: Input,
     with_embeddings: bool,
     async_manager: &mut AsyncHookManager,
+    persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
     pending_async_context: &mut Option<String>,
     max_resume: u32,
 ) -> Result<()> {
@@ -922,6 +947,7 @@ async fn ask(
         input,
         with_embeddings,
         async_manager,
+        persistent_manager,
         pending_async_context,
         0,
         max_resume,
@@ -936,6 +962,7 @@ async fn ask_inner(
     mut input: Input,
     with_embeddings: bool,
     async_manager: &mut AsyncHookManager,
+    persistent_manager: &std::sync::Arc<tokio::sync::Mutex<PersistentHookManager>>,
     pending_async_context: &mut Option<String>,
     resume_count: u32,
     max_resume: u32,
@@ -969,27 +996,28 @@ async fn ask_inner(
         )
     };
     let (output, tool_results) = if input.stream() {
-        match call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await
-        {
+        match call_chat_completions_streaming(&input, client.as_ref(), abort_signal.clone()).await {
             Ok(result) => result,
             Err(err) => {
                 let event = HookEvent::StopFailure {
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                let _ = dispatch_hooks_with_manager(
+                let _ = dispatch_hooks_with_managers(
                     &event,
                     &hooks.entries,
                     &session_id,
                     &cwd,
                     Some(async_manager),
+                    Some(persistent_manager),
                 )
                 .await;
                 return Err(err);
             }
         }
     } else {
-        match call_chat_completions(&input, true, false, client.as_ref(), abort_signal.clone()).await
+        match call_chat_completions(&input, true, false, client.as_ref(), abort_signal.clone())
+            .await
         {
             Ok(result) => result,
             Err(err) => {
@@ -997,12 +1025,13 @@ async fn ask_inner(
                     error: err.to_string(),
                     error_type: "api_error".to_string(),
                 };
-                let _ = dispatch_hooks_with_manager(
+                let _ = dispatch_hooks_with_managers(
                     &event,
                     &hooks.entries,
                     &session_id,
                     &cwd,
                     Some(async_manager),
+                    Some(persistent_manager),
                 )
                 .await;
                 return Err(err);
@@ -1024,6 +1053,7 @@ async fn ask_inner(
             &cwd,
             resume_count,
             Some(async_manager),
+            Some(persistent_manager),
         )
         .await;
         if let Some(additional_context) = stop_outcome
@@ -1047,6 +1077,7 @@ async fn ask_inner(
             input.merge_tool_results(output, tool_results),
             false,
             async_manager,
+            persistent_manager,
             pending_async_context,
             resume_count,
             max_resume,
@@ -1054,9 +1085,7 @@ async fn ask_inner(
         .await
     } else {
         if let Some(stop_outcome) = stop_outcome {
-            if stop_outcome.result.resume.unwrap_or(false)
-                && resume_count < max_resume
-            {
+            if stop_outcome.result.resume.unwrap_or(false) && resume_count < max_resume {
                 if abort_signal.aborted() {
                     return Ok(());
                 }
@@ -1073,6 +1102,7 @@ async fn ask_inner(
                     new_input,
                     true,
                     async_manager,
+                    persistent_manager,
                     pending_async_context,
                     resume_count + 1,
                     max_resume,
@@ -1097,6 +1127,7 @@ async fn ask_inner(
                 new_input,
                 true,
                 async_manager,
+                persistent_manager,
                 pending_async_context,
                 resume_count + 1,
                 max_resume,


### PR DESCRIPTION
Hooks provide a powerful extension point for an agent harness.  They can be used to extend the environment with memory, tracing, guardrails, and many other benefits.

This PR provides an implementation of hooks that are compatible with claude code hooks, allowing use of various existing hooks that were created for claude code or other agent runners that support claude code hooks

The hooks can be added globally or per-agent.
