### PR TITLE
fix(bedrock): use text blocks for non-object tool results

### DIFF
--- a/src/client/bedrock.rs
+++ b/src/client/bedrock.rs
@@ -404,11 +404,7 @@ fn build_chat_completions_body(data: ChatCompletionsData, model: &Model) -> Resu
                         user_parts.push(json!({
                             "toolResult": {
                                 "toolUseId": tool_result.call.id,
-                                "content": [
-                                    {
-                                        "json": tool_result.output,
-                                    }
-                                ]
+                                "content": [bedrock_tool_result_content(&tool_result.output)]
                             }
                         }));
                     }
@@ -640,4 +636,51 @@ fn gen_signing_key(key: &str, date_stamp: &str, region: &str, service: &str) -> 
     let k_region = hmac_sha256(&k_date, region);
     let k_service = hmac_sha256(&k_region, service);
     hmac_sha256(&k_service, "aws4_request")
+}
+
+fn bedrock_tool_result_content(output: &Value) -> Value {
+    if output.is_object() {
+        json!({ "json": output })
+    } else {
+        json!({ "text": output.to_string() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bedrock_tool_result_content_uses_json_for_objects() {
+        let output = json!({ "issues": [] });
+        assert_eq!(
+            bedrock_tool_result_content(&output),
+            json!({ "json": { "issues": [] } })
+        );
+    }
+
+    #[test]
+    fn bedrock_tool_result_content_uses_text_for_arrays() {
+        let output = json!([{ "id": "1" }]);
+        assert_eq!(
+            bedrock_tool_result_content(&output),
+            json!({ "text": "[{\"id\":\"1\"}]" })
+        );
+    }
+
+    #[test]
+    fn bedrock_tool_result_content_uses_text_for_scalars() {
+        assert_eq!(
+            bedrock_tool_result_content(&json!("done")),
+            json!({ "text": "\"done\"" })
+        );
+        assert_eq!(
+            bedrock_tool_result_content(&json!(42)),
+            json!({ "text": "42" })
+        );
+        assert_eq!(
+            bedrock_tool_result_content(&json!(null)),
+            json!({ "text": "null" })
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Fix Bedrock tool result formatting so non-object JSON outputs (arrays, strings, numbers, null) are sent as text blocks instead of invalid `json` blocks.

## Motivation
Bedrock Converse requires `toolResult.content[].json` to be a JSON object. aichat always wrapped tool output in a `json` block, which breaks MCP tools that return top-level arrays (e.g. Atlassian `getAccessibleAtlassianResources`).

Fixes #1542

## Changes
- Add `bedrock_tool_result_content()` helper in `src/client/bedrock.rs`
- Use `{ "json": output }` for object outputs
- Fall back to `{ "text": output.to_string() }` for arrays and other scalar JSON values
- Add unit tests for object, array, and scalar cases

## Tests
- `cargo test bedrock_tool_result_content` — 3 passed
- `RUSTFLAGS='--deny warnings' cargo test --all` — 24 passed

## Notes
- Matches Claude client behavior for non-object outputs (`to_string()`), while preserving structured `json` blocks for objects as Bedrock expects.