### PR TITLE
fix: always set stream parameter in OpenAI-compatible requests

### DIFF
--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -326,9 +326,7 @@ pub fn openai_build_chat_completions_body(data: ChatCompletionsData, model: &Mod
     if let Some(v) = top_p {
         body["top_p"] = v.into();
     }
-    if stream {
-        body["stream"] = true.into();
-    }
+    body["stream"] = stream.into();
     if let Some(functions) = functions {
         body["tools"] = functions
             .iter()


### PR DESCRIPTION
Previously, the stream parameter was only set to true when streaming was enabled, but omitted entirely when disabled. This could cause some OpenAI-compatible APIs to default to unexpected behavior. Now the parameter is always explicitly set to the correct boolean value.
Since the default value on OpenAI's API is already false, this should not affect OpenAI official models.