### PR TITLE
fix: handle Claude streaming error events to prevent session corruption on overload

### DIFF
--- a/src/client/claude.rs
+++ b/src/client/claude.rs
@@ -144,6 +144,13 @@ pub async fn claude_chat_completions_streaming(
                         ))?;
                     }
                 }
+                "error" => {
+                    let err_type = data["error"]["type"].as_str().unwrap_or("unknown");
+                    let err_msg = data["error"]["message"]
+                        .as_str()
+                        .unwrap_or("Unknown error");
+                    bail!("{err_msg} (type: {err_type})");
+                }
                 _ => {}
             }
         }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -524,6 +524,8 @@ pub fn catch_error(data: &Value, status: u16) -> Result<()> {
     } else if let (Some(detail), Some(status)) = (data["detail"].as_str(), data["status"].as_i64())
     {
         bail!("{detail} (status: {status})");
+    } else if let (Some(detail), Some(code)) = (data["detail"].as_str(), data["code"].as_i64()) {
+        bail!("{detail} (status: {code})");
     } else if let Some(error) = data["error"].as_str() {
         bail!("{error}");
     } else if let Some(message) = data["message"].as_str() {


### PR DESCRIPTION
Fixes #1463

## Problem

When Claude returns an overload error (HTTP 529 or SSE error event), the session can become corrupted with an empty assistant message, causing all subsequent requests to fail:

```
Error: Failed to call chat-completions api

Caused by:
    messages.1: all messages must have non-empty content except for the optional final assistant message
```

**Root cause — two issues:**

1. **SSE error events silently ignored**: When Claude returns HTTP 200 but sends an SSE event with `"type": "error"` (e.g. `overloaded_error`), the streaming handler falls through to the `_ => {}` catch-all and ignores it. This results in empty output being treated as a successful completion. The empty string is then saved as an assistant message in the session, corrupting it for future requests.

2. **`catch_error` misses `{"code": N, "detail": "..."}` shape**: Anthropic's 529 response uses `"code"` as the key (not `"status"`), so the existing `{"status": N, "detail": "..."}` branch in `catch_error` never matched. The error fell through to the generic fallback with an uninformative message.

## Solution

1. **`src/client/claude.rs`**: Add explicit handling for `"error"` type SSE events in `claude_chat_completions_streaming`. When a Claude error event arrives, bail with the error type and message instead of silently ignoring it.

2. **`src/client/common.rs`**: Extend `catch_error` to also match the `{"code": N, "detail": "..."}` response shape, producing a clear `"Overloaded (status: 529)"` error message.

## Testing

- Built and verified the code compiles cleanly.
- The fix ensures that Claude overload errors surface as proper errors rather than silently corrupting the session with an empty assistant message.