### PR TITLE
fix: use terminal yellow instead of hardcoded orange in shell exec output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,7 @@ async fn shell_execute(
     }
     if *IS_STDOUT_TERMINAL {
         let options = ["execute", "revise", "describe", "copy", "quit"];
-        let command = color_text(eval_str.trim(), nu_ansi_term::Color::Rgb(255, 165, 0));
+        let command = warning_text(eval_str.trim());
         let first_letter_color = nu_ansi_term::Color::Cyan;
         let prompt_text = options
             .iter()


### PR DESCRIPTION
Fixes #1475

## Problem

The shell exec command display uses a hardcoded RGB orange color `(255, 165, 0)` which conflicts with many terminal color themes and ignores the user's color preferences.

## Solution

Replace the hardcoded `color_text(eval_str.trim(), nu_ansi_term::Color::Rgb(255, 165, 0))` with the existing `warning_text()` helper, which uses the terminal's native `Yellow` color. This:
- Respects the user's terminal color theme
- Honors the `NO_COLOR` environment variable (already handled by `color_text`/`warning_text`)
- Is consistent with how other warning-style output is colored in the codebase

## Testing

Built and verified the code compiles cleanly. The shell exec (`aichat -e`) command display now uses the terminal's yellow color instead of the hardcoded orange.