### PR TITLE
fix(bedrock): use text blocks for non-object tool results

### DIFF
--- a/src/client/bedrock.rs
+++ b/src/client/bedrock.rs
@@ -318,6 +318,18 @@ struct EmbeddingsResBody {
     embeddings: Vec<Vec<f32>>,
 }
 
+/// Bedrock Converse requires `toolResult.content[].json` to be a JSON object.
+/// Non-object tool outputs (arrays, strings, scalars) must use a text block instead.
+fn bedrock_tool_result_content(output: &Value) -> Value {
+    if output.is_object() {
+        json!({ "json": output })
+    } else if let Some(text) = output.as_str() {
+        json!({ "text": text })
+    } else {
+        json!({ "text": output.to_string() })
+    }
+}
+
 fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Result<Value> {
     let ChatCompletionsData {
         mut messages,
@@ -404,11 +416,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
                         user_parts.push(json!({
                             "toolResult": {
                                 "toolUseId": tool_result.call.id,
-                                "content": [
-                                    {
-                                        "json": tool_result.output,
-                                    }
-                                ]
+                                "content": [bedrock_tool_result_content(&tool_result.output)]
                             }
                         }));
                     }
@@ -640,4 +648,36 @@ fn gen_signing_key(key: &str, date_stamp: &str, region: &str, service: &str) -> 
     let k_region = hmac_sha256(&k_date, region);
     let k_service = hmac_sha256(&k_region, service);
     hmac_sha256(&k_service, "aws4_request")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bedrock_tool_result_content_uses_json_for_objects() {
+        let output = json!({ "status": "ok", "count": 2 });
+        let block = bedrock_tool_result_content(&output);
+        assert_eq!(block["json"], output);
+        assert!(block.get("text").is_none());
+    }
+
+    #[test]
+    fn bedrock_tool_result_content_uses_text_for_arrays() {
+        let output = json!([{ "id": "cloud-1" }, { "id": "cloud-2" }]);
+        let block = bedrock_tool_result_content(&output);
+        assert_eq!(block["text"], output.to_string());
+        assert!(block.get("json").is_none());
+    }
+
+    #[test]
+    fn bedrock_tool_result_content_uses_text_for_scalars() {
+        assert_eq!(
+            bedrock_tool_result_content(&json!("done"))["text"],
+            "done"
+        );
+        assert_eq!(bedrock_tool_result_content(&json!(42))["text"], "42");
+        assert_eq!(bedrock_tool_result_content(&json!(null))["text"], "null");
+        assert_eq!(bedrock_tool_result_content(&json!({}))["json"], json!({}));
+    }
 }


### PR DESCRIPTION
## Summary

When using the Bedrock client with function calling, tool outputs that are not JSON objects (e.g. top-level arrays from MCP tools) caused the follow-up Converse request to fail validation.

## Motivation

Bedrock Converse requires `toolResult.content[].json` to be a JSON object. aichat always wrapped tool output in a `json` block regardless of type, so array-returning tools such as Atlassian MCP's `getAccessibleAtlassianResources` failed with:

```
The format of the value at messages.2.content.0.toolResult.content.0.json is invalid. Provide a json object for the field and try again.
```

The Anthropic-native client already tolerates non-object tool output via plain text content.

Fixes #1542

## Changes

- Add `bedrock_tool_result_content()` helper that emits a `json` block for objects and a `text` block otherwise
- Use raw string text for JSON string values; serialize arrays/scalars with `to_string()`
- Add unit tests for object, array, string, number, null, and empty object cases

## Tests

- `cargo test bedrock_tool_result` — 3 passed
- `cargo test` — 24 passed
- `cargo fmt -- --check` — passed

## Notes

No behavior change for tools that already return JSON objects. This only affects the Bedrock client path.