### PR TITLE
fix(cli): apply cmd_prelude before --info output

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1614,18 +1614,27 @@ impl Config {
             return Ok(());
         }
         let prelude = match self.working_mode {
-            WorkingMode::Repl => self.repl_prelude.as_ref(),
-            WorkingMode::Cmd => self.cmd_prelude.as_ref(),
+            WorkingMode::Repl => self.repl_prelude.clone(),
+            WorkingMode::Cmd => self.cmd_prelude.clone(),
             WorkingMode::Serve => return Ok(()),
         };
-        let prelude = match prelude {
-            Some(v) => {
-                if v.is_empty() {
-                    return Ok(());
-                }
-                v.to_string()
-            }
-            None => return Ok(()),
+        self.apply_prelude_value(prelude.as_deref())
+    }
+
+    pub fn apply_info_prelude(&mut self) -> Result<()> {
+        if self.macro_flag || !self.state().is_empty() {
+            return Ok(());
+        }
+        let prelude = self
+            .cmd_prelude
+            .clone()
+            .or_else(|| self.repl_prelude.clone());
+        self.apply_prelude_value(prelude.as_deref())
+    }
+
+    fn apply_prelude_value(&mut self, prelude: Option<&str>) -> Result<()> {
+        let Some(prelude) = prelude.filter(|v| !v.is_empty()) else {
+            return Ok(());
         };
 
         let err_msg = || format!("Invalid prelude '{prelude}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ async fn run(config: GlobalConfig, cli: Cli, text: Option<String>) -> Result<()>
         config.write().set_save_session_this_time()?;
     }
     if cli.info {
+        config.write().apply_info_prelude()?;
         let info = config.read().info()?;
         println!("{info}");
         return Ok(());


### PR DESCRIPTION
## Summary

Apply configured prelude settings before printing `aichat --info`, so the output reflects the same default role/session that normal command execution uses.

## Motivation

When `cmd_prelude` (for example `role:<name>`) is set in `config.yaml`, the role is applied before regular command execution but `--info` returned early without applying the prelude. Users saw system info instead of the configured role.

Bare `aichat --info` runs in REPL working mode, so calling the existing `apply_prelude()` alone would still ignore `cmd_prelude`. This change adds `apply_info_prelude()` that prefers `cmd_prelude` and falls back to `repl_prelude`.

Fixes #1476

## Changes

- Refactor prelude parsing into `apply_prelude_value()`
- Add `apply_info_prelude()` for `--info` display
- Call `apply_info_prelude()` before printing `--info` output

## Tests

- `cargo build` (success)
- `cargo clippy -- -D warnings` reports pre-existing warnings in unrelated files (`rag/mod.rs`, `serve.rs`, `utils/mod.rs`); no new warnings from this diff

## Notes

- CLI flags such as `--role` still take precedence because prelude application is skipped when state is already set
- Related closed PR #1500 used a simpler approach that would not cover `cmd_prelude` when `--info` runs in REPL mode