### PR TITLE
fix(config): honor $EDITOR when config editor is unset

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,7 +7,7 @@ top_p: null                      # Set default top-p parameter, with a range of 
 stream: true                     # Controls whether to use the stream-style API.
 save: true                       # Indicates whether to persist the message
 keybindings: emacs               # Choose keybinding style (emacs, vi)
-editor: null                     # Specifies the command used to edit input buffer or session. (e.g. vim, emacs, nano).
+editor: null                     # Editor for input buffer, roles, sessions, etc. Falls back to $VISUAL, then $EDITOR, then nano/notepad.
 wrap: no                         # Controls text wrapping (no, auto, <max-width>)
 wrap_code: false                 # Enables or disables wrapping of code blocks
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1719,20 +1719,18 @@ impl Config {
     }
 
     pub fn editor(&self) -> Result<String> {
-        EDITOR.get_or_init(move || {
-            let editor = self.editor.clone()
-                .or_else(|| env::var("VISUAL").ok().or_else(|| env::var("EDITOR").ok()))
-                .unwrap_or_else(|| {
-                    if cfg!(windows) {
-                        "notepad".to_string()
-                    } else {
-                        "nano".to_string()
-                    }
+        if let Some(editor) = EDITOR.get() {
+            return editor
+                .clone()
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Editor not found. Please add the `editor` configuration or set the $EDITOR or $VISUAL environment variable."
+                    )
                 });
-            which::which(&editor).ok().map(|_| editor)
-        })
-        .clone()
-        .ok_or_else(|| anyhow!("Editor not found. Please add the `editor` configuration or set the $EDITOR or $VISUAL environment variable."))
+        }
+        let editor = resolve_editor(self.editor.as_deref())?;
+        let _ = EDITOR.set(Some(editor.clone()));
+        Ok(editor)
     }
 
     pub fn repl_complete(

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -284,7 +284,13 @@ Type ".help" for additional help.
 
         if let Ok(cmd) = config.read().editor() {
             let temp_file = temp_file("-repl-", ".md");
-            let command = process::Command::new(cmd);
+            let parts = shell_words::split(&cmd)
+                .with_context(|| format!("Invalid editor command '{cmd}'"))?;
+            let (program, args) = parts
+                .split_first()
+                .ok_or_else(|| anyhow::anyhow!("Invalid editor command '{cmd}'"))?;
+            let mut command = process::Command::new(program);
+            command.args(args);
             editor = editor.with_buffer_editor(command, temp_file);
         }
 

--- a/src/utils/command.rs
+++ b/src/utils/command.rs
@@ -154,8 +154,63 @@ pub fn run_loader_command(path: &str, extension: &str, loader_command: &str) -> 
     }
 }
 
+pub fn default_editor() -> String {
+    if cfg!(windows) {
+        "notepad".to_string()
+    } else {
+        "nano".to_string()
+    }
+}
+
+pub fn editor_program_exists(editor: &str) -> bool {
+    let Ok(parts) = shell_words::split(editor) else {
+        return false;
+    };
+    let Some(program) = parts.first() else {
+        return false;
+    };
+    let path = Path::new(program);
+    if path.is_absolute() {
+        return path.is_file();
+    }
+    which::which(program).is_ok()
+}
+
+pub fn resolve_editor(config_editor: Option<&str>) -> Result<String> {
+    let config_editor = config_editor
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let visual = env::var("VISUAL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let editor_env = env::var("EDITOR")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    let explicit = config_editor
+        .or(visual.as_deref())
+        .or(editor_env.as_deref());
+
+    let editor = explicit.map(str::to_string).unwrap_or_else(default_editor);
+
+    if explicit.is_none() && !editor_program_exists(&editor) {
+        bail!(
+            "Editor not found. Please add the `editor` configuration or set the $EDITOR or $VISUAL environment variable."
+        );
+    }
+    Ok(editor)
+}
+
 pub fn edit_file(editor: &str, path: &Path) -> Result<()> {
-    let mut child = Command::new(editor).arg(path).spawn()?;
+    let parts =
+        shell_words::split(editor).with_context(|| format!("Invalid editor command '{editor}'"))?;
+    let (program, args) = parts
+        .split_first()
+        .ok_or_else(|| anyhow!("Invalid editor command '{editor}'"))?;
+    let mut child = Command::new(program).args(args).arg(path).spawn()?;
     child.wait()?;
     Ok(())
 }
@@ -225,5 +280,84 @@ fn get_history_file(shell: &str) -> Option<PathBuf> {
         "ksh" => Some(home_dir()?.join(".ksh_history")),
         "tcsh" => Some(home_dir()?.join(".history")),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod editor_tests {
+    use super::*;
+
+    #[test]
+    fn editor_program_exists_for_absolute_path() {
+        assert!(editor_program_exists("/bin/sh"));
+        assert!(!editor_program_exists("/definitely/not/an/editor"));
+    }
+
+    #[test]
+    fn editor_program_exists_uses_first_token() {
+        assert!(editor_program_exists("sh -c true"));
+    }
+
+    #[test]
+    fn resolve_editor_prefers_config_over_env() {
+        let previous_editor = env::var("EDITOR").ok();
+        let previous_visual = env::var("VISUAL").ok();
+        env::set_var("EDITOR", "nano");
+        env::set_var("VISUAL", "nano");
+
+        let resolved = resolve_editor(Some("vim")).expect("config editor should resolve");
+
+        if let Some(value) = previous_editor {
+            env::set_var("EDITOR", value);
+        } else {
+            env::remove_var("EDITOR");
+        }
+        if let Some(value) = previous_visual {
+            env::set_var("VISUAL", value);
+        } else {
+            env::remove_var("VISUAL");
+        }
+
+        assert_eq!(resolved, "vim");
+    }
+
+    #[test]
+    fn resolve_editor_uses_editor_env_when_config_missing() {
+        let previous_editor = env::var("EDITOR").ok();
+        let previous_visual = env::var("VISUAL").ok();
+        env::remove_var("VISUAL");
+        env::set_var("EDITOR", "  vim  ");
+
+        let resolved = resolve_editor(None).expect("EDITOR should be used");
+
+        if let Some(value) = previous_editor {
+            env::set_var("EDITOR", value);
+        } else {
+            env::remove_var("EDITOR");
+        }
+        if let Some(value) = previous_visual {
+            env::set_var("VISUAL", value);
+        } else {
+            env::remove_var("VISUAL");
+        }
+
+        assert_eq!(resolved, "vim");
+    }
+
+    #[test]
+    fn resolve_editor_ignores_blank_config_values() {
+        let previous_editor = env::var("EDITOR").ok();
+        env::set_var("EDITOR", "vim");
+
+        let resolved =
+            resolve_editor(Some("   ")).expect("blank config should fall back to EDITOR");
+
+        if let Some(value) = previous_editor {
+            env::set_var("EDITOR", value);
+        } else {
+            env::remove_var("EDITOR");
+        }
+
+        assert_eq!(resolved, "vim");
     }
 }


### PR DESCRIPTION
## Summary

Improve editor resolution so aichat uses `$VISUAL` / `$EDITOR` when `editor` is not set in `config.yaml`.

## Motivation

Fixes #1527. Users expect aichat to follow the standard Unix editor convention when `editor` is unset. The previous logic could discard a valid `$EDITOR` value when `which` failed on the full editor string (for example editors with arguments), causing the REPL to silently fall back to `nano`.

## Changes

- Add `resolve_editor()` with priority: config → `$VISUAL` → `$EDITOR` → platform default
- Ignore blank `editor` config values so env vars are not skipped
- Trust explicit editor settings from config/env; only validate the platform fallback with `which`
- Parse editor commands with `shell_words` in `edit_file()` and REPL buffer editing
- Document `$VISUAL` / `$EDITOR` fallback in `config.example.yaml`
- Add regression tests for editor resolution

## Tests

```bash
cargo fmt --check
cargo test
```

Result: all 26 tests pass.

## Notes

- Explicit editor values are not pre-validated with `which`; spawn errors surface at runtime if the command is missing.
- REPL still ignores `editor()` errors via `if let Ok(...)`; this change removes the common failure path for valid `$EDITOR` values.

Fixes #1527