### PR TITLE
feat: port apfel demos into aichat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+cargo build                        # Debug build
+cargo build --release              # Release build (LTO, stripped, opt-level="z")
+cargo test --all                   # Run all tests (21 tests)
+cargo test <test_name>             # Run single test, e.g. cargo test test_parse_structure_prompt1
+cargo clippy --all --all-targets -- -D warnings   # Lint (CI enforces zero warnings)
+cargo fmt --all --check            # Format check
+```
+
+CI runs on Linux, macOS, and Windows with `RUSTFLAGS=--deny warnings`.
+
+## Architecture
+
+AIChat is an all-in-one CLI for 20+ LLM providers. It has three working modes selected at startup in `main.rs`:
+
+- **CMD mode** (default) - single request/response, then exit
+- **REPL mode** (no args + interactive terminal) - persistent interactive loop with 36+ dot-commands
+- **Serve mode** (`--serve`) - HTTP server exposing OpenAI-compatible APIs, plus web Playground and Arena UIs
+
+### Core modules
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/client/` | LLM provider implementations behind the `Client` trait (`common.rs`) |
+| `src/config/` | `Config` struct (global state machine), `Input`, `Role`, `Session`, `Agent` |
+| `src/rag/` | RAG pipeline: document splitting, HNSW vector search, BM25 lexical search, reranking |
+| `src/repl/` | Interactive REPL: line editing (reedline), completion, highlighting, command dispatch |
+| `src/render/` | Markdown rendering with syntax highlighting (syntect) for terminal output |
+| `src/serve.rs` | HTTP server (hyper) with chat completions, embeddings, rerank endpoints |
+| `src/function.rs` | Tool/function calling: declaration registry, execution, result merging |
+| `src/utils/` | Abort signals, clipboard, HTTP requests, spinners, document loaders, path utils |
+
+### Client plugin system
+
+New LLM providers are added via three macros in `src/client/macros.rs`:
+
+1. `register_client!` - called once in `src/client/mod.rs` to register all providers. Generates the `ClientConfig` enum, per-client structs, `init_client()`, and model listing functions.
+2. `impl_client_trait!` - implements the `Client` trait for a provider by wiring up `prepare_*` and `handle_*` functions for chat completions, embeddings, and rerank.
+3. `client_common_fns!` - provides shared accessor methods (`global_config`, `name`, `model`, etc.).
+
+Each provider module (e.g., `openai.rs`, `claude.rs`) defines a config struct and the three function pairs (prepare + handle) for chat, embeddings, and rerank. The `openai_compatible.rs` module backs 18 additional providers that share the OpenAI API format.
+
+### Configuration and state
+
+`Config` (`src/config/mod.rs`) acts as both persistent settings (from `~/.aichat/config.yaml`) and runtime state. It holds the current model, role, session, RAG, and agent. State transitions happen through methods like `use_role()`, `use_session()`, `use_agent()`. It's wrapped in `Arc<RwLock<Config>>` as `GlobalConfig` and threaded through the entire application.
+
+### Tool call loop
+
+When an LLM returns tool calls: deduplicate calls, execute each tool (find function in registry, run executable, capture output), merge results back into the input, then recursively call the LLM again. This loop is in `main.rs` and `function.rs`.
+
+### RAG pipeline
+
+Documents are split (language-aware: markdown, HTML, code), embedded via an embedding model, indexed with HNSW (vector) and BM25 (lexical), then hybrid-searched at query time with optional reranking. Data persists as YAML in `~/.aichat/rags/`.
+
+### Key patterns
+
+- **Abort signal** (`utils/abort_signal.rs`) - `Arc<AtomicBool>` + tokio watch channel, passed through async operations for Ctrl+C cancellation via `tokio::select!`
+- **Streaming** (`client/stream.rs`) - SSE event processing with `SseHandler` for real-time token output
+- **Role templating** (`config/role.rs`) - Markdown frontmatter (model, temperature, use_tools) + structured prompts with `### INPUT:`/`### OUTPUT:` sections for few-shot examples
+- **Session compression** (`config/session.rs`) - summarizes old messages when token count exceeds threshold
+
+## Adding a new LLM provider
+
+1. Create `src/client/<provider>.rs` with a config struct and implement `prepare_chat_completions`, `chat_completions`, `chat_completions_streaming` (plus embeddings/rerank if supported)
+2. Add the provider to `register_client!` in `src/client/mod.rs`
+3. Use `impl_client_trait!` to wire up the trait implementation
+4. If OpenAI-compatible, add to `OPENAI_COMPATIBLE_PROVIDERS` array instead
+5. Add model definitions to `models.yaml`

--- a/assets/roles/explain.md
+++ b/assets/roles/explain.md
@@ -1,0 +1,5 @@
+Explain what the given command, error message, or code snippet does.
+Be specific about each part, flag, and argument.
+If it is an error, explain what caused it and how to fix it.
+Provide short responses in about 80 words.
+APPLY MARKDOWN formatting when possible.

--- a/assets/roles/gitsum.md
+++ b/assets/roles/gitsum.md
@@ -1,0 +1,5 @@
+Summarize the provided git log in 2-4 sentences.
+Group related changes together (features, fixes, refactors, docs).
+Mention what was built or changed, not individual commit hashes.
+Be specific about what happened.
+No bullet points.

--- a/assets/roles/mac-narrator.md
+++ b/assets/roles/mac-narrator.md
@@ -1,0 +1,5 @@
+You narrate this computer's life like a nature documentary.
+Given system data, respond with EXACTLY 1-2 short sentences.
+Be specific about process names and numbers.
+Dry British humor.
+No bullet points, no lists.

--- a/assets/roles/naming.md
+++ b/assets/roles/naming.md
@@ -1,0 +1,6 @@
+Suggest 5 names for what the user describes.
+Show each on its own line in this exact format:
+camelCase | snake_case | short explanation (max 5 words)
+
+No numbering, no bullet points, no other text.
+Just 5 lines of suggestions.

--- a/assets/roles/oneliner.md
+++ b/assets/roles/oneliner.md
@@ -1,0 +1,5 @@
+You generate UNIX one-liners for {{__os_distro__}} ({{__shell__}}).
+Output ONLY the command -- no explanation, no markdown, no code fences.
+Prefer awk, sed, grep, sort, uniq, cut, tr, xargs, find, and jq.
+Use pipes. Keep it to a single line.
+Never output anything except the command itself.

--- a/assets/roles/port.md
+++ b/assets/roles/port.md
@@ -1,0 +1,4 @@
+Explain in 1-2 sentences what process is using the given port.
+Mention the process name, PID, and what the process likely is (e.g., "Node.js dev server", "PostgreSQL database", "nginx web server").
+If multiple processes are listed, mention all.
+Be specific. No bullet points.

--- a/assets/roles/wtd.md
+++ b/assets/roles/wtd.md
@@ -1,0 +1,4 @@
+Summarize what this directory or project is in 2-3 sentences.
+Mention the language or framework, what it does, and how to build or run it if obvious from the provided context.
+Be concise and specific.
+No bullet points.

--- a/scripts/shell-integration/demos.bash
+++ b/scripts/shell-integration/demos.bash
@@ -1,0 +1,112 @@
+# Demo commands for aichat (bash)
+# Source this file in your .bashrc:
+#   source /path/to/demos.bash
+
+# cmd — natural language to shell command (wraps aichat -e)
+cmd() {
+    aichat -e "$*"
+}
+
+# oneliner — complex pipe chains from plain English
+oneliner() {
+    aichat -r oneliner "$*"
+}
+
+# explain — explain a command, error, or code snippet
+# Usage: explain "some command"
+#        some-command 2>&1 | explain
+explain() {
+    if [[ -n "$1" ]]; then
+        aichat -r explain "$*"
+    elif [[ ! -t 0 ]]; then
+        aichat -r explain
+    else
+        echo 'Usage: explain "command or error"'
+        echo '       some-command | explain'
+        return 1
+    fi
+}
+
+# naming — suggest names for code elements
+naming() {
+    if [[ -z "$1" ]]; then
+        echo 'Usage: naming "describe what it does"'
+        return 1
+    fi
+    aichat -r naming "$*"
+}
+
+# wtd — what's this directory?
+# Usage: wtd [directory]
+wtd() {
+    local target="${1:-.}"
+    if [[ ! -d "$target" ]]; then
+        echo "Error: '$target' is not a directory" >&2
+        return 1
+    fi
+    local snapshot=""
+    snapshot+="Directory: $(cd "$target" && pwd)"$'\n'
+    snapshot+="$(ls -la "$target" 2>/dev/null | head -30)"$'\n'
+    for f in README.md README readme.md Package.swift package.json Cargo.toml go.mod pyproject.toml Makefile Dockerfile; do
+        if [[ -f "$target/$f" ]]; then
+            snapshot+=$'\n'"--- $f (first 5 lines) ---"$'\n'
+            snapshot+="$(head -5 "$target/$f" 2>/dev/null)"$'\n'
+        fi
+    done
+    if git -C "$target" rev-parse --git-dir &>/dev/null 2>&1; then
+        snapshot+=$'\n'"--- git ---"$'\n'
+        snapshot+="branch: $(git -C "$target" branch --show-current 2>/dev/null)"$'\n'
+        snapshot+="last commit: $(git -C "$target" log --oneline -1 2>/dev/null)"$'\n'
+    fi
+    echo "$snapshot" | aichat -r wtd
+}
+
+# port — what's using this port?
+port() {
+    if [[ -z "$1" ]] || ! [[ "$1" =~ ^[0-9]+$ ]]; then
+        echo 'Usage: port <port-number>'
+        return 1
+    fi
+    local info
+    info=$(lsof -i :"$1" -P -n 2>/dev/null)
+    if [[ -z "$info" ]]; then
+        echo "Nothing is using port $1."
+        return 0
+    fi
+    echo "Port $1:"$'\n'"$info" | aichat -r port
+}
+
+# gitsum — summarize recent git activity
+# Usage: gitsum [count]
+gitsum() {
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        echo "Error: not a git repository" >&2
+        return 1
+    fi
+    local count="${1:-10}"
+    local log branch authors
+    log=$(git log --oneline -"$count" 2>/dev/null)
+    branch=$(git branch --show-current 2>/dev/null)
+    authors=$(git log --format='%an' -"$count" 2>/dev/null | sort | uniq -c | sort -rn | head -5)
+    if [[ -z "$log" ]]; then
+        echo "No commits found."
+        return 0
+    fi
+    printf "Branch: %s\nRecent %s commits:\n%s\n\nAuthors:\n%s\n" \
+        "$branch" "$count" "$log" "$authors" | aichat -r gitsum
+}
+
+# mac-narrator — your Mac's inner monologue
+mac-narrator() {
+    local snapshot
+    snapshot=$(
+        ps -eo pid,%cpu,%mem,comm -r 2>/dev/null | head -8
+        echo "---"
+        vm_stat 2>/dev/null | head -5
+        echo "---"
+        df -h / 2>/dev/null | tail -1
+        echo "---"
+        uptime 2>/dev/null
+    )
+    echo "$snapshot" | aichat -r mac-narrator
+}

--- a/scripts/shell-integration/demos.zsh
+++ b/scripts/shell-integration/demos.zsh
@@ -1,0 +1,112 @@
+# Demo commands for aichat (zsh)
+# Source this file in your .zshrc:
+#   source /path/to/demos.zsh
+
+# cmd — natural language to shell command (wraps aichat -e)
+cmd() {
+    aichat -e "$*"
+}
+
+# oneliner — complex pipe chains from plain English
+oneliner() {
+    aichat -r oneliner "$*"
+}
+
+# explain — explain a command, error, or code snippet
+# Usage: explain "some command"
+#        some-command 2>&1 | explain
+explain() {
+    if [[ -n "$1" ]]; then
+        aichat -r explain "$*"
+    elif [[ ! -t 0 ]]; then
+        aichat -r explain
+    else
+        echo 'Usage: explain "command or error"'
+        echo '       some-command | explain'
+        return 1
+    fi
+}
+
+# naming — suggest names for code elements
+naming() {
+    if [[ -z "$1" ]]; then
+        echo 'Usage: naming "describe what it does"'
+        return 1
+    fi
+    aichat -r naming "$*"
+}
+
+# wtd — what's this directory?
+# Usage: wtd [directory]
+wtd() {
+    local target="${1:-.}"
+    if [[ ! -d "$target" ]]; then
+        echo "Error: '$target' is not a directory" >&2
+        return 1
+    fi
+    local snapshot=""
+    snapshot+="Directory: $(cd "$target" && pwd)"$'\n'
+    snapshot+="$(ls -la "$target" 2>/dev/null | head -30)"$'\n'
+    for f in README.md README readme.md Package.swift package.json Cargo.toml go.mod pyproject.toml Makefile Dockerfile; do
+        if [[ -f "$target/$f" ]]; then
+            snapshot+=$'\n'"--- $f (first 5 lines) ---"$'\n'
+            snapshot+="$(head -5 "$target/$f" 2>/dev/null)"$'\n'
+        fi
+    done
+    if git -C "$target" rev-parse --git-dir &>/dev/null 2>&1; then
+        snapshot+=$'\n'"--- git ---"$'\n'
+        snapshot+="branch: $(git -C "$target" branch --show-current 2>/dev/null)"$'\n'
+        snapshot+="last commit: $(git -C "$target" log --oneline -1 2>/dev/null)"$'\n'
+    fi
+    echo "$snapshot" | aichat -r wtd
+}
+
+# port — what's using this port?
+port() {
+    if [[ -z "$1" ]] || ! [[ "$1" =~ ^[0-9]+$ ]]; then
+        echo 'Usage: port <port-number>'
+        return 1
+    fi
+    local info
+    info=$(lsof -i :"$1" -P -n 2>/dev/null)
+    if [[ -z "$info" ]]; then
+        echo "Nothing is using port $1."
+        return 0
+    fi
+    echo "Port $1:"$'\n'"$info" | aichat -r port
+}
+
+# gitsum — summarize recent git activity
+# Usage: gitsum [count]
+gitsum() {
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        echo "Error: not a git repository" >&2
+        return 1
+    fi
+    local count="${1:-10}"
+    local log branch authors
+    log=$(git log --oneline -"$count" 2>/dev/null)
+    branch=$(git branch --show-current 2>/dev/null)
+    authors=$(git log --format='%an' -"$count" 2>/dev/null | sort | uniq -c | sort -rn | head -5)
+    if [[ -z "$log" ]]; then
+        echo "No commits found."
+        return 0
+    fi
+    printf "Branch: %s\nRecent %s commits:\n%s\n\nAuthors:\n%s\n" \
+        "$branch" "$count" "$log" "$authors" | aichat -r gitsum
+}
+
+# mac-narrator — your Mac's inner monologue
+mac-narrator() {
+    local snapshot
+    snapshot=$(
+        ps -eo pid,%cpu,%mem,comm -r 2>/dev/null | head -8
+        echo "---"
+        vm_stat 2>/dev/null | head -5
+        echo "---"
+        df -h / 2>/dev/null | tail -1
+        echo "---"
+        uptime 2>/dev/null
+    )
+    echo "$snapshot" | aichat -r mac-narrator
+}


### PR DESCRIPTION
## Summary

- Add 7 built-in roles ported from [apfel demos](https://github.com/Arthur-Ficial/apfel/tree/main/demo): `oneliner`, `explain`, `naming`, `wtd`, `port`, `gitsum`, `mac-narrator`
- Add bash/zsh shell functions (`scripts/shell-integration/demos.{bash,zsh}`) that gather context and pipe to the appropriate role, plus `cmd` as an alias for `aichat -e`
- Skip `cmd` as a role since it duplicates the existing `--execute` / `%shell%` functionality

### Usage

Roles work directly:
```bash
aichat -r oneliner "sum column 3 of a CSV"
aichat -r naming "function that retries HTTP requests"
aichat -r explain "curl -sSL -o /dev/null -w '%{http_code}'"
```

Shell functions (source `demos.bash` or `demos.zsh`) add context-gathering wrappers:
```bash
cmd "find all .log files modified today"   # alias for aichat -e
wtd ~/some/project                         # gathers dir info automatically
port 3000                                  # runs lsof, pipes to role
gitsum 20                                  # gathers git log, pipes to role
mac-narrator                               # gathers system stats, pipes to role
```

## Test plan

- [x] `cargo test --all` -- 21 tests pass
- [x] `cargo clippy --all --all-targets -- -D warnings` -- clean
- [x] `cargo fmt --all --check` -- clean
- [x] Manual: `aichat --list-roles` shows new roles
- [x] Manual: `aichat -r naming "function that retries HTTP"` returns naming suggestions
- [x] Manual: source `demos.zsh` and run `gitsum` in a git repo

Closes #1504