### PR TITLE
feat: add DeepSeek v4 series models (deepseek-v4-flash, deepseek-v4-pro)

### DIFF
--- a/models.yaml
+++ b/models.yaml
@@ -1115,7 +1115,7 @@
 
 # Links:
 #  - https://api-docs.deepseek.com/quick_start/pricing
-#  - https://platform.deepseek.com/api-docs/api/create-chat-completion
+#  - https://api-docs.deepseek.com/api/create-chat-completion
 - provider: deepseek
   models:
     - name: deepseek-chat
@@ -1129,6 +1129,18 @@
       max_output_tokens: 32768
       input_price: 0.56
       output_price: 1.68
+    - name: deepseek-v4-flash
+      max_input_tokens: 1000000
+      max_output_tokens: 384000
+      input_price: 0.14
+      output_price: 0.28
+      supports_function_calling: true
+    - name: deepseek-v4-pro
+      max_input_tokens: 1000000
+      max_output_tokens: 384000
+      input_price: 1.74
+      output_price: 3.48
+      supports_function_calling: true
 
 # Links:
 #  - https://open.bigmodel.cn/pricing


### PR DESCRIPTION
## Summary
- Add `deepseek-v4-flash` and `deepseek-v4-pro` to the DeepSeek provider in models.yaml
- Both models: 1M tokens context, 384K max output, support function calling

## Model Details

| Model | Context | Max Output | Input Price | Output Price |
|---|---|---|---|---|
| `deepseek-v4-flash` | 1,000,000 | 384,000 | $0.14/M | $0.28/M |
| `deepseek-v4-pro` | 1,000,000 | 384,000 | $1.74/M | $3.48/M |

## Backward Compatibility
Existing `deepseek-chat` and `deepseek-reasoner` models remain available. (Note: DeepSeek will deprecate these legacy IDs on July 24, 2026.)

## Verification
- YAML format validated
- Build succeeds
- All 21 existing tests pass
- End-to-end API calls with both v4-flash and v4-pro verified successfully

Closes #1514